### PR TITLE
docs: remove leftover HTML comment from Key Features section

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,14 @@
-# Build and push Docker images to GHCR and Docker Hub.
-# Triggered automatically on git tag push: git tag v0.9.2 && git push --tags
+# Build and push Docker images + Helm chart to GHCR and Docker Hub.
+# Triggered automatically on git tag push: git tag v0.9.3 && git push --tags
 #
 # Required GitHub Secrets:
 #   DOCKERHUB_USERNAME  — Docker Hub username
 #   DOCKERHUB_TOKEN     — Docker Hub access token (PAT)
 #
-# Image naming (follows Istio/HashiCorp/Temporal convention):
-#   Docker Hub: cordum/api-gateway:0.9.2, cordum/scheduler:0.9.2, ...
-#   GHCR:       ghcr.io/cordum-io/cordum/api-gateway:0.9.2, ...
+# Published artifacts:
+#   Docker Hub: cordum/api-gateway:0.9.3, cordum/scheduler:0.9.3, ...
+#   GHCR:       ghcr.io/cordum-io/cordum/api-gateway:0.9.3, ...
+#   Helm (OCI): ghcr.io/cordum-io/cordum/charts/cordum:0.9.3
 
 name: Build and Push Docker Images
 
@@ -207,3 +208,43 @@ jobs:
         run: |
           cosign sign --yes ghcr.io/cordum-io/cordum/dashboard@${DIGEST}
           cosign sign --yes docker.io/cordum/dashboard@${DIGEST}
+
+  helm-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Login to GHCR (OCI)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Update chart version from git tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^version:.*/version: ${VERSION}/" cordum-helm/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" cordum-helm/Chart.yaml
+          echo "Chart version set to ${VERSION}"
+          grep -E '^(version|appVersion):' cordum-helm/Chart.yaml
+
+      - name: Update image tags in Artifact Hub annotations
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/v0\.[0-9]*\.[0-9]*/${VERSION}/g" cordum-helm/Chart.yaml
+          echo "Image tags updated to ${VERSION}"
+
+      - name: Lint chart
+        run: helm lint cordum-helm/
+
+      - name: Package chart
+        run: |
+          helm package cordum-helm/ --destination /tmp/charts
+          ls -la /tmp/charts/
+
+      - name: Push chart to GHCR (OCI)
+        run: |
+          helm push /tmp/charts/cordum-*.tgz oci://ghcr.io/cordum-io/cordum/charts
+          echo "Helm chart pushed to oci://ghcr.io/cordum-io/cordum/charts/cordum"

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ open http://localhost:8082
 ### Deploy to Kubernetes
 
 ```bash
-helm repo add cordum https://charts.cordum.io
-helm install cordum cordum/cordum \
+helm install cordum oci://ghcr.io/cordum-io/cordum/charts/cordum \
   --namespace cordum --create-namespace \
   --set secrets.apiKey=$(openssl rand -hex 32) \
   --set redis.auth.password=$(openssl rand -hex 32) \
@@ -134,7 +133,7 @@ helm install cordum cordum/cordum \
   --set ingress.dashboard.host=cordum.example.com
 ```
 
