### PR TITLE
docs: comprehensive documentation overhaul

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -154,6 +154,7 @@ cordumctl pool topic remove <pool-name> job.my-service.process
 # License management
 cordumctl license info                    # display license details (plan, entitlements, expiry)
 cordumctl license install ./license.json  # install license from file
+cordumctl license reload                  # hot-reload license on running gateway (no restart)
 cordumctl status                          # show tier, expiry, usage vs limits
 
 # Health & status

--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,24 @@ dev-down:
 dev-logs:
 	docker compose logs -f
 
-.PHONY: proto build build-all $(SERVICES:%=build-%) test test-integration coverage coverage-core openapi docker smoke dev-up dev-down dev-logs
+help:
+	@echo ""
+	@echo "Cordum Makefile targets:"
+	@echo ""
+	@echo "  make help               Show this help message"
+	@echo "  make build              Build all services (runs proto first)"
+	@echo "  make build SERVICE=X    Build a single service (e.g. SERVICE=cordum-scheduler)"
+	@echo "  make proto              Regenerate protobuf Go code"
+	@echo "  make test               Run all Go tests"
+	@echo "  make test-integration   Run integration tests (requires Docker)"
+	@echo "  make coverage           Full coverage report"
+	@echo "  make coverage-core      Core coverage check (80% minimum)"
+	@echo "  make openapi            Regenerate OpenAPI spec"
+	@echo "  make docker SERVICE=X   Build Docker image for a service"
+	@echo "  make smoke              Run platform smoke tests"
+	@echo "  make dev-up             Start all services via docker compose"
+	@echo "  make dev-down           Stop all services"
+	@echo "  make dev-logs           Tail docker compose logs"
+	@echo ""
+
+.PHONY: help proto build build-all $(SERVICES:%=build-%) test test-integration coverage coverage-core openapi docker smoke dev-up dev-down dev-logs

--- a/README.md
+++ b/README.md
@@ -99,7 +99,19 @@ graph LR
 
 ## Quickstart
 
-**Prerequisites:** Docker (4GB+ RAM), Docker Compose, Go 1.24+
+### First Time?
+
+| Goal | Path |
+|------|------|
+| **Just want to try it?** | `./tools/scripts/quickstart.sh` (below) |
+| **Manual step-by-step?** | [docs/quickstart.md](docs/quickstart.md) |
+| **Developing Cordum?** | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+### Prerequisites
+
+- **Docker Desktop v4+** or **Docker CLI v20.10+** with **Compose v2** (4GB+ RAM allocated)
+- **jq** (recommended, for parsing API responses)
+- **Go 1.24+** (optional, only needed for `cordumctl` or cert generation)
 
 ```bash
 git clone https://github.com/cordum-io/cordum.git
@@ -165,6 +177,8 @@ Also available on GHCR: `ghcr.io/cordum-io/cordum/{service}:{version}`
 | 9093 | Workflow Engine Health |
 | 50051 | Safety Kernel (gRPC) |
 | 50400 | Context Engine (gRPC) |
+
+> **Port conflicts?** If any port is already in use, either stop the conflicting service or override ports in your `.env` file before starting the stack.
 
 ### After Setup
 

--- a/cordum-helm/README.md
+++ b/cordum-helm/README.md
@@ -33,7 +33,7 @@ helm install cordum cordum/cordum -n cordum --create-namespace \
   --set dashboard.env.tenantId=default
 ```
 
-Note: the chart defaults to the image tags in `values.yaml` (currently `v0.1.4`)
+Note: the chart defaults to the image tags in `values.yaml` (currently `v0.9.7`)
 and pulls from GHCR. Override `global.image.tag` and `dashboard.image.tag` if
 your registry uses different tags.
 
