### PR TITLE
Fix context window token conversion

### DIFF
--- a/core/context/engine/service.go
+++ b/core/context/engine/service.go
@@ -121,6 +121,8 @@ func (s *Service) BuildWindow(ctx context.Context, req *pb.BuildWindowRequest) (
 	var inputTokens32 int32
 	if inputTokens > math.MaxInt32 {
 		inputTokens32 = math.MaxInt32
+	} else if inputTokens < math.MinInt32 {
+		inputTokens32 = math.MinInt32
 	} else {
 		inputTokens32 = int32(inputTokens)
 	}


### PR DESCRIPTION
## Summary\n- avoid int32 conversion overflow when building context windows\n\n## Testing\n- not run