### PR TITLE
docs: expand .env.example with multi-key auth formats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,9 +75,14 @@ REDIS_DATA_TTL=24h
 # API key (required - set a strong random key)
 # quickstart.sh auto-generates this. For manual setup: openssl rand -hex 32
 CORDUM_API_KEY=
-# Alternative: JSON array of keys with metadata
+# Multi-key setups: provide CORDUM_API_KEYS in one of these formats, or load
+# from a file.
+# Comma-separated (parts: key | tenant:key | tenant:key:role |
+# tenant:key:role:principal_id):
+# CORDUM_API_KEYS=team-a:key1:admin,team-b:key2:viewer
+# JSON array with per-key metadata:
 # CORDUM_API_KEYS=[{"key":"key1","tenant":"default","role":"admin"}]
-# Or load from file (reloads on change)
+# Load keys from a file (reloads on change):
 # CORDUM_API_KEYS_PATH=/etc/cordum/api-keys.json
 
 # Default tenant for single-tenant mode


### PR DESCRIPTION
## Summary

Expand `.env.example` to document the comma-separated `CORDUM_API_KEYS` format alongside the existing JSON example, per #55.

## Changes

Before, `.env.example` (lines 78-81) only showed the JSON array form:

```
# Alternative: JSON array of keys with metadata
# CORDUM_API_KEYS=[{"key":"key1","tenant":"default","role":"admin"}]
# Or load from file (reloads on change)
# CORDUM_API_KEYS_PATH=/etc/cordum/api-keys.json
```

`ParseAPIKeys` in `core/controlplane/gateway/auth/helpers.go` already accepts a comma-separated form with colon-delimited parts (`key`, `tenant:key`, `tenant:key:role`, `tenant:key:role:principal_id`), but that format was not shown in the example. This PR adds a commented example for the CSV format and groups the three options (CSV, JSON, file) under a shared header so the choices are easier to scan.

## Testing

Docs-only change; no code or tests touched. `go test ./...` not run.

## Checklist
- [x] I kept changes scoped and did not alter unrelated behavior
- [x] I did not change existing proto field numbers; any new fields are appended
- [x] I updated docs in `docs/` if behavior, commands, or architecture changed (N/A, `.env.example` only)
- [x] I ran tests (`go test ./...`) or explained why not (docs-only)

Fixes #55

This contribution was developed with AI assistance (Codex).
