### PR TITLE
fix(scheduler): use inclusion-based approach for placement labels

### DIFF
--- a/core/controlplane/scheduler/strategy_least_loaded.go
+++ b/core/controlplane/scheduler/strategy_least_loaded.go
@@ -196,27 +196,22 @@ func filterPlacementLabels(labels map[string]string) map[string]string {
 	if len(labels) == 0 {
 		return nil
 	}
-	out := make(map[string]string, len(labels))
+	out := make(map[string]string)
 	for k, v := range labels {
-		if k == "preferred_worker_id" || k == "preferred_pool" {
-			continue
+		// Only labels with specific prefixes are used for placement constraints.
+		// All other labels are business/observability data and should not constrain worker selection.
+		// Supported prefixes:
+		// - "placement." - explicit placement constraints (e.g., placement.region=us-east)
+		// - "constraint." - worker capability constraints (e.g., constraint.gpu=true)
+		// - "node." - node selector labels (e.g., node.type=gpu)
+		if strings.HasPrefix(k, "placement.") ||
+			strings.HasPrefix(k, "constraint.") ||
+			strings.HasPrefix(k, "node.") {
+			out[k] = v
 		}
-		if k == "approval_granted" || k == "approval_reason" || k == "approval_note" || k == "secrets_present" {
-			continue
-		}
-		if strings.HasPrefix(k, "cordum.") {
-			continue
-		}
-		// These labels are used for traceability/observability and should not constrain placement.
-		// Placement constraints should be expressed via dedicated labels (e.g. hardware/region),
-		// not workflow/run identifiers.
-		if k == "workflow_id" || k == "run_id" || k == "step_id" || k == "node_id" {
-			continue
-		}
-		if k == "worker_id" {
-			continue
-		}
-		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/core/controlplane/scheduler/strategy_least_loaded_test.go
+++ b/core/controlplane/scheduler/strategy_least_loaded_test.go
@@ -144,28 +144,72 @@ func TestLeastLoadedStrategyMarksWorkerOverloadedWhenAtCapacity(t *testing.T) {
 }
 
 func TestFilterPlacementLabels(t *testing.T) {
+	// Only labels with specific prefixes should be treated as placement constraints
 	labels := map[string]string{
 		"preferred_worker_id": "w1",
 		"preferred_pool":      "pool",
 		"approval_granted":    "true",
-		"approval_reason":     "ok",
-		"approval_note":       "note",
-		"secrets_present":     "true",
-		"cordum.trace":        "trace",
 		"workflow_id":         "wf",
 		"run_id":              "run",
-		"step_id":             "step",
-		"node_id":             "node",
-		"worker_id":           "worker",
-		"region":              "us-east",
-		"gpu":                 "true",
+		"amount":              "500", // business label - should be ignored
+		"from":                "alice", // business label - should be ignored
+		"to":                  "bob", // business label - should be ignored
+		"placement.region":    "us-east", // explicit placement constraint
+		"constraint.gpu":      "true", // explicit capability constraint
+		"node.type":           "gpu-node", // node selector
 	}
 	out := filterPlacementLabels(labels)
-	if len(out) != 2 {
-		t.Fatalf("expected 2 placement labels, got %d", len(out))
+	if len(out) != 3 {
+		t.Fatalf("expected 3 placement labels, got %d: %#v", len(out), out)
 	}
-	if out["region"] != "us-east" || out["gpu"] != "true" {
-		t.Fatalf("unexpected placement labels: %#v", out)
+	if out["placement.region"] != "us-east" {
+		t.Fatalf("expected placement.region=us-east, got %#v", out)
+	}
+	if out["constraint.gpu"] != "true" {
+		t.Fatalf("expected constraint.gpu=true, got %#v", out)
+	}
+	if out["node.type"] != "gpu-node" {
+		t.Fatalf("expected node.type=gpu-node, got %#v", out)
+	}
+}
+
+func TestFilterPlacementLabelsIgnoresBusinessLabels(t *testing.T) {
+	// Business labels like amount, from, to should NOT constrain worker placement
+	labels := map[string]string{
+		"amount": "500",
+		"from":   "alice",
+		"to":     "bob",
+		"status": "pending",
+	}
+	out := filterPlacementLabels(labels)
+	if out != nil {
+		t.Fatalf("expected nil (no placement labels), got %#v", out)
+	}
+}
+
+func TestStrategyIgnoresBusinessLabelsForWorkerMatch(t *testing.T) {
+	// Workers should be selected even when jobs have business labels
+	// that workers don't have
+	strategy := NewLeastLoadedStrategy(routingForTopic("job.default", "default"))
+	workers := map[string]*pb.Heartbeat{
+		"w1": {WorkerId: "w1", Pool: "default", ActiveJobs: 0, CpuLoad: 10},
+	}
+
+	req := &pb.JobRequest{
+		Topic: "job.default",
+		Labels: map[string]string{
+			"amount": "500",
+			"from":   "alice",
+			"to":     "bob",
+		},
+	}
+
+	subject, err := strategy.PickSubject(req, workers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if subject != "worker.w1.jobs" {
+		t.Fatalf("expected subject worker.w1.jobs, got %s", subject)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixed bug where business labels (amount, from, to) were incorrectly used as placement constraints
- Changed from exclusion-based approach (blacklist known labels) to inclusion-based approach (whitelist specific prefixes)
- Only labels with explicit prefixes are now used for worker placement:
  - `placement.*` - placement constraints (e.g., `placement.region=us-east`)
  - `constraint.*` - capability constraints (e.g., `constraint.gpu=true`)
  - `node.*` - node selectors (e.g., `node.type=gpu`)

## Root Cause
The `filterPlacementLabels` function was using an exclusion-based approach that excluded known system labels but treated everything else as placement constraints. This caused job labels like `amount: 500, from: alice, to: bob` to require workers to have matching labels, which workers never would have.

## Test plan
- [x] Added TestFilterPlacementLabels - verifies only prefixed labels are used
- [x] Added TestFilterPlacementLabelsIgnoresBusinessLabels - verifies nil for business labels  
- [x] Added TestStrategyIgnoresBusinessLabelsForWorkerMatch - e2e test for worker selection
- [x] All 30 packages pass
- [x] Mock bank demo tested with all 3 transfer types (auto, review, blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)