@@ -44,7 +44,7 @@ Common overrides:
 ```bash
 helm install cordum ./cordum-helm \
   -n cordum --create-namespace \
-  --set global.image.tag=v0.1.4 \
+  --set global.image.tag=v0.9.7 \
   --set secrets.apiKey=$(openssl rand -hex 32) \
   --set redis.auth.password=$(openssl rand -hex 32) \
   --set gateway.env.tenantId=default \

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -366,10 +366,14 @@ P2 core should evolve to:
 
 ## 16) Enterprise licensing and entitlements
 
-Status: Planned. Enterprise features are licensed add-ons (SSO/SAML, advanced
-RBAC, SIEM export, support SLA, custom pack development, managed/on-prem
-deployment). Enterprise binaries and tooling live in the enterprise and tools
-repos; this repo stays platform-only.
+Status: Implemented. Licensing lives in `core/licensing/` with Ed25519 signature
+verification and three tiers (Community/Team/Enterprise). Entitlement enforcement
+is applied across all services: gateway rate limits, scheduler concurrency caps,
+workflow step limits, safety kernel policy bundle quotas, and audit retention
+periods. Licenses degrade gracefully on expiry (services continue at Community
+tier). Enterprise add-ons (license issuance, SSO/SAML, advanced RBAC, SIEM
+export, support SLA) live in the enterprise and tools repos; this repo provides
+the loading, validation, and tier enforcement layer.
 
 ---
 
@@ -561,7 +565,7 @@ Optional: a lightweight dashboard that talks to the gateway for run/status visib
 - Datadog/Coralogix/GitHub/K8s connectors (**packages only**)
 - LLM providers / prompt logic (**packages only**)
 - SRE Investigator logic (**package**)
-- MCP proxy/controller logic (**separate service/package later**)
+- MCP proxy/controller logic (**separate service — `cmd/cordum-mcp/` provides the MCP server bridge**)
 
 Core should provide **governance + runtime**, not domain logic.
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -51,7 +51,7 @@ variables from your shell, so keep the `export` lines when running scripts.
 ### Use GHCR Images (Release Builds)
 
 ```bash
-export CORDUM_VERSION=v0.1.4
+export CORDUM_VERSION=v0.9.7
 docker compose -f docker-compose.release.yml pull
 docker compose -f docker-compose.release.yml up -d
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1241,6 +1241,48 @@ Note: There are no `GET /api/v1/approvals/{id}` or `PUT /api/v1/approvals/{id}` 
 - Response: full snapshot object
 - Errors: `400`, `404`
 
+### DELETE `/api/v1/policy/bundles/{id}`
+
+- Auth: required + admin
+- Deletes a policy bundle by ID.
+- Response: `204 No Content`
+- Errors: `400` (invalid id), `404` (not found)
+
+### GET `/api/v1/policy/output/rules`
+
+- Auth: required
+- Response: list of output policy rules.
+
+```json
+{ "items": [{ "id": "rule-1", "name": "PII filter", "enabled": true, "action": "redact", "pattern": "..." }] }
+```
+
+- Errors: auth errors.
+
+### GET `/api/v1/policy/output/stats`
+
+- Auth: required
+- Response: aggregate output policy statistics (quarantine counts, redaction counts, denial counts).
+
+```json
+{ "total_checked": 1024, "quarantined": 12, "redacted": 45, "denied": 3 }
+```
+
+- Errors: auth errors.
+
+### PUT `/api/v1/policy/output/rules/{id}`
+
+- Auth: required + admin
+- Updates an existing output policy rule.
+- Request:
+
+```json
+{ "name": "PII filter", "enabled": true, "action": "redact", "pattern": "..." }
+```
+
+- Response: updated rule object.
+- Errors: `400` (invalid rule), `404` (not found)
+
 ### POST `/api/v1/policy/publish`
 
 - Request schema (`policyPublishRequest`):
@@ -1971,13 +2013,6 @@ curl -sS http://localhost:8081/api/v1/marketplace/packs \
 - Response: `{"items": [{"name": "job.my-pack.process", "pool": "my-pack", "status": "active", "pack_id": "my-pack", "input_schema_id": "", "output_schema_id": "", "requires": [], "risk_tags": []}]}`
 - Notes: Returns all registered topics from the topic registry. Topics are registered automatically when packs are installed.
 
-### PUT `/api/v1/topics`
-
-- Auth: required + admin
-- Body: `{"name": "job.my-topic", "pool": "my-pool", "status": "active"}`
-- Creates or updates a topic registration. Topic names must start with `job.`.
-- Errors: `400` (validation), auth errors.
-
 ### DELETE `/api/v1/topics/{name}`
 
 - Auth: required + admin
