### PR TITLE
fix: remove specific adopter count from public roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -193,7 +193,7 @@ The path to v1.0.0 focuses on **production hardening** and **API stability**. Ba
 
 ### Goals
 - 🎯 **v1.0.0 GA Release**
-- 🎯 **100+ Production Adopters**
+- 🎯 **Grow Early Adopter Community**
 - 🎯 **Public Pack Registry**
 
 ### Features


### PR DESCRIPTION
## Summary
- Replace "100+ Production Adopters" goal with "Grow Early Adopter Community" in public ROADMAP.md
- Public roadmaps should show what we're building, not internal adoption KPIs that conflict with our honest "seeking early adopters" messaging in ADOPTERS.md and GOVERNANCE.md

## Context
Part of a cross-repo licensing and messaging consistency fix. CAP protocol page was mislabeled as BUSL-1.1 (fixed in Cordum-site), and SDK licenses were inconsistent (fixed in cap repo).