### PR TITLE
fix: notify safety kernel when pack policy fragments change

### DIFF
--- a/core/controlplane/gateway/handlers_packs.go
+++ b/core/controlplane/gateway/handlers_packs.go
@@ -329,6 +329,9 @@ func (s *server) installPackFromDir(ctx context.Context, bundleDir string, opts 
 	if packCredential != nil {
 		s.publishConfigChanged("system", "workers")
 	}
+	if len(appliedPolicyChanges) > 0 {
+		s.publishConfigChanged(policyConfigScope, policyConfigID)
+	}
 	return record, packCredential, nil
 }
 
@@ -873,6 +876,7 @@ func (s *server) applyPolicyOverlay(ctx context.Context, overlay packPolicyOverl
 	if err := s.configSvc.Set(ctx, doc); err != nil {
 		return appliedPolicyChange{}, err
 	}
+	s.publishConfigChanged(policyConfigScope, policyConfigID)
 	return appliedPolicyChange{
 		Overlay: packAppliedPolicyOverlay{
 			Name:       overlay.Name,
@@ -898,7 +902,11 @@ func (s *server) removePolicyOverlay(ctx context.Context, overlay packAppliedPol
 	}
 	delete(bundles, overlay.FragmentID)
 	doc.Data[policyConfigKey] = bundles
-	return s.configSvc.Set(ctx, doc)
+	if err := s.configSvc.Set(ctx, doc); err != nil {
+		return err
+	}
+	s.publishConfigChanged(policyConfigScope, policyConfigID)
+	return nil
 }
 
 func (s *server) restorePolicyOverlay(ctx context.Context, change appliedPolicyChange) error {
@@ -923,7 +931,11 @@ func (s *server) restorePolicyOverlay(ctx context.Context, change appliedPolicyC
 		bundles[change.Overlay.FragmentID] = deepCopy(change.Previous)
 	}
 	doc.Data[policyConfigKey] = bundles
-	return s.configSvc.Set(ctx, doc)
+	if err := s.configSvc.Set(ctx, doc); err != nil {
+		return err
+	}
+	s.publishConfigChanged(policyConfigScope, policyConfigID)
+	return nil
 }
 
 func (s *server) runPolicySimulation(ctx context.Context, test packPolicySimulation, packID string) (string, string, error) {


### PR DESCRIPTION
## Summary
Pack install writes policy fragments to Redis but never notified the safety kernel via NATS. Safety kernel only picked up new pack rules on poll (30s) or restart.

Fix: add `publishConfigChanged` calls to `applyPolicyOverlay`, `removePolicyOverlay`, `restorePolicyOverlay`, and the pack install post-install block.

## Test plan
- [x] `go test ./core/controlplane/gateway/... ./core/controlplane/safetykernel/...` passes
- [x] K8s e2e: install pack → safety kernel loads fragment on startup
- [x] All 3 transfer paths work (allow/require_human/deny)

🤖 Generated with [Claude Code](https://claude.com/claude-code)