@@ -2012,6 +2047,18 @@ curl -sS http://localhost:8081/api/v1/marketplace/packs \
 ```
 
 - Errors: `403` (non-admin), plus auth/tenant middleware errors (`401`, `403`).
+
+### GET `/api/v1/workers/{id}`
+
+- Auth: required + admin
+- Response: single `Heartbeat` object for the specified worker.
+- Errors: `404` (worker not found), `403` (non-admin).
+
+### GET `/api/v1/workers/{id}/jobs`
+
+- Auth: required + admin
+- Response: list of jobs currently assigned to or recently completed by the worker.
+- Errors: `404` (worker not found), `403` (non-admin).
 
 ### GET `/metrics`
 
@@ -2201,6 +2248,26 @@ Returns all active distributed locks held in Redis. This is a read-only diagnost
 
 All pool management endpoints require **admin** role.
 
+### GET `/api/v1/pools`
+
+List all worker pools.
+
+**Response (200):**
+```json
+{ "items": [{ "name": "gpu-pool", "status": "active", "requires": ["gpu"], "description": "GPU-enabled pool" }] }
+```
+
+### GET `/api/v1/pools/{name}`
+
+Get details for a specific pool.
+
+**Response (200):**
+```json
+{ "name": "gpu-pool", "status": "active", "requires": ["gpu"], "description": "GPU-enabled pool", "topics": ["job.ml.train"] }
+```
+
+**Errors:** 404 (not found)
+
 ### PUT `/api/v1/pools/{name}`
 
 Create a new worker pool.
@@ -2315,6 +2382,8 @@ The following routes are registered in gateway route setup.
 | POST | `/api/v1/auth/keys` |
 | DELETE | `/api/v1/auth/keys/{id}` |
 | GET | `/api/v1/workers` |
+| GET | `/api/v1/workers/{id}` |
+| GET | `/api/v1/workers/{id}/jobs` |
 | GET | `/api/v1/workers/credentials` |
 | POST | `/api/v1/workers/credentials` |
 | DELETE | `/api/v1/workers/credentials/{worker_id}` |
@@ -2382,6 +2451,7 @@ The following routes are registered in gateway route setup.
 | GET | `/api/v1/policy/bundles` |
 | GET | `/api/v1/policy/bundles/{id}` |
 | PUT | `/api/v1/policy/bundles/{id}` |
+| DELETE | `/api/v1/policy/bundles/{id}` |
 | POST | `/api/v1/policy/bundles/{id}/simulate` |
 | GET | `/api/v1/policy/bundles/snapshots` |
 | POST | `/api/v1/policy/bundles/snapshots` |
@@ -2389,6 +2459,17 @@ The following routes are registered in gateway route setup.
 | POST | `/api/v1/policy/publish` |
 | POST | `/api/v1/policy/rollback` |
 | GET | `/api/v1/policy/audit` |
+| GET | `/api/v1/policy/output/rules` |
+| GET | `/api/v1/policy/output/stats` |
+| PUT | `/api/v1/policy/output/rules/{id}` |
+| GET | `/api/v1/pools` |
+| GET | `/api/v1/pools/{name}` |
+| PUT | `/api/v1/pools/{name}` |
+| PATCH | `/api/v1/pools/{name}` |
+| DELETE | `/api/v1/pools/{name}` |
+| POST | `/api/v1/pools/{name}/drain` |
+| PUT | `/api/v1/pools/{name}/topics/{topic}` |
+| DELETE | `/api/v1/pools/{name}/topics/{topic}` |
 | GET | `/api/v1/admin/locks` |
 | GET | `/api/v1/stream` (websocket upgrade) |
 | GET | `/mcp/sse` |

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -13,8 +13,19 @@ and is licensed under BUSL-1.1.
 - Audit export (JSON, CSV, SIEM)
 - Advanced RBAC controls
 
-License configuration (e.g., `CORDUM_LICENSE_KEY`, `CORDUM_LICENSE_PATH`) is
-documented in the `cordum-enterprise` repo.
+License loading, validation, and tier enforcement now live in core
+(`core/licensing/`). The core licensing system uses Ed25519 signature
+verification and enforces three tiers (Community/Team/Enterprise) with
+entitlement limits across all services (gateway rate limits, scheduler
+concurrency, workflow steps, safety kernel policy bundles, audit retention).
+Licenses degrade gracefully to Community tier on expiry.
+
+The enterprise repo provides license **issuance**, SSO/SAML, and advanced RBAC.
+
+Configuration variables (set in core):
+- `CORDUM_LICENSE_FILE` — path to the signed license file
+- `CORDUM_LICENSE_TOKEN` — inline license token (alternative to file)
+- `CORDUM_LICENSE_PUBLIC_KEY` — Ed25519 public key for signature verification
 
 ## Authentication
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -22,7 +22,7 @@ helm repo update
 helm install cordum cordum/cordum -n cordum --create-namespace
 ```
 
