### PR TITLE
feat: add Prometheus metrics for approval workflow

### DIFF
--- a/cmd/cordum-scheduler/main.go
+++ b/cmd/cordum-scheduler/main.go
@@ -144,6 +144,18 @@ func sanitizeLogValue(s string) string {
 	}, s)
 }
 
+func syncApprovalQueueDepth(ctx context.Context, jobStore *store.RedisJobStore, approvalMetrics infraMetrics.ApprovalMetrics) {
+	if jobStore == nil || approvalMetrics == nil {
+		return
+	}
+	count, err := jobStore.CountJobsByState(ctx, scheduler.JobStateApproval)
+	if err != nil {
+		slog.Warn("approval queue depth sync failed", "error", err)
+		return
+	}
+	approvalMetrics.SetApprovalQueueDepth("all", int(count))
+}
+
 func main() {
 	logging.Init("scheduler")
 	slog.Info("cordum scheduler starting...")
@@ -170,6 +182,7 @@ func main() {
 	}
 
 	metrics := infraMetrics.NewProm("cordum_scheduler")
+	approvalMetrics := infraMetrics.NewApprovalProm("cordum")
 	metricsAddr := strings.TrimSpace(os.Getenv("SCHEDULER_METRICS_ADDR"))
 	if metricsAddr == "" {
 		metricsAddr = ":9090"
@@ -206,6 +219,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer func() { _ = jobStore.Close() }()
+	syncApprovalQueueDepth(context.Background(), jobStore, approvalMetrics)
 
 	var dlqStore *store.DLQStore
 	dlqStore, err = store.NewDLQStore(cfg.RedisURL, 0)
@@ -454,7 +468,8 @@ func main() {
 	}
 
 	dispatchTimeout, runningTimeout, scanInterval := reconcilerTimeouts(snapshot.Timeouts)
-	reconciler := scheduler.NewReconciler(jobStore, dispatchTimeout, runningTimeout, scanInterval)
+	reconciler := scheduler.NewReconciler(jobStore, dispatchTimeout, runningTimeout, scanInterval).
+		WithApprovalMetrics(approvalMetrics)
 	go reconciler.Start(ctx)
 	pendingReplayer := scheduler.NewPendingReplayer(engine, jobStore, dispatchTimeout, scanInterval)
 	go pendingReplayer.Start(ctx)

--- a/core/controlplane/gateway/gateway.go
+++ b/core/controlplane/gateway/gateway.go
@@ -110,13 +110,14 @@ type server struct {
 	eventsCh      chan wsEvent
 	wsClientBufSz int
 
-	metrics        infraMetrics.GatewayMetrics
-	tenant         string
-	started        time.Time
-	auth           AuthProvider
-	entitlements   *licensing.EntitlementResolver
-	telemetry      *telemetry.Collector
-	telemetryState *telemetry.Store
+	metrics         infraMetrics.GatewayMetrics
+	approvalMetrics infraMetrics.ApprovalMetrics
+	tenant          string
+	started         time.Time
+	auth            AuthProvider
+	entitlements    *licensing.EntitlementResolver
+	telemetry       *telemetry.Collector
+	telemetryState  *telemetry.Store
 
 	workflowStore         *wf.RedisStore
 	workflowEng           *wf.Engine
@@ -286,6 +287,7 @@ func RunWithAuth(cfg *config.Config, provider AuthProvider, entitlementResolvers
 	}
 
 	gwMetrics := infraMetrics.NewGatewayProm("cordum_api_gateway")
+	approvalMetrics := infraMetrics.NewApprovalProm("cordum")
 	var userStore UserStore
 	var keyStore KeyStore
 	var err error
@@ -544,6 +546,7 @@ func RunWithAuth(cfg *config.Config, provider AuthProvider, entitlementResolvers
 		eventsCh:              make(chan wsEvent, 512),
 		wsClientBufSz:         wsClientBufferSize(),
 		metrics:               gwMetrics,
+		approvalMetrics:       approvalMetrics,
 		tenant:                tenantID,
 		auth:                  provider,
 		entitlements:          entitlementResolver,
@@ -569,6 +572,7 @@ func RunWithAuth(cfg *config.Config, provider AuthProvider, entitlementResolvers
 		statusCacheObj:        newStatusCache(2 * time.Second),
 		shutdownCh:            make(chan struct{}),
 	}
+	s.syncApprovalQueueDepth(context.Background())
 	defer s.Close()
 	telemetryStore, err := telemetry.NewStore(cfg.RedisURL)
 	if err != nil {

--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -265,6 +265,50 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+func timeFromUnixHeuristic(ts int64) (time.Time, bool) {
+	if ts <= 0 {
+		return time.Time{}, false
+	}
+	switch {
+	case ts < secondsThreshold:
+		return time.Unix(ts, 0).UTC(), true
+	case ts < millisThreshold:
+		return time.UnixMilli(ts).UTC(), true
+	case ts < microsThreshold:
+		return time.UnixMicro(ts).UTC(), true
+	default:
+		return time.Unix(0, ts).UTC(), true
+	}
+}
+
+func approvalRequestedAt(_ *pb.JobRequest, safetyRecord model.SafetyDecisionRecord) (time.Time, bool) {
+	return timeFromUnixHeuristic(safetyRecord.CheckedAt)
+}
+
+func (s *server) observeApprovalResolutionMetrics(req *pb.JobRequest, safetyRecord model.SafetyDecisionRecord, resolvedAt int64, decision string) {
+	if s == nil || s.approvalMetrics == nil {
+		return
+	}
+	if requestedAt, ok := approvalRequestedAt(req, safetyRecord); ok {
+		if resolvedTime, ok := timeFromUnixHeuristic(resolvedAt); ok {
+			s.approvalMetrics.ObserveApprovalLatency(resolvedTime.Sub(requestedAt).Seconds())
+		}
+	}
+	s.approvalMetrics.IncApprovalDecision(decision)
+}
+
+func (s *server) syncApprovalQueueDepth(ctx context.Context) {
+	if s == nil || s.jobStore == nil || s.approvalMetrics == nil {
+		return
+	}
+	count, err := s.jobStore.CountJobsByState(ctx, model.JobStateApproval)
+	if err != nil {
+		slog.Warn("approval queue depth sync failed", "error", err)
+		return
+	}
+	s.approvalMetrics.SetApprovalQueueDepth("all", int(count))
+}
+
 func (s *server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
 	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.workflowEng) {
 		return
@@ -320,6 +364,7 @@ func (s *server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
 	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.jobStore) {
 		return
 	}
+	s.syncApprovalQueueDepth(r.Context())
 	limit, cursor := parsePagination(r, 100)
 	// Overfetch slightly to account for items that will be filtered out
 	// by tenant access checks, so the client receives close to `limit` items.
@@ -1045,6 +1090,8 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 			result = handlerResult{http.StatusInternalServerError, "failed to persist approval resolution"}
 			return nil
 		}
+		s.observeApprovalResolutionMetrics(req, safetyRecord, resolved.ApprovalRecord.ApprovedAt, "approved")
+		s.syncApprovalQueueDepth(ctx)
 		packet := &pb.BusPacket{
 			TraceId:         resolved.TraceID,
 			SenderId:        "api-gateway",
@@ -1209,6 +1256,8 @@ func (s *server) handleRejectJob(w http.ResponseWriter, r *http.Request) {
 			result = handlerResult{http.StatusInternalServerError, "failed to persist approval resolution"}
 			return nil
 		}
+		s.observeApprovalResolutionMetrics(req, safetyRecord, resolved.ApprovalRecord.ApprovedAt, "denied")
+		s.syncApprovalQueueDepth(ctx)
 		errorMessage := "approval rejected"
 		if reason != "" {
 			errorMessage = reason

--- a/core/controlplane/gateway/handlers_grpc.go
+++ b/core/controlplane/gateway/handlers_grpc.go
@@ -295,6 +295,7 @@ func (s *server) SubmitJob(ctx context.Context, req *pb.SubmitJobRequest) (*pb.S
 			if err := s.jobStore.SetSafetyDecision(ctx, jobID, safetyRecord); err != nil {
 				slog.Error("failed to persist safety decision for approval", "job_id", jobID, "error", err)
 			}
+			s.syncApprovalQueueDepth(ctx)
 		}
 		return &pb.SubmitJobResponse{
 			JobId:   jobID,

--- a/core/controlplane/gateway/handlers_jobs.go
+++ b/core/controlplane/gateway/handlers_jobs.go
@@ -1634,6 +1634,7 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 			if err := s.jobStore.SetSafetyDecision(r.Context(), jobID, safetyRecord); err != nil {
 				slog.Error("failed to persist safety decision for approval", "job_id", jobID, "error", err)
 			}
+			s.syncApprovalQueueDepth(r.Context())
 		}
 
 		w.Header().Set("X-Trace-Id", traceID)

--- a/core/controlplane/scheduler/reconciler.go
+++ b/core/controlplane/scheduler/reconciler.go
@@ -21,6 +21,17 @@ type Reconciler struct {
 	lockTTL          time.Duration
 	mu               sync.RWMutex
 	metrics          Metrics
+	approvalMetrics  approvalMetrics
+}
+
+type approvalMetrics interface {
+	SetApprovalQueueDepth(riskTier string, depth int)
+	IncApprovalExpired()
+	IncApprovalDecision(decision string)
+}
+
+type approvalDepthCounter interface {
+	CountJobsByState(ctx context.Context, state JobState) (int64, error)
 }
 
 type approvalRepairStore interface {
@@ -43,6 +54,12 @@ func NewReconciler(store JobStore, dispatchTimeout, runningTimeout, pollInterval
 // WithMetrics attaches a Metrics implementation to the reconciler.
 func (r *Reconciler) WithMetrics(m Metrics) *Reconciler {
 	r.metrics = m
+	return r
+}
+
+// WithApprovalMetrics attaches approval workflow metrics to the reconciler.
+func (r *Reconciler) WithApprovalMetrics(m approvalMetrics) *Reconciler {
+	r.approvalMetrics = m
 	return r
 }
 
@@ -162,6 +179,9 @@ func (r *Reconciler) handleTimeouts(ctx context.Context, state JobState, cutoff 
 			}
 			_ = r.store.SetFailureReason(ctx, rec.ID, reason)
 			slog.Info("job timed out", "job_id", rec.ID, "from_state", state)
+			if state == JobStateApproval {
+				r.recordApprovalExpiry(ctx)
+			}
 			progress++
 		}
 
@@ -189,8 +209,36 @@ func (r *Reconciler) handleDeadlineExpirations(ctx context.Context, now time.Tim
 		} else {
 			_ = r.store.SetFailureReason(ctx, rec.ID, "timeout: deadline expired")
 			slog.Info("job deadline expired", "job_id", rec.ID)
+			if rec.State == JobStateApproval {
+				r.recordApprovalExpiry(ctx)
+			}
 		}
 	}
+}
+
+func (r *Reconciler) recordApprovalExpiry(ctx context.Context) {
+	if r == nil || r.approvalMetrics == nil {
+		return
+	}
+	r.approvalMetrics.IncApprovalExpired()
+	r.approvalMetrics.IncApprovalDecision("expired")
+	r.syncApprovalQueueDepth(ctx)
+}
+
+func (r *Reconciler) syncApprovalQueueDepth(ctx context.Context) {
+	if r == nil || r.approvalMetrics == nil || r.store == nil {
+		return
+	}
+	counter, ok := r.store.(approvalDepthCounter)
+	if !ok {
+		return
+	}
+	count, err := counter.CountJobsByState(ctx, JobStateApproval)
+	if err != nil {
+		slog.Warn("approval queue depth sync failed", "error", err)
+		return
+	}
+	r.approvalMetrics.SetApprovalQueueDepth("all", int(count))
 }
 
 func (r *Reconciler) handleApprovalRepairs(ctx context.Context, now time.Time) {

--- a/core/controlplane/scheduler/reconciler_test.go
+++ b/core/controlplane/scheduler/reconciler_test.go
@@ -95,7 +95,7 @@ func (s *fakeReconcileStore) ListExpiredDeadlines(_ context.Context, nowUnix int
 	var out []JobRecord
 	for id, ts := range s.dead {
 		if ts <= nowUnix {
-			out = append(out, JobRecord{ID: id, DeadlineUnix: ts})
+			out = append(out, JobRecord{ID: id, State: s.states[id], DeadlineUnix: ts})
 			if limit > 0 && int64(len(out)) >= limit {
 				break
 			}
@@ -117,6 +117,18 @@ func (s *fakeReconcileStore) ListJobsByState(_ context.Context, state JobState, 
 		}
 	}
 	return out, nil
+}
+
+func (s *fakeReconcileStore) CountJobsByState(_ context.Context, state JobState) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var count int64
+	for _, st := range s.states {
+		if st == state {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (s *fakeReconcileStore) AddJobToTrace(_ context.Context, traceID, jobID string) error {
@@ -258,6 +270,31 @@ func (s *fakeReconcileStore) CancelJob(_ context.Context, jobID string) (JobStat
 	return JobStateCancelled, nil
 }
 
+type approvalMetricsSpy struct {
+	queueDepth map[string]int
+	decisions  map[string]int
+	expired    int
+}
+
+func newApprovalMetricsSpy() *approvalMetricsSpy {
+	return &approvalMetricsSpy{
+		queueDepth: make(map[string]int),
+		decisions:  make(map[string]int),
+	}
+}
+
+func (m *approvalMetricsSpy) SetApprovalQueueDepth(riskTier string, depth int) {
+	m.queueDepth[riskTier] = depth
+}
+
+func (m *approvalMetricsSpy) IncApprovalExpired() {
+	m.expired++
+}
+
+func (m *approvalMetricsSpy) IncApprovalDecision(decision string) {
+	m.decisions[decision]++
+}
+
 func TestReconcilerTimeouts(t *testing.T) {
 	store := newFakeReconcileStore()
 
@@ -381,6 +418,55 @@ func TestReconcilerSetsFailureReasonOnDeadlineExpiry(t *testing.T) {
 	reason, _ := store.GetFailureReason(context.Background(), "deadline-job")
 	if reason != "timeout: deadline expired" {
 		t.Fatalf("expected reason 'timeout: deadline expired', got %q", reason)
+	}
+}
+
+func TestReconcilerTracksApprovalExpiryMetricsOnTimeout(t *testing.T) {
+	store := newFakeReconcileStore()
+	store.states["approval-timeout"] = JobStateApproval
+	store.updated["approval-timeout"] = toUnixMicros(time.Now().Add(-5 * time.Minute))
+	metrics := newApprovalMetricsSpy()
+
+	rec := NewReconciler(store, time.Minute, time.Minute, time.Second).
+		WithApprovalMetrics(metrics)
+	rec.handleTimeouts(context.Background(), JobStateApproval, time.Now().Add(-time.Minute))
+
+	if state, _ := store.GetState(context.Background(), "approval-timeout"); state != JobStateTimeout {
+		t.Fatalf("expected approval-timeout to be TIMEOUT, got %s", state)
+	}
+	if metrics.expired != 1 {
+		t.Fatalf("expected expired metric increment, got %d", metrics.expired)
+	}
+	if metrics.decisions["expired"] != 1 {
+		t.Fatalf("expected expired decision increment, got %d", metrics.decisions["expired"])
+	}
+	if metrics.queueDepth["all"] != 0 {
+		t.Fatalf("expected queue depth 0 after expiry, got %d", metrics.queueDepth["all"])
+	}
+}
+
+func TestReconcilerTracksApprovalExpiryMetricsOnDeadline(t *testing.T) {
+	store := newFakeReconcileStore()
+	store.states["approval-deadline"] = JobStateApproval
+	store.updated["approval-deadline"] = toUnixMicros(time.Now())
+	store.dead["approval-deadline"] = time.Now().Add(-time.Minute).Unix()
+	metrics := newApprovalMetricsSpy()
+
+	rec := NewReconciler(store, time.Minute, time.Minute, time.Second).
+		WithApprovalMetrics(metrics)
+	rec.handleDeadlineExpirations(context.Background(), time.Now())
+
+	if state, _ := store.GetState(context.Background(), "approval-deadline"); state != JobStateTimeout {
+		t.Fatalf("expected approval-deadline to be TIMEOUT, got %s", state)
+	}
+	if metrics.expired != 1 {
+		t.Fatalf("expected expired metric increment, got %d", metrics.expired)
+	}
+	if metrics.decisions["expired"] != 1 {
+		t.Fatalf("expected expired decision increment, got %d", metrics.decisions["expired"])
+	}
+	if metrics.queueDepth["all"] != 0 {
+		t.Fatalf("expected queue depth 0 after deadline expiry, got %d", metrics.queueDepth["all"])
 	}
 }
 

--- a/core/infra/metrics/metrics.go
+++ b/core/infra/metrics/metrics.go
@@ -82,6 +82,14 @@ type WorkflowMetrics interface {
 	ObserveWorkflowDuration(workflow string, durationSeconds float64)
 }
 
+// ApprovalMetrics captures approval workflow observability.
+type ApprovalMetrics interface {
+	SetApprovalQueueDepth(riskTier string, depth int)
+	ObserveApprovalLatency(durationSeconds float64)
+	IncApprovalExpired()
+	IncApprovalDecision(decision string)
+}
+
 // Noop implements Metrics without emitting anything.
 type Noop struct{}
 
@@ -119,6 +127,14 @@ func (Noop) IncInputFailOpen(string)                           {}
 func (Noop) IncJobLockAbandoned()                              {}
 func (Noop) IncResultPtrWriteFailure()                         {}
 func (Noop) IncDispatchRollback(string)                        {}
+
+// NoopApproval implements ApprovalMetrics without emitting anything.
+type NoopApproval struct{}
+
+func (NoopApproval) SetApprovalQueueDepth(string, int) {}
+func (NoopApproval) ObserveApprovalLatency(float64)    {}
+func (NoopApproval) IncApprovalExpired()               {}
+func (NoopApproval) IncApprovalDecision(string)        {}
 
 // Prom implements Metrics backed by Prometheus counters.
 type Prom struct {
@@ -644,4 +660,62 @@ func (w *workflowProm) IncWorkflowCompleted(workflow, status string) {
 
 func (w *workflowProm) ObserveWorkflowDuration(workflow string, durationSeconds float64) {
 	w.duration.WithLabelValues(workflow).Observe(durationSeconds)
+}
+
+// --- Approval metrics ---
+
+type approvalProm struct {
+	queueDepth    *prometheus.GaugeVec
+	latency       prometheus.Histogram
+	expiredTotal  prometheus.Counter
+	decisionTotal *prometheus.CounterVec
+	once          sync.Once
+}
+
+func NewApprovalProm(namespace string) ApprovalMetrics {
+	a := &approvalProm{
+		queueDepth: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "approval_queue_depth",
+			Help:      "Pending approvals by risk tier",
+		}, []string{"risk_tier"}),
+		latency: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "approval_latency_seconds",
+			Help:      "Time from approval request to resolution",
+			Buckets:   prometheus.DefBuckets,
+		}),
+		expiredTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "approval_expired_total",
+			Help:      "Approvals that timed out without resolution",
+		}),
+		decisionTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "approval_decisions_total",
+			Help:      "Approval decisions by outcome",
+		}, []string{"decision"}),
+	}
+	a.once.Do(func() {
+		podRegisterer.MustRegister(a.queueDepth, a.latency, a.expiredTotal, a.decisionTotal)
+	})
+	return a
+}
+
+func (a *approvalProm) SetApprovalQueueDepth(riskTier string, depth int) {
+	a.queueDepth.WithLabelValues(riskTier).Set(float64(depth))
+}
+
+func (a *approvalProm) ObserveApprovalLatency(durationSeconds float64) {
+	if durationSeconds >= 0 {
+		a.latency.Observe(durationSeconds)
+	}
+}
+
+func (a *approvalProm) IncApprovalExpired() {
+	a.expiredTotal.Inc()
+}
+
+func (a *approvalProm) IncApprovalDecision(decision string) {
+	a.decisionTotal.WithLabelValues(decision).Inc()
 }

--- a/core/infra/metrics/metrics_test.go
+++ b/core/infra/metrics/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,6 +59,14 @@ func TestNoopMetrics(t *testing.T) {
 	m.DecSagaActive()
 	m.IncJobCancelFailures()
 	m.IncValidationRejections()
+}
+
+func TestNoopApprovalMetrics(t *testing.T) {
+	var m NoopApproval
+	m.SetApprovalQueueDepth("all", 1)
+	m.ObserveApprovalLatency(0.25)
+	m.IncApprovalExpired()
+	m.IncApprovalDecision("approved")
 }
 
 func TestPromMetrics(t *testing.T) {
@@ -204,10 +213,46 @@ func TestWorkflowMetrics(t *testing.T) {
 	}
 }
 
+func TestApprovalMetrics(t *testing.T) {
+	reg := withTestRegistry(t)
+	m := NewApprovalProm("cordum")
+	m.SetApprovalQueueDepth("all", 3)
+	m.ObserveApprovalLatency(0.5)
+	m.IncApprovalExpired()
+	m.IncApprovalDecision("approved")
+	m.IncApprovalDecision("denied")
+	m.IncApprovalDecision("expired")
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	if !hasMetric(families, "cordum_approval_queue_depth", map[string]string{"risk_tier": "all"}) {
+		t.Fatalf("expected approval_queue_depth metric")
+	}
+	if !hasMetric(families, "cordum_approval_latency_seconds", nil) {
+		t.Fatalf("expected approval_latency_seconds metric")
+	}
+	if !hasMetric(families, "cordum_approval_expired_total", nil) {
+		t.Fatalf("expected approval_expired_total metric")
+	}
+	if !hasMetric(families, "cordum_approval_decisions_total", map[string]string{"decision": "approved"}) {
+		t.Fatalf("expected approval_decisions_total approved metric")
+	}
+	if !hasMetric(families, "cordum_approval_decisions_total", map[string]string{"decision": "denied"}) {
+		t.Fatalf("expected approval_decisions_total denied metric")
+	}
+	if !hasMetric(families, "cordum_approval_decisions_total", map[string]string{"decision": "expired"}) {
+		t.Fatalf("expected approval_decisions_total expired metric")
+	}
+}
+
 func TestHandler(t *testing.T) {
 	withTestRegistry(t)
 	m := NewProm("cordum")
 	m.IncJobsReceived("job.test")
+	a := NewApprovalProm("cordum")
+	a.SetApprovalQueueDepth("all", 1)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -217,6 +262,9 @@ func TestHandler(t *testing.T) {
 	}
 	if rec.Body.Len() == 0 {
 		t.Fatalf("expected metrics output")
+	}
+	if !strings.Contains(rec.Body.String(), "cordum_approval_queue_depth") {
+		t.Fatalf("expected approval metrics in handler output")
 	}
 }
 
@@ -342,6 +390,26 @@ func TestMetricsPodLabelWorkflow(t *testing.T) {
 		for _, metric := range fam.GetMetric() {
 			if !hasLabel(metric.GetLabel(), "pod", podName) {
 				t.Fatalf("workflow metric %s missing pod=%s label", fam.GetName(), podName)
+			}
+		}
+	}
+}
+
+func TestMetricsPodLabelApproval(t *testing.T) {
+	reg := withTestRegistry(t)
+	m := NewApprovalProm("cordum")
+	m.SetApprovalQueueDepth("all", 1)
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	podName := resolvePodName()
+	for _, fam := range families {
+		for _, metric := range fam.GetMetric() {
+			if !hasLabel(metric.GetLabel(), "pod", podName) {
+				t.Fatalf("approval metric %s missing pod=%s label", fam.GetName(), podName)
 			}
 		}
 	}

--- a/core/infra/store/job_store.go
+++ b/core/infra/store/job_store.go
@@ -1188,6 +1188,19 @@ func (s *RedisJobStore) ListJobsByState(ctx context.Context, state model.JobStat
 	return out, nil
 }
 
+// CountJobsByState returns the current number of jobs indexed for a state.
+func (s *RedisJobStore) CountJobsByState(ctx context.Context, state model.JobState) (int64, error) {
+	key := stateIndexKey(state)
+	if key == "" {
+		return 0, fmt.Errorf("unknown state %s", state)
+	}
+	count, err := s.client.ZCount(ctx, key, "-inf", "+inf").Result()
+	if err != nil {
+		return 0, fmt.Errorf("job store count jobs by state %s: %w", state, err)
+	}
+	return count, nil
+}
+
 func (s *RedisJobStore) Close() error {
 	return s.client.Close()
 }


### PR DESCRIPTION
## Summary

Adds the four Prometheus metrics requested in #159 so teams can watch approval queue depth, latency, and auto-expiry from the existing `/metrics` endpoint. No new dependencies.

## Changes

New metrics (cordum namespace):
- `approval_queue_depth` (gauge, `risk_tier` label) - pending approvals
- `approval_latency_seconds` (histogram) - request to resolution
- `approval_expired_total` (counter) - approvals that timed out
- `approval_decisions_total` (counter, `decision` label)

Wiring follows the existing `GatewayMetrics` / `WorkflowMetrics` pattern in `core/infra/metrics`:
- New `ApprovalMetrics` interface + `approvalProm` impl (`NoopApproval` for tests)
- Gateway server constructs one via `NewApprovalProm` alongside `gwMetrics`
- `handleListApprovals`, `handleApproveJob`, `handleRejectJob` update queue depth and emit decision/latency samples. Latency uses `SafetyDecisionRecord.CheckedAt` as the request timestamp so no schema change is needed.
- Scheduler `Reconciler` gained `WithApprovalMetrics`; jobs timing out from `JobStateApproval` bump `approval_expired_total`, `approval_decisions_total{decision="expired"}`, and refresh queue depth.
- `RedisJobStore.CountJobsByState` backs the gauge via `ZCount` on the existing state index.

## Testing

- `go build ./...`, `go vet ./...` - green
- `go test ./core/infra/metrics/... ./core/controlplane/scheduler/...` - green
- Metric registration tests added in `metrics_test.go`; reconciler expiry test added in `reconciler_test.go`.

## Checklist

- [x] I kept changes scoped and did not alter unrelated behavior
- [x] I did not change existing proto field numbers; any new fields are appended
- [x] I updated docs in `docs/` if behavior, commands, or architecture changed (no docs needed - metrics surface only)
- [x] I ran tests (`go test ./...`) or explained why not

Closes #159.