### PR TITLE
fix: generate TLS certs before docker compose in nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Generate API key
       run: echo "CORDUM_API_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
+    - name: Generate TLS certificates
+      run: go run ./cmd/cordumctl generate-certs
+
     - name: Start services
       run: |
         docker compose up -d --build
@@ -116,6 +119,9 @@ jobs:
     - name: Generate API key
       run: echo "CORDUM_API_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
+    - name: Generate TLS certificates
+      run: go run ./cmd/cordumctl generate-certs
+
     - name: Start services
       run: |
         docker compose up -d --build
@@ -190,6 +196,9 @@ jobs:
 
     - name: Generate API key
       run: echo "CORDUM_API_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
+    - name: Generate TLS certificates
+      run: go run ./cmd/cordumctl generate-certs
 
     - name: Start services
       run: |


### PR DESCRIPTION
## Summary
- Redis exits(1) in nightly CI because TLS cert files (`./certs/`) are never generated
- All downstream services fail with `dependency failed to start: container cordum-redis-1 exited (1)`
- Adds `go run ./cmd/cordumctl generate-certs` before `docker compose up` in all 3 jobs (full-production-gate, release-gate, soak-test)
- Matches the pattern already used by `tools/scripts/quickstart.sh`

## Test plan
- [ ] Re-run nightly workflow via `workflow_dispatch` after merge
- [ ] Verify all 8 services reach healthy state
- [ ] Verify production gates execute successfully

Fixes: https://github.com/cordum-io/cordum/actions/runs/22293505192