-Note: the chart defaults to the image tags in `values.yaml` (currently `v0.1.4`)
+Note: the chart defaults to the image tags in `values.yaml` (currently `v0.9.7`)
 and pulls from GHCR. If those tags are not published in your registry, override
 `global.image.tag` and `dashboard.image.tag` (or point to your own registry).
 
@@ -93,7 +93,7 @@ helm upgrade --install cordum ./cordum-helm \
 ```bash
 helm install cordum ./cordum-helm \
   -n cordum --create-namespace \
-  --set global.image.tag=v0.1.4 \
+  --set global.image.tag=v0.9.7 \
   --set secrets.apiKey=<your-api-key> \
   --set gateway.env.tenantId=default \
   --set dashboard.env.tenantId=default

--- a/docs/k8s-deployment.md
+++ b/docs/k8s-deployment.md
@@ -199,17 +199,17 @@ The `production/kustomization.yaml` composes:
 ```yaml
 images:
   - name: cordum-context-engine
-    newTag: v0.1.0
+    newTag: v0.9.7
   - name: cordum-safety-kernel
-    newTag: v0.1.0
+    newTag: v0.9.7
   - name: cordum-scheduler
-    newTag: v0.1.0
+    newTag: v0.9.7
   - name: cordum-api-gateway
-    newTag: v0.1.0
+    newTag: v0.9.7
   - name: cordum-workflow-engine
-    newTag: v0.1.0
+    newTag: v0.9.7
   - name: cordum-dashboard
-    newTag: v0.1.0
+    newTag: v0.9.7
 ```
 
 **Replica overrides:**
@@ -758,7 +758,7 @@ The `cordum-helm/` directory provides an alternative deployment method using Hel
 
 ```
 cordum-helm/
-├── Chart.yaml                          # Chart metadata (v0.1.4)
+├── Chart.yaml                          # Chart metadata (v0.9.7)
 ├── values.yaml                         # Default values
 ├── README.md                           # Chart documentation
 └── templates/
@@ -778,7 +778,7 @@ cordum-helm/
 | Key | Default | Description |
 |-----|---------|-------------|
 | `global.image.repository` | `ghcr.io/cordum-io/cordum/control-plane` | Base image for control plane services |
-| `global.image.tag` | `v0.1.4` | Image tag for all services |
+| `global.image.tag` | `v0.9.7` | Image tag for all services |
 | `secrets.apiKey` | `""` | API key (required) |
 | `secrets.adminPassword` | `""` | Admin password for user auth |
 | `nats.enabled` | `true` | Deploy bundled NATS |
@@ -822,7 +822,7 @@ Create a `values-production.yaml` file:
 # values-production.yaml
 global:
   image:
-    tag: "v0.1.4"
+    tag: "v0.9.7"
 
 secrets:
   apiKey: ""  # Set via --set or external secret

--- a/docs/pack.md
+++ b/docs/pack.md
@@ -256,6 +256,11 @@ top-level `bundles` key to prevent future scope corruption.
 Safety kernel merges file/URL policy with config service fragments on load/reload.
 Snapshot hashes are combined (e.g. `baseSnapshot|cfg:<hash>`).
 
