### PR TITLE
fix: dagre graphlib alias + resolved approvals visibility

### DIFF
--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -398,28 +398,32 @@ func (s *server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
 			"approval_required": record.ApprovalRequired,
 			"approval_ref":      record.ApprovalRef,
 		}
+		approvalRecord, approvalErr := s.jobStore.GetApprovalRecord(r.Context(), job.ID)
+		hasResolvedApproval := approvalErr == nil && approvalRecord.ApprovedBy != ""
 		// Merge approval resolution fields when an approval record exists.
-		if approval, err := s.jobStore.GetApprovalRecord(r.Context(), job.ID); err == nil && approval.ApprovedBy != "" {
-			item["resolved_by"] = approval.ApprovedBy
-			item["resolved_comment"] = approval.Note
-			item["resolution"] = approval.Reason
-			if approval.ApprovedAt > 0 {
-				item["resolved_at"] = approval.ApprovedAt
+		if hasResolvedApproval {
+			item["resolved_by"] = approvalRecord.ApprovedBy
+			item["resolved_comment"] = approvalRecord.Note
+			item["resolution"] = approvalRecord.Reason
+			if approvalRecord.ApprovedAt > 0 {
+				item["resolved_at"] = approvalRecord.ApprovedAt
 			}
 		}
 		// Enrich with workflow labels from the original job request so the
 		// dashboard can distinguish gate approvals from policy approvals.
-		// Also skip approvals whose workflow run has already terminated.
+		// Also skip unresolved approvals whose workflow run has already
+		// terminated. Resolved approvals must remain visible in history.
 		if req, err := s.jobStore.GetJobRequest(r.Context(), job.ID); err == nil && req != nil {
 			var (
 				payload       map[string]any
 				contextStatus = "absent"
 			)
 			if req.Labels != nil {
-				// Filter out stale approvals: if the run is terminal, skip this item.
+				// Filter out stale unresolved approvals: if the run is terminal,
+				// skip only items that have not been resolved yet.
 				if runID := strings.TrimSpace(req.Labels["run_id"]); runID != "" && s.workflowStore != nil {
 					if run, runErr := s.workflowStore.GetRun(r.Context(), runID); runErr == nil && run != nil {
-						if wf.IsTerminalRunStatus(run.Status) {
+						if wf.IsTerminalRunStatus(run.Status) && !hasResolvedApproval {
 							continue
 						}
 					}

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
+        "@dagrejs/graphlib": "^4.0.1",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -290,31 +291,6 @@
       "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
       "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
@@ -4043,7 +4019,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
+    "@dagrejs/graphlib": "^4.0.1",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       ),
       "@dagrejs/graphlib": path.resolve(
         __dirname,
-        "node_modules/@dagrejs/graphlib/index.js",
+        "node_modules/@dagrejs/graphlib/dist/graphlib.cjs.js",
       ),
     },
   },


### PR DESCRIPTION
## Summary
- Fix vite.config.ts graphlib alias (index.js → dist/graphlib.cjs.js) — fixes build
- Add @dagrejs/graphlib as explicit dependency
- Show resolved workflow approvals in history (was always 0)

## Test plan
- [x] npm run build passes
- [x] All 1076 tests pass
- [x] TX4 approval visible in /approvals after approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)