### PR TITLE
fix: scope gosec to project source dirs and add 15m timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4
@@ -113,10 +114,21 @@ jobs:
       with:
         go-version: '1.24'
 
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Download dependencies
+      run: go mod download
+
     - name: Run Gosec Security Scanner
       run: |
         go install github.com/securego/gosec/v2/cmd/gosec@latest
-        gosec -no-fail -fmt sarif -out results.sarif ./...
+        gosec -no-fail -fmt sarif -out results.sarif -exclude-dir=vendor ./cmd/... ./core/... ./sdk/...
 
     - name: Sanitize SARIF
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,11 @@ jobs:
       run: go mod download
 
     - name: Run Gosec Security Scanner
+      env:
+        GOFLAGS: ""
+        GOTOOLCHAIN: local
       run: |
-        go install github.com/securego/gosec/v2/cmd/gosec@latest
+        go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
         gosec -no-fail -fmt sarif -out results.sarif -exclude-dir=vendor ./cmd/... ./core/... ./sdk/...
 
     - name: Sanitize SARIF


### PR DESCRIPTION
## Summary
- `gosec ./...` was scanning the entire Go module cache (grpc, redis, cap, etc.), causing the Security Scan job to run for 60+ minutes and always time out
- Scoped gosec to only scan project source: `./cmd/... ./core/... ./sdk/...`
- Added `timeout-minutes: 15` to the security job
- Added Go module cache for faster dependency resolution

## Test plan
- [ ] Verify Security Scan job completes within 15 minutes
- [ ] Verify SARIF output still uploads correctly
- [ ] Verify other CI jobs (Lint, Build, Test, Integration) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)