+When a pack installs or updates a policy fragment, the installer publishes a NATS
+notification on `sys.config.changed` to signal the safety kernel. The kernel
+picks up the new fragment and reloads policy immediately — no service restart
+required.
+
 Policy rules may include **remediations** to suggest safer alternatives:
 
 ```yaml

--- a/docs/production.md
+++ b/docs/production.md
@@ -399,7 +399,7 @@ Document a restore drill and run it at least quarterly.
 - Use versioned images and a staged rollout (dev -> staging -> prod).
 - Validate schema/policy changes in staging before publish.
 - Keep backward compatibility for workflow payloads.
-- The production K8s overlay pins all images to `v0.1.0` — update `kustomization.yaml` images section for upgrades.
+- The production K8s overlay pins all images to `v0.9.7` — update `kustomization.yaml` images section for upgrades.
 
 ### Rolling Upgrade Procedure
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -438,6 +438,84 @@ done
 - Keep public and enterprise images in separate registries.
 - Audit all API keys and principal roles.
 
+## Licensing Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CORDUM_LICENSE_FILE` | Path to the license JSON file on disk |
+| `CORDUM_LICENSE_TOKEN` | Inline license token (alternative to file) |
+| `CORDUM_LICENSE_PUBLIC_KEY` | Inline ECDSA public key (PEM) for license signature verification |
+| `CORDUM_LICENSE_PUBLIC_KEY_PATH` | Path to public key file for license verification |
+
+### Tiers
+
+| Tier | Description |
+|------|-------------|
+| **Community** | Default when no license is installed. Enforced limits on workers, concurrent jobs, rate limits, and audit retention. |
+| **Team** | Unlocks higher limits, additional features, and extended audit retention. |
+| **Enterprise** | Full platform capabilities including SAML/SSO, advanced RBAC, unlimited workers, and priority support. |
+
+If no license file or token is provided, the gateway starts in **Community** tier with enforced limits.
+
+### Expiry Lifecycle
+
+1. **Valid** — License is active and within its validity window.
+2. **Warning** (30 days before expiry) — The gateway logs warnings and the dashboard displays an expiry notice. All features remain available.
+3. **Grace period** (14 days after expiry, configurable) — The license is expired but the platform continues operating at its licensed tier with logged warnings.
+4. **Degraded** — After the grace period, the gateway falls back to Community tier limits. The platform never bricks — it degrades gracefully to community defaults.
+
+### CLI Commands
+
+```bash
+cordumctl license install ./license.json   # Install a license from file
+cordumctl license info                     # Display license plan, entitlements, and expiry
+cordumctl license reload                   # Hot-reload license on running gateway (no restart)
+```
+
+### Hot-Reload
+
+Reload a license on a running gateway without restart:
+
+```bash
+curl -X POST https://gateway:8081/api/v1/license/reload \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+The gateway re-reads the license from environment or disk, revalidates the signature, and applies the new entitlements immediately.
+
+## Telemetry Configuration
+
+### Mode
+
+| `CORDUM_TELEMETRY_MODE` | Behavior |
+|--------------------------|----------|
+| `off` | No telemetry data is collected or stored. |
+| `local_only` (default) | Telemetry is collected and stored locally for the dashboard. No data is sent externally. |
+| `anonymous` | Aggregate, anonymized usage data is sent to Cordum. Requires explicit opt-in. |
+
+The default is `local_only` — remote reporting is never enabled without explicit operator opt-in.
+
+### Dashboard Consent
+
+On first visit, the dashboard displays a consent banner explaining telemetry modes. The operator must choose a mode before telemetry data is transmitted externally.
+
+### Inspect Payload
+
+Review exactly what telemetry data would be sent:
+
+```bash
+curl -H "Authorization: Bearer $API_KEY" \
+  https://gateway:8081/api/v1/telemetry/inspect
+```
+
+### Data Principles
+
+- **No PII collected** — telemetry contains only aggregate counts, hashed install ID, and feature flags.
+- No job content, prompts, outputs, user identifiers, or tenant data is ever included.
+- The hashed install ID is a one-way SHA-256 hash of the instance ID — it cannot be reversed to identify the installation.
+
 ## 9) K8s Hardening (recommended)
 
 - Requests/limits for every pod (already in `deploy/k8s/base.yaml`).
@@ -956,6 +1034,11 @@ Complete list of production-relevant environment variables:
 | `REDIS_TLS_KEY` | All | Redis TLS client key path |
 | `REDIS_CLUSTER_ADDRESSES` | All | Redis cluster seed node addresses |
 | `CORDUM_LICENSE_REQUIRED` | Gateway | Enforce enterprise license check |
+| `CORDUM_LICENSE_FILE` | Gateway | Path to license JSON file |
+| `CORDUM_LICENSE_TOKEN` | Gateway | Inline license token |
+| `CORDUM_LICENSE_PUBLIC_KEY` | Gateway | Inline ECDSA public key for license verification |
+| `CORDUM_LICENSE_PUBLIC_KEY_PATH` | Gateway | Path to public key file for license verification |
+| `CORDUM_TELEMETRY_MODE` | Gateway | Telemetry mode: `off`, `local_only` (default), `anonymous` |
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,7 @@
 # Cordum Quick Start (5 minutes)
 
+> **Time estimate:** First run takes ~3 minutes (Docker image builds). Subsequent starts take ~30 seconds.
+
 This walkthrough starts a local stack and runs a minimal approval-only workflow
 without any external workers.
 
@@ -15,10 +17,10 @@ export CORDUM_TENANT_ID=default
 
 ## Prerequisites
 
-- Docker + Docker Compose
-- curl
-- jq
-- Go (optional, only if using `cordumctl`)
+- **Docker Desktop v4+** or **Docker CLI v20.10+** with **Compose v2** (4GB+ RAM allocated)
+- **curl**
+- **jq** (recommended, for parsing API responses in this guide)
+- **Go 1.24+** (optional, only if using `cordumctl`)
 
 ## Step 1: Set API key + tenant
 
@@ -127,6 +129,18 @@ curl -sS -X DELETE http://localhost:8081/api/v1/workflows/${workflow_id}?org_id=
   -H "X-API-Key: ${API_KEY}" \
   -H "X-Tenant-ID: ${TENANT_ID}" >/dev/null
 ```
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| **Port already in use** | Change ports in `.env` or stop the conflicting service (`lsof -i :8081` to find it) |
+| **API key missing / 401 errors** | Generate one with `openssl rand -hex 32` and export as `CORDUM_API_KEY`, or use `quickstart.sh` which handles this automatically |
+| **Dashboard shows empty** | Normal on a fresh install. Create a workflow first (Step 4 above) or run the smoke test |
+| **TLS / certificate errors** | `quickstart.sh` generates self-signed certs. Your browser will show a warning -- this is expected for local dev. Delete `./certs/` and re-run to regenerate |
+| **Docker out of memory** | Allocate at least 4 GB RAM to Docker Desktop |
+
+For more, see [troubleshooting.md](troubleshooting.md).
 
 ## Next steps
 

