### PR TITLE
fix: npm ci --legacy-peer-deps in Dockerfile

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
lucide-react 1.7 has peer dep conflicts with react-icons. Docker build fails without --legacy-peer-deps.