-See [cordum-helm/](cordum-helm/) for the full Helm chart reference.
+See [cordum-helm/](cordum-helm/) for the full Helm chart reference. Chart also available on [Artifact Hub](https://artifacthub.io/packages/helm/cordum/cordum).
 
 **Container images** (multi-arch: amd64 + arm64):
 

--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ For detailed troubleshooting, see [docs/troubleshooting.md](docs/troubleshooting
 
 ## Key Features
 
-<!-- Replace with a visual showing the Policy Studio and Safety Kernel in action -->
-
 ![nWwQVRVqwlZKeRbBZvkSof-img-4_1771930611000_na1fn_d29ya2Zsb3ctdmlzdWFsaXphdGlvbg](https://github.com/user-attachments/assets/ee44853d-1e89-463b-bf3c-0ba0481eee68)
 
 | Governance Feature | Why It Matters for Enterprise |

--- a/cordum-helm/README.md
+++ b/cordum-helm/README.md
@@ -106,17 +106,16 @@ build and load images into kind, then override tags:
 ```bash
 docker compose build
 
-for svc in api-gateway scheduler safety-kernel workflow-engine context-engine; do
-  docker tag "cordum-cordum-${svc}:latest" "ghcr.io/cordum-io/cordum/control-plane:dev-${svc}"
+for svc in api-gateway scheduler safety-kernel workflow-engine context-engine dashboard; do
+  docker tag "cordum-cordum-${svc}:latest" "ghcr.io/cordum-io/cordum/${svc}:dev"
 done
-docker tag cordum-cordum-dashboard:latest ghcr.io/cordum-io/cordum/dashboard:dev
 
 kind load docker-image --name cordum \
-  ghcr.io/cordum-io/cordum/control-plane:dev-api-gateway \
-  ghcr.io/cordum-io/cordum/control-plane:dev-scheduler \
-  ghcr.io/cordum-io/cordum/control-plane:dev-safety-kernel \
-  ghcr.io/cordum-io/cordum/control-plane:dev-workflow-engine \
-  ghcr.io/cordum-io/cordum/control-plane:dev-context-engine \
+  ghcr.io/cordum-io/cordum/api-gateway:dev \
+  ghcr.io/cordum-io/cordum/scheduler:dev \
+  ghcr.io/cordum-io/cordum/safety-kernel:dev \
+  ghcr.io/cordum-io/cordum/workflow-engine:dev \
+  ghcr.io/cordum-io/cordum/context-engine:dev \
   ghcr.io/cordum-io/cordum/dashboard:dev
 
 helm upgrade --install cordum ./cordum-helm -n cordum --create-namespace \

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -55,7 +55,7 @@ services:
       start_period: 10s
 
   context-engine:
-    image: ghcr.io/cordum-io/cordum/control-plane:${CORDUM_VERSION:-latest}-context-engine
+    image: ghcr.io/cordum-io/cordum/context-engine:${CORDUM_VERSION:-latest}
     restart: unless-stopped
     depends_on:
       redis:
@@ -83,7 +83,7 @@ services:
       start_period: 10s
 
   safety-kernel:
-    image: ghcr.io/cordum-io/cordum/control-plane:${CORDUM_VERSION:-latest}-safety-kernel
+    image: ghcr.io/cordum-io/cordum/safety-kernel:${CORDUM_VERSION:-latest}
     restart: unless-stopped
     depends_on:
       nats:
@@ -118,7 +118,7 @@ services:
       start_period: 10s
 
   scheduler:
-    image: ghcr.io/cordum-io/cordum/control-plane:${CORDUM_VERSION:-latest}-scheduler
+    image: ghcr.io/cordum-io/cordum/scheduler:${CORDUM_VERSION:-latest}
     restart: unless-stopped
     depends_on:
       nats:
@@ -162,7 +162,7 @@ services:
       start_period: 10s
 
   api-gateway:
-    image: ghcr.io/cordum-io/cordum/control-plane:${CORDUM_VERSION:-latest}-api-gateway
+    image: ghcr.io/cordum-io/cordum/api-gateway:${CORDUM_VERSION:-latest}
     restart: unless-stopped
     networks:
       default:
@@ -219,7 +219,7 @@ services:
       start_period: 10s
 
   workflow-engine:
-    image: ghcr.io/cordum-io/cordum/control-plane:${CORDUM_VERSION:-latest}-workflow-engine
+    image: ghcr.io/cordum-io/cordum/workflow-engine:${CORDUM_VERSION:-latest}
     restart: unless-stopped
     depends_on:
       nats:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -57,11 +57,11 @@ docker compose -f docker-compose.release.yml up -d
 ```
 
 Release images:
-- `ghcr.io/cordum-io/cordum/control-plane:<version>-api-gateway`
-- `ghcr.io/cordum-io/cordum/control-plane:<version>-scheduler`
-- `ghcr.io/cordum-io/cordum/control-plane:<version>-safety-kernel`
-- `ghcr.io/cordum-io/cordum/control-plane:<version>-workflow-engine`
-- `ghcr.io/cordum-io/cordum/control-plane:<version>-context-engine`
+- `ghcr.io/cordum-io/cordum/api-gateway:<version>`
+- `ghcr.io/cordum-io/cordum/scheduler:<version>`
+- `ghcr.io/cordum-io/cordum/safety-kernel:<version>`
+- `ghcr.io/cordum-io/cordum/workflow-engine:<version>`
+- `ghcr.io/cordum-io/cordum/context-engine:<version>`
 - `ghcr.io/cordum-io/cordum/dashboard:<version>`
 
 ### Smoke Test (No Workers Required)

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -28,24 +28,23 @@ and pulls from GHCR. If those tags are not published in your registry, override
 
 ## Local dev (kind + local images)
 
-The chart expects images like `ghcr.io/cordum-io/cordum/control-plane:<tag>-api-gateway`.
+The chart expects images like `ghcr.io/cordum-io/cordum/api-gateway:<tag>`.
 If you are installing from a local clone without published images, build and
 load images into your cluster and override tags:
 
 ```bash
 docker compose build
 
-for svc in api-gateway scheduler safety-kernel workflow-engine context-engine; do
-  docker tag "cordum-cordum-${svc}:latest" "ghcr.io/cordum-io/cordum/control-plane:dev-${svc}"
+for svc in api-gateway scheduler safety-kernel workflow-engine context-engine dashboard; do
+  docker tag "cordum-cordum-${svc}:latest" "ghcr.io/cordum-io/cordum/${svc}:dev"
 done
-docker tag cordum-cordum-dashboard:latest ghcr.io/cordum-io/cordum/dashboard:dev
 
 kind load docker-image --name cordum \
-  ghcr.io/cordum-io/cordum/control-plane:dev-api-gateway \
-  ghcr.io/cordum-io/cordum/control-plane:dev-scheduler \
-  ghcr.io/cordum-io/cordum/control-plane:dev-safety-kernel \
-  ghcr.io/cordum-io/cordum/control-plane:dev-workflow-engine \
-  ghcr.io/cordum-io/cordum/control-plane:dev-context-engine \
+  ghcr.io/cordum-io/cordum/api-gateway:dev \
+  ghcr.io/cordum-io/cordum/scheduler:dev \
+  ghcr.io/cordum-io/cordum/safety-kernel:dev \
+  ghcr.io/cordum-io/cordum/workflow-engine:dev \
+  ghcr.io/cordum-io/cordum/context-engine:dev \
   ghcr.io/cordum-io/cordum/dashboard:dev
 
 helm upgrade --install cordum ./cordum-helm -n cordum --create-namespace \


### PR DESCRIPTION
Removes the placeholder HTML comment from the README Key Features section. The visual is already in place.

Fixes #179. Thanks @vincent067 for spotting this!

Co-Authored-By: vincent <vincent067@users.noreply.github.com>