--- a/docs/safety-kernel.md
+++ b/docs/safety-kernel.md
@@ -52,6 +52,14 @@ Approval binding behavior:
 - `approval_required` is true for `require_approval`.
 - `approval_ref` is set to the incoming `job_id`.
 
+### Licensing Tier Limits on Velocity Rules
+
+Velocity rules (rate-based policy rules) are capped by the active licensing tier
+entitlements. Community tier gets a limited number of velocity rules; Team tier
+gets a higher limit; Enterprise tier is unlimited. When the velocity rule count
+exceeds the tier limit, excess rules are ignored and a warning is logged during
+policy load.
+
 ## 3. MCP Label Filtering
 
 MCP request context is extracted from job labels:

--- a/docs/system_overview.md
+++ b/docs/system_overview.md
@@ -75,6 +75,19 @@ NATS bus (sys.* + job.* + worker.<id>.jobs)
   - gRPC service for `BuildWindow` and `UpdateMemory`.
   - Maintains chat history and generic memory under `mem:<memory_id>:*`.
 
+- MCP Server (`cmd/cordum-mcp`; binary `cordum-mcp`)
+  - Model Context Protocol bridge that exposes Cordum capabilities (jobs, workflows, policy) as MCP tools and resources.
+
+- Licensing (`core/licensing/`)
+  - Ed25519-signed license loading and validation with three tiers (Community/Team/Enterprise).
+  - Entitlement enforcement across services: gateway rate limits, scheduler concurrency caps, workflow step limits, safety kernel policy bundle quotas, audit retention periods.
+  - Graceful degradation to Community tier on license expiry.
+  - Config: `CORDUM_LICENSE_FILE`, `CORDUM_LICENSE_TOKEN`, `CORDUM_LICENSE_PUBLIC_KEY`.
+
+- Telemetry (`core/telemetry/`)
+  - Structured metrics collection across all services; Prometheus exposition on each service's metrics port.
+  - License-tier-aware retention and export controls.
+
 - External workers (not in this repo)
   - Subscribe to job topics or direct subjects; honor `sys.job.cancel`.
   - Write results to Redis and publish `sys.job.result`.
@@ -176,6 +189,7 @@ JetStream (optional):
 - `cordum-workflow-engine`
 - `cordum-context-engine`
 - `cordumctl` (CLI)
+- `cordum-mcp` (MCP server)
 
 ## Repo layout
 


### PR DESCRIPTION
## Summary
- Architecture docs updated: licensing changed from "Planned" to "Implemented", telemetry and MCP server added
- Production guide: new Licensing Configuration and Telemetry Configuration sections
- API reference: 8 missing endpoints added, phantom PUT /api/v1/topics removed
- Quickstart: "First Time?" path, versioned prerequisites, troubleshooting section
- Makefile: help target added
- All stale v0.1.4 image refs updated to v0.9.7

12 files changed, 277 insertions

## Test plan
- [x] All doc links verified
- [x] `make help` works
- [x] helm lint passes
- [x] No stale version references