### PR TITLE
feat(delegation): gateway + policy + storage — request surface and auth

### DIFF
--- a/core/audit/exporter.go
+++ b/core/audit/exporter.go
@@ -17,11 +17,67 @@ import (
 
 // Event types emitted by the audit subsystem.
 const (
-	EventSafetyDecision  = "safety.decision"
-	EventSafetyApproval  = "safety.approval"
-	EventPolicyChange    = "safety.policy_change"
-	EventSafetyViolation = "safety.violation"
-	EventSystemAuth      = "system.auth"
+	EventSafetyDecision = "safety.decision"
+	// EventDelegationLineage captures the full human-readable delegation chain
+	// once per (job_id, token_jti) at dispatch so downstream SIEM rules can
+	// correlate the compact safety.decision delegation fields back to the
+	// complete issuer ancestry.
+	EventDelegationLineage = "delegation.lineage"
+	// EventDelegationRejected captures submit-time delegation verification
+	// failures before a job is accepted. Reason carries the delegation error
+	// code (for example malformed, revoked, or audience_mismatch).
+	EventDelegationRejected = "delegation.rejected"
+	// EventDelegationRevokedBeforeDispatch captures dispatch-time delegation
+	// re-verification failures after a submit already succeeded. Reason carries
+	// the stable failure code persisted onto the job / DLQ record.
+	EventDelegationRevokedBeforeDispatch = "delegation.revoked_before_dispatch"
+	EventSafetyApproval                  = "safety.approval"
+	EventPolicyChange                    = "safety.policy_change"
+	EventSafetyViolation                 = "safety.violation"
+	EventSystemAuth                      = "system.auth"
+	// EventMCPToolApproval is emitted for every MCP per-tool approval
+	// lifecycle transition: enqueue, approve, reject, expire, consume.
+	// The Extra map carries tool_name, args_hash, approval_id,
+	// requester, resolver, and outcome so downstream SIEM rules can
+	// correlate per-tool activity without parsing natural-language
+	// Reason fields.
+	EventMCPToolApproval = "mcp.tool_approval"
+	// EventMCPToolDenied is emitted when the scope filter rejects an
+	// MCP tools/call request. Extra carries tool_name, sub_reason,
+	// agent_id, and tenant so downstream SIEM rules can detect
+	// privilege-escalation probes.
+	EventMCPToolDenied = "mcp.tool_denied"
+	// EventMCPToolInvocation is emitted for every completed tools/call
+	// regardless of outcome. Extra carries tool_name, agent_id, tenant,
+	// duration_ms, and result_size so downstream SIEM rules can correlate
+	// activity volume without parsing natural-language Reason fields.
+	EventMCPToolInvocation = "mcp.tool_invocation"
+	// EventMCPToolOutboundInvocation is emitted when Cordum acts as an
+	// MCP client (outbound) — e.g. brokering a remote tool call via the
+	// MCP bridge. Extra carries server, tool_name, tenant, duration_ms,
+	// and outcome for SIEM correlation of egress activity.
+	EventMCPToolOutboundInvocation = "mcp.tool_outbound_invocation"
+	EventMCPSignatureInvalid       = "mcp.signature_invalid"
+	// EventHeartbeatDisagreement is emitted while heartbeat demotion is in
+	// warn mode and session-token authority disagrees with legacy heartbeat
+	// recency for the same worker liveness decision.
+	EventHeartbeatDisagreement = "heartbeat_disagreement"
+	EventWorkerTrustChange     = "worker_trust_change"
+	EventTopicRegistered       = "topic_registered"
+	EventTopicUnregistered     = "topic_unregistered"
+	// EventLicenseLegacyRejected is emitted when the licensing layer
+	// rejects a pre-GA top-level features/limits envelope instead of
+	// silently migrating it to the current schema.
+	EventLicenseLegacyRejected = "license.legacy_format_rejected"
+	// EventLicenseBreakglassActivated is emitted whenever an expired or
+	// invalid license still admits a request through one of the explicit
+	// break-glass recovery paths.
+	EventLicenseBreakglassActivated = "license.breakglass_activated"
+	// EventShadowEval is emitted by the Safety Kernel when an active
+	// policy evaluation is mirrored against the shadow policy for
+	// A/B impact analysis. Extra carries shadow_bundle_id, bundle_id,
+	// active_verdict, shadow_verdict, diff, and latency_ms.
+	EventShadowEval = "shadow_eval"
 )
 
 // Severity levels for SIEM events.
@@ -34,6 +90,22 @@ const (
 )
 
 // SIEMEvent is the canonical event schema exported to SIEM systems.
+//
+// Chain fields (Seq, EventHash, PrevHash) are populated by the audit Chainer
+// when an event flows through the consumer pipeline. They form a per-tenant
+// append-only hash chain so downstream verification can detect tampering:
+//
+//   - Seq is a monotonic per-tenant sequence number assigned at append time.
+//     The first event for a tenant has Seq=1. Gaps or non-monotonic values
+//     indicate missing or out-of-order events.
+//   - EventHash is SHA-256 of the canonical JSON encoding of the event with
+//     Seq and EventHash cleared (PrevHash is included in the hash input so
+//     tampering with a predecessor cascades forward). Hex-encoded.
+//   - PrevHash is the EventHash of the tenant's previous event, or empty for
+//     the genesis event. Hex-encoded.
+//
+// All three fields are additive JSON properties; SIEM exporters that do not
+// understand them pass them through unchanged.
 type SIEMEvent struct {
 	Timestamp     time.Time         `json:"timestamp"`
 	EventType     string            `json:"event_type"`
@@ -52,6 +124,9 @@ type SIEMEvent struct {
 	PolicyVersion string            `json:"policy_version,omitempty"`
 	Identity      string            `json:"identity,omitempty"`
 	Extra         map[string]string `json:"extra,omitempty"`
+	Seq           int64             `json:"seq,omitempty"`
+	EventHash     string            `json:"event_hash,omitempty"`
+	PrevHash      string            `json:"prev_hash,omitempty"`
 }
 
 // Exporter sends batches of SIEM events to an external system.

--- a/core/audit/exporter.go
+++ b/core/audit/exporter.go
@@ -62,6 +62,12 @@ const (
 	// warn mode and session-token authority disagrees with legacy heartbeat
 	// recency for the same worker liveness decision.
 	EventHeartbeatDisagreement = "heartbeat_disagreement"
+	// EventApprovalRevisionMismatch is emitted when the scheduler's
+	// approval fast-path rejects a job because the approval_snapshot
+	// label does not match the stored SafetyDecisionRecord.PolicySnapshot.
+	// Signals that policy drifted between approval time and dispatch time
+	// and the fast-path refused to short-circuit on stale constraints.
+	EventApprovalRevisionMismatch = "approval.revision_mismatch"
 	EventWorkerTrustChange     = "worker_trust_change"
 	EventTopicRegistered       = "topic_registered"
 	EventTopicUnregistered     = "topic_unregistered"

--- a/core/auth/delegation/cascade.go
+++ b/core/auth/delegation/cascade.go
@@ -37,47 +37,57 @@ if redis.call("EXISTS", tokenPrefix .. root) == 0 then
   return {}
 end
 
-local queue = {root}
-local depthQueue = {0}
-local head = 1
-local seen = {}
-local revoked = {}
+-- Phase 1: pre-walk the cascade graph depth-first to determine the
+-- full set of descendants to revoke and verify none exceeds maxDepth.
+-- This is a separate pass from the mutation loop so a depth violation
+-- fails CLOSED — no partial revocations — instead of revoking the
+-- first maxDepth levels and then erroring out mid-walk.
+local toRevoke = {root}
+local seenPre = {[root] = true}
 
-while head <= #queue do
-  local current = queue[head]
-  local depth = depthQueue[head]
-  head = head + 1
-
-  if not seen[current] then
-    seen[current] = true
-    local tokenKey = tokenPrefix .. current
-    local tenant = redis.call("HGET", tokenKey, "tenant")
-
-    redis.call("SET", revokedPrefix .. current, "1", "EX", ttlSeconds)
-    redis.call("HSET", tokenKey,
-      "revoked", "1",
-      "revoked_at", revokedAt,
-      "revoked_reason", reason
-    )
-    if tenant and tenant ~= "" then
-      redis.call("ZREM", activePrefix .. tenant, current)
-    end
-    table.insert(revoked, current)
-
-    if cascade then
-      local children = redis.call("SMEMBERS", childrenPrefix .. current)
-      table.sort(children)
-      if depth >= maxDepth and #children > 0 then
+if cascade then
+  local preQueue = {root}
+  local preDepth = {0}
+  local preHead = 1
+  while preHead <= #preQueue do
+    local node = preQueue[preHead]
+    local depth = preDepth[preHead]
+    preHead = preHead + 1
+    if depth >= maxDepth then
+      local children = redis.call("SMEMBERS", childrenPrefix .. node)
+      if #children > 0 then
         return redis.error_reply("cascade depth exceeded")
       end
+    else
+      local children = redis.call("SMEMBERS", childrenPrefix .. node)
+      table.sort(children)
       for _, child in ipairs(children) do
-        if not seen[child] then
-          table.insert(queue, child)
-          table.insert(depthQueue, depth + 1)
+        if not seenPre[child] then
+          seenPre[child] = true
+          table.insert(toRevoke, child)
+          table.insert(preQueue, child)
+          table.insert(preDepth, depth + 1)
         end
       end
     end
   end
+end
+
+-- Phase 2: the cascade fits under maxDepth — revoke every node.
+local revoked = {}
+for _, current in ipairs(toRevoke) do
+  local tokenKey = tokenPrefix .. current
+  local tenant = redis.call("HGET", tokenKey, "tenant")
+  redis.call("SET", revokedPrefix .. current, "1", "EX", ttlSeconds)
+  redis.call("HSET", tokenKey,
+    "revoked", "1",
+    "revoked_at", revokedAt,
+    "revoked_reason", reason
+  )
+  if tenant and tenant ~= "" then
+    redis.call("ZREM", activePrefix .. tenant, current)
+  end
+  table.insert(revoked, current)
 end
 
 return revoked

--- a/core/auth/delegation/cascade.go
+++ b/core/auth/delegation/cascade.go
@@ -1,0 +1,187 @@
+package delegation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	delegationCascadeDepthLimit = 256
+	delegationRevocationTTL     = 24 * time.Hour
+)
+
+type CascadeRevocationResult struct {
+	RootJTI       string
+	RevokedJTIs   []string
+	CascadedCount int
+}
+
+var cascadeRevocationScript = redis.NewScript(`
+local root = ARGV[1]
+local revokedAt = ARGV[2]
+local reason = ARGV[3]
+local ttlSeconds = tonumber(ARGV[4])
+local maxDepth = tonumber(ARGV[5])
+local cascade = ARGV[6] == "1"
+
+local tokenPrefix = KEYS[1]
+local childrenPrefix = KEYS[2]
+local revokedPrefix = KEYS[3]
+local activePrefix = KEYS[4]
+
+if redis.call("EXISTS", tokenPrefix .. root) == 0 then
+  return {}
+end
+
+local queue = {root}
+local depthQueue = {0}
+local head = 1
+local seen = {}
+local revoked = {}
+
+while head <= #queue do
+  local current = queue[head]
+  local depth = depthQueue[head]
+  head = head + 1
+
+  if not seen[current] then
+    seen[current] = true
+    local tokenKey = tokenPrefix .. current
+    local tenant = redis.call("HGET", tokenKey, "tenant")
+
+    redis.call("SET", revokedPrefix .. current, "1", "EX", ttlSeconds)
+    redis.call("HSET", tokenKey,
+      "revoked", "1",
+      "revoked_at", revokedAt,
+      "revoked_reason", reason
+    )
+    if tenant and tenant ~= "" then
+      redis.call("ZREM", activePrefix .. tenant, current)
+    end
+    table.insert(revoked, current)
+
+    if cascade then
+      local children = redis.call("SMEMBERS", childrenPrefix .. current)
+      table.sort(children)
+      if depth >= maxDepth and #children > 0 then
+        return redis.error_reply("cascade depth exceeded")
+      end
+      for _, child in ipairs(children) do
+        if not seen[child] then
+          table.insert(queue, child)
+          table.insert(depthQueue, depth + 1)
+        end
+      end
+    end
+  end
+end
+
+return revoked
+`)
+
+func (s *RedisRevocationStore) CascadeRevoke(ctx context.Context, rootJTI, reason string, revokedAt time.Time, cascade bool) (CascadeRevocationResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.client == nil {
+		return CascadeRevocationResult{}, fmt.Errorf("delegation revocation store unavailable")
+	}
+	rootJTI = strings.TrimSpace(rootJTI)
+	if rootJTI == "" {
+		return CascadeRevocationResult{}, fmt.Errorf("delegation jti required")
+	}
+	if revokedAt.IsZero() {
+		revokedAt = time.Now().UTC()
+	}
+	result, err := cascadeRevocationScript.Eval(ctx, s.client, []string{
+		delegationTokenKeyPrefix,
+		delegationChildrenKeyPrefix,
+		delegationRevocationPrefix,
+		delegationActiveKeyPrefix,
+	}, rootJTI, revokedAt.UTC().Format(time.RFC3339Nano), strings.TrimSpace(reason), int(delegationRevocationTTL/time.Second), delegationCascadeDepthLimit, boolToLua(cascade)).Result()
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "cascade depth exceeded") {
+			return CascadeRevocationResult{}, ErrCascadeTooDeep
+		}
+		return CascadeRevocationResult{}, fmt.Errorf("cascade revoke delegation token: %w", err)
+	}
+	revokedJTIs, err := cascadeRevocationJTIs(result)
+	if err != nil {
+		return CascadeRevocationResult{}, err
+	}
+	if len(revokedJTIs) == 0 {
+		return CascadeRevocationResult{}, ErrNotFound
+	}
+	return CascadeRevocationResult{
+		RootJTI:       rootJTI,
+		RevokedJTIs:   revokedJTIs,
+		CascadedCount: max(0, len(revokedJTIs)-1),
+	}, nil
+}
+
+func cascadeRevocationJTIs(value any) ([]string, error) {
+	switch typed := value.(type) {
+	case nil:
+		return nil, nil
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			switch value := item.(type) {
+			case string:
+				if trim := strings.TrimSpace(value); trim != "" {
+					out = append(out, trim)
+				}
+			case []byte:
+				if trim := strings.TrimSpace(string(value)); trim != "" {
+					out = append(out, trim)
+				}
+			default:
+				return nil, fmt.Errorf("unexpected cascade revoke result type %T", item)
+			}
+		}
+		return out, nil
+	case []string:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if trim := strings.TrimSpace(item); trim != "" {
+				out = append(out, trim)
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unexpected cascade revoke result type %T", value)
+	}
+}
+
+func boolToLua(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
+}
+
+func (s *RedisRevocationStore) RecordChildDelegation(ctx context.Context, parentJTI, childJTI string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.client == nil {
+		return fmt.Errorf("delegation revocation store unavailable")
+	}
+	parentJTI = strings.TrimSpace(parentJTI)
+	childJTI = strings.TrimSpace(childJTI)
+	if parentJTI == "" || childJTI == "" {
+		return nil
+	}
+	return s.client.SAdd(ctx, delegationChildrenKey(parentJTI), childJTI).Err()
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/core/auth/delegation/cascade_test.go
+++ b/core/auth/delegation/cascade_test.go
@@ -1,0 +1,242 @@
+package delegation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestRedisRevocationStoreCascadeRevoke(t *testing.T) {
+	revocations, _ := newTestRevocationStore(t)
+	listStore := NewRedisListStoreFromClient(revocations.client)
+	now := time.Now().UTC()
+
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-root",
+		Tenant:         "default",
+		Issuer:         "agent-a",
+		Subject:        "agent-a",
+		Audience:       "agent-b",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.alpha"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-root"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-3 * time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+	})
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-child",
+		Tenant:         "default",
+		Issuer:         "agent-a",
+		Subject:        "agent-b",
+		Audience:       "agent-c",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.alpha"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-root"}, {AgentID: "agent-b", JTI: "dlg-child", ParentJTI: "dlg-root"}},
+		ChainDepth:     2,
+		IssuedAt:       now.Add(-2 * time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+		ParentJTI:      "dlg-root",
+	})
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-grandchild",
+		Tenant:         "default",
+		Issuer:         "agent-a",
+		Subject:        "agent-c",
+		Audience:       "agent-d",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.alpha"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-root"}, {AgentID: "agent-b", JTI: "dlg-child", ParentJTI: "dlg-root"}, {AgentID: "agent-c", JTI: "dlg-grandchild", ParentJTI: "dlg-child"}},
+		ChainDepth:     3,
+		IssuedAt:       now.Add(-time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+		ParentJTI:      "dlg-child",
+	})
+
+	result, err := revocations.CascadeRevoke(context.Background(), "dlg-root", "compromised", now, true)
+	if err != nil {
+		t.Fatalf("CascadeRevoke() error = %v", err)
+	}
+	if result.CascadedCount != 2 || len(result.RevokedJTIs) != 3 {
+		t.Fatalf("unexpected cascade result: %#v", result)
+	}
+	for _, jti := range []string{"dlg-root", "dlg-child", "dlg-grandchild"} {
+		revoked, err := revocations.IsRevoked(context.Background(), jti)
+		if err != nil {
+			t.Fatalf("IsRevoked(%s) error = %v", jti, err)
+		}
+		if !revoked {
+			t.Fatalf("expected %s to be revoked", jti)
+		}
+		view, ok, err := listStore.Get(context.Background(), jti)
+		if err != nil {
+			t.Fatalf("Get(%s) error = %v", jti, err)
+		}
+		if !ok || !view.Revoked || view.RevokedReason != "compromised" {
+			t.Fatalf("expected revoked metadata for %s, got %#v", jti, view)
+		}
+	}
+}
+
+func TestRedisRevocationStoreCascadeRevokeWithoutCascade(t *testing.T) {
+	revocations, _ := newTestRevocationStore(t)
+	listStore := NewRedisListStoreFromClient(revocations.client)
+	now := time.Now().UTC()
+
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-root",
+		Tenant:         "default",
+		Subject:        "agent-a",
+		Audience:       "agent-b",
+		AllowedActions: []string{"read"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-root"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+	})
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-child",
+		Tenant:         "default",
+		Subject:        "agent-b",
+		Audience:       "agent-c",
+		AllowedActions: []string{"read"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-root"}, {AgentID: "agent-b", JTI: "dlg-child", ParentJTI: "dlg-root"}},
+		ChainDepth:     2,
+		IssuedAt:       now,
+		ExpiresAt:      now.Add(time.Hour),
+		ParentJTI:      "dlg-root",
+	})
+
+	result, err := revocations.CascadeRevoke(context.Background(), "dlg-root", "manual", now, false)
+	if err != nil {
+		t.Fatalf("CascadeRevoke(false) error = %v", err)
+	}
+	if result.CascadedCount != 0 || len(result.RevokedJTIs) != 1 {
+		t.Fatalf("unexpected non-cascade result: %#v", result)
+	}
+	rootRevoked, err := revocations.IsRevoked(context.Background(), "dlg-root")
+	if err != nil {
+		t.Fatalf("IsRevoked(root) error = %v", err)
+	}
+	childRevoked, err := revocations.IsRevoked(context.Background(), "dlg-child")
+	if err != nil {
+		t.Fatalf("IsRevoked(child) error = %v", err)
+	}
+	if !rootRevoked || childRevoked {
+		t.Fatalf("expected only root revoked, got root=%v child=%v", rootRevoked, childRevoked)
+	}
+}
+
+func TestRedisRevocationStoreCascadeRevokeCycleSafe(t *testing.T) {
+	revocations, _ := newTestRevocationStore(t)
+	listStore := NewRedisListStoreFromClient(revocations.client)
+	now := time.Now().UTC()
+
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-a",
+		Tenant:         "default",
+		Subject:        "agent-a",
+		Audience:       "agent-b",
+		AllowedActions: []string{"read"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-a"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+		ParentJTI:      "dlg-b",
+	})
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-b",
+		Tenant:         "default",
+		Subject:        "agent-b",
+		Audience:       "agent-c",
+		AllowedActions: []string{"read"},
+		Chain:          []ChainLink{{AgentID: "agent-b", JTI: "dlg-b"}},
+		ChainDepth:     1,
+		IssuedAt:       now,
+		ExpiresAt:      now.Add(time.Hour),
+		ParentJTI:      "dlg-a",
+	})
+
+	result, err := revocations.CascadeRevoke(context.Background(), "dlg-a", "manual", now, true)
+	if err != nil {
+		t.Fatalf("CascadeRevoke(cycle) error = %v", err)
+	}
+	if result.CascadedCount != 1 || len(result.RevokedJTIs) != 2 {
+		t.Fatalf("unexpected cycle result: %#v", result)
+	}
+}
+
+func TestRedisRevocationStoreCascadeRevokeEvalErrorIsAtomic(t *testing.T) {
+	revocations, _ := newTestRevocationStore(t)
+	listStore := NewRedisListStoreFromClient(revocations.client)
+	now := time.Now().UTC()
+
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-root",
+		Tenant:         "default",
+		Subject:        "agent-a",
+		Audience:       "agent-b",
+		AllowedActions: []string{"read"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-root"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+	})
+	recordDelegationToken(t, listStore, DelegationView{
+		JTI:            "dlg-child",
+		Tenant:         "default",
+		Subject:        "agent-b",
+		Audience:       "agent-c",
+		AllowedActions: []string{"read"},
+		Chain:          []ChainLink{{AgentID: "agent-a", JTI: "dlg-root"}, {AgentID: "agent-b", JTI: "dlg-child", ParentJTI: "dlg-root"}},
+		ChainDepth:     2,
+		IssuedAt:       now,
+		ExpiresAt:      now.Add(time.Hour),
+		ParentJTI:      "dlg-root",
+	})
+
+	failing := &RedisRevocationStore{client: evalErrorClient{
+		UniversalClient: revocations.client,
+		err:             errors.New("boom"),
+	}}
+	if _, err := failing.CascadeRevoke(context.Background(), "dlg-root", "manual", now, true); err == nil {
+		t.Fatal("expected eval error")
+	}
+	for _, jti := range []string{"dlg-root", "dlg-child"} {
+		revoked, err := revocations.IsRevoked(context.Background(), jti)
+		if err != nil {
+			t.Fatalf("IsRevoked(%s) error = %v", jti, err)
+		}
+		if revoked {
+			t.Fatalf("expected %s to remain unrevoked on eval failure", jti)
+		}
+		view, ok, err := listStore.Get(context.Background(), jti)
+		if err != nil {
+			t.Fatalf("Get(%s) error = %v", jti, err)
+		}
+		if !ok || view.Revoked {
+			t.Fatalf("expected %s metadata to remain active, got %#v", jti, view)
+		}
+	}
+}
+
+func recordDelegationToken(t *testing.T, store *RedisListStore, view DelegationView) {
+	t.Helper()
+	if err := store.RecordIssuedToken(context.Background(), view); err != nil {
+		t.Fatalf("RecordIssuedToken(%s) error = %v", view.JTI, err)
+	}
+}
+
+type evalErrorClient struct {
+	redis.UniversalClient
+	err error
+}
+
+func (c evalErrorClient) Eval(ctx context.Context, script string, keys []string, args ...any) *redis.Cmd {
+	cmd := redis.NewCmd(ctx)
+	cmd.SetErr(c.err)
+	return cmd
+}

--- a/core/auth/delegation/cascade_test.go
+++ b/core/auth/delegation/cascade_test.go
@@ -3,6 +3,7 @@ package delegation
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ func TestRedisRevocationStoreCascadeRevoke(t *testing.T) {
 	listStore := NewRedisListStoreFromClient(revocations.client)
 	now := time.Now().UTC()
 
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-root",
 		Tenant:         "default",
 		Issuer:         "agent-a",
@@ -27,7 +28,7 @@ func TestRedisRevocationStoreCascadeRevoke(t *testing.T) {
 		IssuedAt:       now.Add(-3 * time.Minute),
 		ExpiresAt:      now.Add(time.Hour),
 	})
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-child",
 		Tenant:         "default",
 		Issuer:         "agent-a",
@@ -41,7 +42,7 @@ func TestRedisRevocationStoreCascadeRevoke(t *testing.T) {
 		ExpiresAt:      now.Add(time.Hour),
 		ParentJTI:      "dlg-root",
 	})
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-grandchild",
 		Tenant:         "default",
 		Issuer:         "agent-a",
@@ -86,7 +87,7 @@ func TestRedisRevocationStoreCascadeRevokeWithoutCascade(t *testing.T) {
 	listStore := NewRedisListStoreFromClient(revocations.client)
 	now := time.Now().UTC()
 
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-root",
 		Tenant:         "default",
 		Subject:        "agent-a",
@@ -97,7 +98,7 @@ func TestRedisRevocationStoreCascadeRevokeWithoutCascade(t *testing.T) {
 		IssuedAt:       now.Add(-time.Minute),
 		ExpiresAt:      now.Add(time.Hour),
 	})
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-child",
 		Tenant:         "default",
 		Subject:        "agent-b",
@@ -135,7 +136,7 @@ func TestRedisRevocationStoreCascadeRevokeCycleSafe(t *testing.T) {
 	listStore := NewRedisListStoreFromClient(revocations.client)
 	now := time.Now().UTC()
 
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-a",
 		Tenant:         "default",
 		Subject:        "agent-a",
@@ -147,7 +148,7 @@ func TestRedisRevocationStoreCascadeRevokeCycleSafe(t *testing.T) {
 		ExpiresAt:      now.Add(time.Hour),
 		ParentJTI:      "dlg-b",
 	})
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-b",
 		Tenant:         "default",
 		Subject:        "agent-b",
@@ -174,7 +175,7 @@ func TestRedisRevocationStoreCascadeRevokeEvalErrorIsAtomic(t *testing.T) {
 	listStore := NewRedisListStoreFromClient(revocations.client)
 	now := time.Now().UTC()
 
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-root",
 		Tenant:         "default",
 		Subject:        "agent-a",
@@ -185,7 +186,7 @@ func TestRedisRevocationStoreCascadeRevokeEvalErrorIsAtomic(t *testing.T) {
 		IssuedAt:       now.Add(-time.Minute),
 		ExpiresAt:      now.Add(time.Hour),
 	})
-	recordDelegationToken(t, listStore, DelegationView{
+	recordDelegationToken(t, listStore, revocations, DelegationView{
 		JTI:            "dlg-child",
 		Tenant:         "default",
 		Subject:        "agent-b",
@@ -223,10 +224,21 @@ func TestRedisRevocationStoreCascadeRevokeEvalErrorIsAtomic(t *testing.T) {
 	}
 }
 
-func recordDelegationToken(t *testing.T, store *RedisListStore, view DelegationView) {
+// recordDelegationToken writes the token view via the list store AND
+// seeds the parent→child edge that CascadeRevoke walks. The list store's
+// RecordIssuedToken only persists the view itself; the child-set at
+// delegationChildrenKey(parentJTI) is owned by the revocation store
+// and must be populated separately for the cascade to reach past the
+// root. The helper takes both stores so callers can't forget.
+func recordDelegationToken(t *testing.T, listStore *RedisListStore, revocations *RedisRevocationStore, view DelegationView) {
 	t.Helper()
-	if err := store.RecordIssuedToken(context.Background(), view); err != nil {
+	if err := listStore.RecordIssuedToken(context.Background(), view); err != nil {
 		t.Fatalf("RecordIssuedToken(%s) error = %v", view.JTI, err)
+	}
+	if parent := strings.TrimSpace(view.ParentJTI); parent != "" && revocations != nil {
+		if err := revocations.RecordChildDelegation(context.Background(), parent, view.JTI); err != nil {
+			t.Fatalf("RecordChildDelegation(parent=%s child=%s) error = %v", parent, view.JTI, err)
+		}
 	}
 }
 

--- a/core/auth/delegation/errors.go
+++ b/core/auth/delegation/errors.go
@@ -1,0 +1,42 @@
+package delegation
+
+import "errors"
+
+var (
+	ErrMalformed        = errors.New("delegation token malformed")
+	ErrExpired          = errors.New("delegation token expired")
+	ErrNotYetValid      = errors.New("delegation token not yet valid")
+	ErrBadSignature     = errors.New("delegation token signature invalid")
+	ErrUnknownKeyId     = errors.New("delegation token key id unknown")
+	ErrAudienceMismatch = errors.New("delegation token audience mismatch")
+	ErrChainTooDeep     = errors.New("delegation token chain too deep")
+	ErrScopeExceeded    = errors.New("delegation token scope exceeded")
+	ErrRevoked          = errors.New("delegation token revoked")
+	ErrNotFound         = errors.New("delegation token not found")
+	ErrCascadeTooDeep   = errors.New("delegation revocation cascade too deep")
+)
+
+func ErrorCode(err error) string {
+	switch {
+	case errors.Is(err, ErrMalformed):
+		return "malformed"
+	case errors.Is(err, ErrExpired):
+		return "expired"
+	case errors.Is(err, ErrNotYetValid):
+		return "not_yet_valid"
+	case errors.Is(err, ErrBadSignature):
+		return "bad_signature"
+	case errors.Is(err, ErrUnknownKeyId):
+		return "unknown_kid"
+	case errors.Is(err, ErrAudienceMismatch):
+		return "audience_mismatch"
+	case errors.Is(err, ErrChainTooDeep):
+		return "chain_too_deep"
+	case errors.Is(err, ErrScopeExceeded):
+		return "scope_exceeded"
+	case errors.Is(err, ErrRevoked):
+		return "revoked"
+	default:
+		return ""
+	}
+}

--- a/core/auth/delegation/keys.go
+++ b/core/auth/delegation/keys.go
@@ -1,0 +1,236 @@
+package delegation
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+const (
+	envDelegationPrivateKey    = "CORDUM_DELEGATION_PRIVATE_KEY"
+	envDelegationActiveKeyID   = "CORDUM_DELEGATION_KEY_ID"
+	envDelegationPublicKeyStem = "CORDUM_DELEGATION_PUBLIC_KEY_"
+	defaultSigningKeyID        = "dlg-1"
+)
+
+var (
+	ErrSigningKeyMissing        = errors.New("delegation signing key not configured")
+	ErrVerificationKeysMissing  = errors.New("delegation verification keys not configured")
+	ErrInvalidSigningKey        = errors.New("invalid delegation signing key")
+	ErrInvalidVerificationKey   = errors.New("invalid delegation verification key")
+	ErrDelegationKeyPermissions = errors.New("delegation key file must not be group/world accessible")
+)
+
+// SigningKey wraps the active Ed25519 signing key plus its advertised KID.
+type SigningKey struct {
+	KID        string
+	PrivateKey ed25519.PrivateKey
+}
+
+func (k SigningKey) PublicKey() ed25519.PublicKey {
+	if len(k.PrivateKey) != ed25519.PrivateKeySize {
+		return nil
+	}
+	pub, _ := k.PrivateKey.Public().(ed25519.PublicKey)
+	return append(ed25519.PublicKey(nil), pub...)
+}
+
+func (k SigningKey) String() string {
+	return fmt.Sprintf("delegation.SigningKey(kid=%q, private=<redacted>)", k.KID)
+}
+
+func (k SigningKey) GoString() string {
+	return k.String()
+}
+
+// GenerateSigningKey creates a fresh Ed25519 signing key.
+func GenerateSigningKey(kid string) (SigningKey, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return SigningKey{}, fmt.Errorf("generate delegation signing key: %w", err)
+	}
+	return SigningKey{
+		KID:        normalizeKeyID(kid),
+		PrivateKey: append(ed25519.PrivateKey(nil), priv...),
+	}, nil
+}
+
+// LoadSigningKeyFromEnv reads the active signing key from
+// CORDUM_DELEGATION_PRIVATE_KEY.
+func LoadSigningKeyFromEnv() (SigningKey, error) {
+	raw := strings.TrimSpace(os.Getenv(envDelegationPrivateKey))
+	if raw == "" {
+		return SigningKey{}, ErrSigningKeyMissing
+	}
+	priv, err := parsePrivateKey([]byte(raw))
+	if err != nil {
+		return SigningKey{}, err
+	}
+	return SigningKey{
+		KID:        activeKeyIDFromEnv(),
+		PrivateKey: priv,
+	}, nil
+}
+
+// LoadSigningKeyFromFile reads the active signing key from a filesystem path.
+func LoadSigningKeyFromFile(path string) (SigningKey, error) {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" {
+		return SigningKey{}, fmt.Errorf("delegation signing key path required")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return SigningKey{}, fmt.Errorf("stat delegation signing key: %w", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return SigningKey{}, fmt.Errorf("%w: %s has mode %04o", ErrDelegationKeyPermissions, path, info.Mode().Perm())
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- operator-configured key path
+	if err != nil {
+		return SigningKey{}, fmt.Errorf("read delegation signing key: %w", err)
+	}
+	priv, err := parsePrivateKey(data)
+	if err != nil {
+		return SigningKey{}, err
+	}
+	return SigningKey{
+		KID:        activeKeyIDFromEnv(),
+		PrivateKey: priv,
+	}, nil
+}
+
+// LoadVerificationKeysFromEnv loads every verification key configured as
+// CORDUM_DELEGATION_PUBLIC_KEY_<KID>=<base64 public key>.
+func LoadVerificationKeysFromEnv() (map[string]ed25519.PublicKey, error) {
+	keyring := make(map[string]ed25519.PublicKey)
+	for _, entry := range os.Environ() {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || !strings.HasPrefix(key, envDelegationPublicKeyStem) {
+			continue
+		}
+		kid := normalizeKeyID(strings.TrimPrefix(key, envDelegationPublicKeyStem))
+		if kid == "" {
+			return nil, fmt.Errorf("%w: empty kid in %s", ErrInvalidVerificationKey, key)
+		}
+		pub, err := decodePublicKey(value)
+		if err != nil {
+			return nil, fmt.Errorf("%w for %s: %v", ErrInvalidVerificationKey, kid, err)
+		}
+		if _, exists := keyring[kid]; exists {
+			return nil, fmt.Errorf("%w: duplicate kid %q", ErrInvalidVerificationKey, kid)
+		}
+		keyring[kid] = pub
+	}
+	if len(keyring) == 0 {
+		return nil, ErrVerificationKeysMissing
+	}
+	return keyring, nil
+}
+
+// SortedKeyIDs returns the KIDs in lexical order. Useful for deterministic
+// logs/tests without exposing key bytes.
+func SortedKeyIDs(keyring map[string]ed25519.PublicKey) []string {
+	keys := make([]string, 0, len(keyring))
+	for kid := range keyring {
+		keys = append(keys, kid)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// EncodePrivateKeyPEM encodes an Ed25519 private key as PKCS#8 PEM.
+func EncodePrivateKeyPEM(privateKey ed25519.PrivateKey) ([]byte, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return nil, ErrInvalidSigningKey
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshal delegation private key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	}), nil
+}
+
+// EncodePublicKeyBase64 returns the standard base64 representation used by
+// CORDUM_DELEGATION_PUBLIC_KEY_<KID>.
+func EncodePublicKeyBase64(publicKey ed25519.PublicKey) (string, error) {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return "", ErrInvalidVerificationKey
+	}
+	return base64.StdEncoding.EncodeToString(publicKey), nil
+}
+
+func activeKeyIDFromEnv() string {
+	return normalizeKeyID(os.Getenv(envDelegationActiveKeyID))
+}
+
+func normalizeKeyID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultSigningKeyID
+	}
+	raw = strings.ToLower(raw)
+	raw = strings.ReplaceAll(raw, "_", "-")
+	return raw
+}
+
+func parsePrivateKey(raw []byte) (ed25519.PrivateKey, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, ErrSigningKeyMissing
+	}
+	if block, _ := pem.Decode([]byte(trimmed)); block != nil {
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("%w: parse pkcs8: %v", ErrInvalidSigningKey, err)
+		}
+		privateKey, ok := key.(ed25519.PrivateKey)
+		if !ok || len(privateKey) != ed25519.PrivateKeySize {
+			return nil, ErrInvalidSigningKey
+		}
+		return append(ed25519.PrivateKey(nil), privateKey...), nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(trimmed)
+	if err != nil {
+		if decoded, err = base64.RawStdEncoding.DecodeString(trimmed); err != nil {
+			return nil, fmt.Errorf("%w: decode base64: %v", ErrInvalidSigningKey, err)
+		}
+	}
+	switch len(decoded) {
+	case ed25519.PrivateKeySize:
+		return append(ed25519.PrivateKey(nil), decoded...), nil
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(decoded), nil
+	default:
+		return nil, fmt.Errorf("%w: expected %d-byte private key or %d-byte seed, got %d bytes", ErrInvalidSigningKey, ed25519.PrivateKeySize, ed25519.SeedSize, len(decoded))
+	}
+}
+
+func decodePublicKey(raw string) (ed25519.PublicKey, error) {
+	raw = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), "ed25519:"))
+	if raw == "" {
+		return nil, ErrInvalidVerificationKey
+	}
+	data, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		if data, err = base64.RawStdEncoding.DecodeString(raw); err != nil {
+			return nil, err
+		}
+	}
+	if len(data) != ed25519.PublicKeySize {
+		return nil, ErrInvalidVerificationKey
+	}
+	return ed25519.PublicKey(data), nil
+}

--- a/core/auth/delegation/keys_test.go
+++ b/core/auth/delegation/keys_test.go
@@ -1,0 +1,146 @@
+package delegation
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLoadSigningKeyFromEnv_Base64RoundTrip(t *testing.T) {
+	seed := bytes.Repeat([]byte{0x42}, ed25519.SeedSize)
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+
+	t.Setenv(envDelegationActiveKeyID, "DLG_2")
+	t.Setenv(envDelegationPrivateKey, base64.StdEncoding.EncodeToString(privateKey))
+	t.Setenv(envDelegationPublicKeyStem+"DLG_2", "ed25519:"+base64.StdEncoding.EncodeToString(publicKey))
+
+	signingKey, err := LoadSigningKeyFromEnv()
+	if err != nil {
+		t.Fatalf("LoadSigningKeyFromEnv() error = %v", err)
+	}
+	if signingKey.KID != "dlg-2" {
+		t.Fatalf("LoadSigningKeyFromEnv() kid = %q, want dlg-2", signingKey.KID)
+	}
+
+	keyring, err := LoadVerificationKeysFromEnv()
+	if err != nil {
+		t.Fatalf("LoadVerificationKeysFromEnv() error = %v", err)
+	}
+
+	message := []byte("delegation-roundtrip")
+	signature := ed25519.Sign(signingKey.PrivateKey, message)
+	if !ed25519.Verify(keyring["dlg-2"], message, signature) {
+		t.Fatal("generated signature did not verify")
+	}
+}
+
+func TestLoadSigningKeyFromEnv_PKCS8PEM(t *testing.T) {
+	generated, err := GenerateSigningKey("dlg-9")
+	if err != nil {
+		t.Fatalf("GenerateSigningKey() error = %v", err)
+	}
+	pemBytes, err := EncodePrivateKeyPEM(generated.PrivateKey)
+	if err != nil {
+		t.Fatalf("EncodePrivateKeyPEM() error = %v", err)
+	}
+
+	t.Setenv(envDelegationPrivateKey, string(pemBytes))
+	t.Setenv(envDelegationActiveKeyID, "dlg-9")
+
+	loaded, err := LoadSigningKeyFromEnv()
+	if err != nil {
+		t.Fatalf("LoadSigningKeyFromEnv() error = %v", err)
+	}
+	if !reflect.DeepEqual([]byte(loaded.PrivateKey), []byte(generated.PrivateKey)) {
+		t.Fatal("loaded private key does not match generated key")
+	}
+}
+
+func TestLoadSigningKeyFromFileRequiresStrictPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not expose portable unix permission bits")
+	}
+
+	generated, err := GenerateSigningKey("dlg-1")
+	if err != nil {
+		t.Fatalf("GenerateSigningKey() error = %v", err)
+	}
+	pemBytes, err := EncodePrivateKeyPEM(generated.PrivateKey)
+	if err != nil {
+		t.Fatalf("EncodePrivateKeyPEM() error = %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "delegation.pem")
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err = LoadSigningKeyFromFile(path)
+	if !errors.Is(err, ErrDelegationKeyPermissions) {
+		t.Fatalf("LoadSigningKeyFromFile() error = %v, want ErrDelegationKeyPermissions", err)
+	}
+}
+
+func TestLoadSigningKeyFromFileStrictFile(t *testing.T) {
+	generated, err := GenerateSigningKey("dlg-1")
+	if err != nil {
+		t.Fatalf("GenerateSigningKey() error = %v", err)
+	}
+	pemBytes, err := EncodePrivateKeyPEM(generated.PrivateKey)
+	if err != nil {
+		t.Fatalf("EncodePrivateKeyPEM() error = %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "delegation.pem")
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadSigningKeyFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadSigningKeyFromFile() error = %v", err)
+	}
+	if !reflect.DeepEqual([]byte(loaded.PrivateKey), []byte(generated.PrivateKey)) {
+		t.Fatal("loaded private key does not match generated key")
+	}
+}
+
+func TestLoadVerificationKeysFromEnv_MultipleKids(t *testing.T) {
+	keyA := bytes.Repeat([]byte{0x11}, ed25519.SeedSize)
+	keyB := bytes.Repeat([]byte{0x22}, ed25519.SeedSize)
+	pubA := ed25519.NewKeyFromSeed(keyA).Public().(ed25519.PublicKey)
+	pubB := ed25519.NewKeyFromSeed(keyB).Public().(ed25519.PublicKey)
+
+	t.Setenv(envDelegationPublicKeyStem+"PRIMARY", base64.StdEncoding.EncodeToString(pubA))
+	t.Setenv(envDelegationPublicKeyStem+"ROTATED_2", base64.StdEncoding.EncodeToString(pubB))
+
+	keyring, err := LoadVerificationKeysFromEnv()
+	if err != nil {
+		t.Fatalf("LoadVerificationKeysFromEnv() error = %v", err)
+	}
+	if got := SortedKeyIDs(keyring); !reflect.DeepEqual(got, []string{"primary", "rotated-2"}) {
+		t.Fatalf("SortedKeyIDs() = %v, want [primary rotated-2]", got)
+	}
+}
+
+func TestSigningKeyStringRedactsPrivateMaterial(t *testing.T) {
+	key, err := GenerateSigningKey("dlg-1")
+	if err != nil {
+		t.Fatalf("GenerateSigningKey() error = %v", err)
+	}
+	text := key.String()
+	if strings.Contains(text, base64.StdEncoding.EncodeToString(key.PrivateKey)) {
+		t.Fatalf("String() leaked private key material: %s", text)
+	}
+	if !strings.Contains(text, "<redacted>") {
+		t.Fatalf("String() = %q, want redaction marker", text)
+	}
+}

--- a/core/auth/delegation/list_store.go
+++ b/core/auth/delegation/list_store.go
@@ -1,0 +1,383 @@
+package delegation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	delegationTokenKeyPrefix    = "delegation:token:"
+	delegationByAgentKeyPrefix  = "delegation:by-agent:"
+	delegationActiveKeyPrefix   = "delegation:active:"
+	delegationAllKeyPrefix      = "delegation:all:"
+	delegationChildrenKeyPrefix = "delegation:children:"
+)
+
+type DelegationView struct {
+	JTI            string      `json:"jti"`
+	Tenant         string      `json:"-"`
+	Issuer         string      `json:"issuer"`
+	Subject        string      `json:"subject"`
+	Audience       string      `json:"audience"`
+	AllowedActions []string    `json:"allowed_actions,omitempty"`
+	AllowedTopics  []string    `json:"allowed_topics,omitempty"`
+	Chain          []ChainLink `json:"chain,omitempty"`
+	ChainDepth     int         `json:"chain_depth"`
+	IssuedAt       time.Time   `json:"issued_at"`
+	ExpiresAt      time.Time   `json:"expires_at"`
+	Revoked        bool        `json:"revoked"`
+	RevokedAt      time.Time   `json:"revoked_at,omitempty"`
+	RevokedReason  string      `json:"revoked_reason,omitempty"`
+	ParentJTI      string      `json:"-"`
+}
+
+type DelegationListFilter struct {
+	Status       string
+	Scope        string
+	BeforeExpiry time.Time
+	SinceIssued  time.Time
+	UntilIssued  time.Time
+}
+
+type DelegationListPage struct {
+	Items      []DelegationView
+	NextCursor string
+}
+
+type RedisListStore struct {
+	client redis.UniversalClient
+}
+
+func NewRedisListStoreFromClient(client redis.UniversalClient) *RedisListStore {
+	return &RedisListStore{client: client}
+}
+
+func (s *RedisListStore) RecordIssuedToken(ctx context.Context, view DelegationView) error {
+	if s == nil || s.client == nil {
+		return fmt.Errorf("delegation list store unavailable")
+	}
+	view.Tenant = strings.TrimSpace(view.Tenant)
+	view.JTI = strings.TrimSpace(view.JTI)
+	view.Subject = strings.TrimSpace(view.Subject)
+	if view.Tenant == "" || view.JTI == "" || view.Subject == "" {
+		return fmt.Errorf("delegation list store requires tenant, jti, and subject")
+	}
+	chainJSON, err := json.Marshal(view.Chain)
+	if err != nil {
+		return fmt.Errorf("marshal delegation chain: %w", err)
+	}
+	actionsJSON, err := json.Marshal(view.AllowedActions)
+	if err != nil {
+		return fmt.Errorf("marshal delegation actions: %w", err)
+	}
+	topicsJSON, err := json.Marshal(view.AllowedTopics)
+	if err != nil {
+		return fmt.Errorf("marshal delegation topics: %w", err)
+	}
+	pipe := s.client.TxPipeline()
+	pipe.HSet(ctx, delegationTokenKey(view.JTI), map[string]any{
+		"tenant":          view.Tenant,
+		"issuer":          strings.TrimSpace(view.Issuer),
+		"subject":         view.Subject,
+		"audience":        strings.TrimSpace(view.Audience),
+		"allowed_actions": string(actionsJSON),
+		"allowed_topics":  string(topicsJSON),
+		"chain":           string(chainJSON),
+		"chain_depth":     view.ChainDepth,
+		"issued_at":       view.IssuedAt.UTC().Format(time.RFC3339Nano),
+		"expires_at":      view.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		"revoked":         boolToString(view.Revoked),
+		"revoked_at":      formatOptionalTime(view.RevokedAt),
+		"revoked_reason":  strings.TrimSpace(view.RevokedReason),
+		"parent_jti":      strings.TrimSpace(view.ParentJTI),
+	})
+	pipe.ZAdd(ctx, delegationByAgentKey(view.Tenant, view.Subject), redis.Z{
+		Score:  float64(view.IssuedAt.UTC().Unix()),
+		Member: view.JTI,
+	})
+	pipe.ZAdd(ctx, delegationActiveKey(view.Tenant), redis.Z{
+		Score:  float64(view.ExpiresAt.UTC().Unix()),
+		Member: view.JTI,
+	})
+	pipe.ZAdd(ctx, delegationAllKey(view.Tenant), redis.Z{
+		Score:  float64(view.IssuedAt.UTC().Unix()),
+		Member: view.JTI,
+	})
+	if parentJTI := strings.TrimSpace(view.ParentJTI); parentJTI != "" {
+		pipe.SAdd(ctx, delegationChildrenKey(parentJTI), view.JTI)
+	}
+	_, err = pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("record delegation token: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisListStore) MarkRevoked(ctx context.Context, tenant, jti, reason string, revokedAt time.Time) error {
+	if s == nil || s.client == nil {
+		return fmt.Errorf("delegation list store unavailable")
+	}
+	tenant = strings.TrimSpace(tenant)
+	jti = strings.TrimSpace(jti)
+	if tenant == "" || jti == "" {
+		return fmt.Errorf("delegation list store requires tenant and jti")
+	}
+	pipe := s.client.TxPipeline()
+	pipe.HSet(ctx, delegationTokenKey(jti), map[string]any{
+		"revoked":        "1",
+		"revoked_at":     revokedAt.UTC().Format(time.RFC3339Nano),
+		"revoked_reason": strings.TrimSpace(reason),
+	})
+	pipe.ZRem(ctx, delegationActiveKey(tenant), jti)
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("mark delegation revoked: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisListStore) ListByAgent(ctx context.Context, tenant, agentID string, filter DelegationListFilter, cursor string, limit int) (DelegationListPage, error) {
+	if s == nil || s.client == nil {
+		return DelegationListPage{}, fmt.Errorf("delegation list store unavailable")
+	}
+	jtis, err := s.client.ZRevRange(ctx, delegationByAgentKey(strings.TrimSpace(tenant), strings.TrimSpace(agentID)), 0, -1).Result()
+	if err != nil {
+		return DelegationListPage{}, fmt.Errorf("list delegations by agent: %w", err)
+	}
+	return s.pageFromJTIs(ctx, jtis, tenant, filter, cursor, limit)
+}
+
+func (s *RedisListStore) ListAll(ctx context.Context, tenant string, filter DelegationListFilter, cursor string, limit int) (DelegationListPage, error) {
+	if s == nil || s.client == nil {
+		return DelegationListPage{}, fmt.Errorf("delegation list store unavailable")
+	}
+	jtis, err := s.client.ZRevRange(ctx, delegationAllKey(strings.TrimSpace(tenant)), 0, -1).Result()
+	if err != nil {
+		return DelegationListPage{}, fmt.Errorf("list delegations: %w", err)
+	}
+	return s.pageFromJTIs(ctx, jtis, tenant, filter, cursor, limit)
+}
+
+func (s *RedisListStore) Get(ctx context.Context, jti string) (DelegationView, bool, error) {
+	if s == nil || s.client == nil {
+		return DelegationView{}, false, fmt.Errorf("delegation list store unavailable")
+	}
+	return s.loadView(ctx, jti)
+}
+
+func (s *RedisListStore) pageFromJTIs(ctx context.Context, jtis []string, tenant string, filter DelegationListFilter, cursor string, limit int) (DelegationListPage, error) {
+	filtered := make([]DelegationView, 0, len(jtis))
+	for _, jti := range jtis {
+		view, ok, err := s.loadView(ctx, jti)
+		if err != nil {
+			return DelegationListPage{}, err
+		}
+		if !ok || !strings.EqualFold(view.Tenant, strings.TrimSpace(tenant)) {
+			continue
+		}
+		if !matchesDelegationFilter(view, filter, time.Now().UTC()) {
+			continue
+		}
+		filtered = append(filtered, view)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return filtered[i].IssuedAt.After(filtered[j].IssuedAt)
+	})
+	offset, err := parseDelegationCursor(cursor)
+	if err != nil {
+		return DelegationListPage{}, err
+	}
+	limit = normalizeDelegationLimit(limit)
+	if offset >= len(filtered) {
+		return DelegationListPage{Items: []DelegationView{}}, nil
+	}
+	end := offset + limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	page := DelegationListPage{
+		Items: append([]DelegationView(nil), filtered[offset:end]...),
+	}
+	if end < len(filtered) {
+		page.NextCursor = strconv.Itoa(end)
+	}
+	return page, nil
+}
+
+func (s *RedisListStore) loadView(ctx context.Context, jti string) (DelegationView, bool, error) {
+	values, err := s.client.HGetAll(ctx, delegationTokenKey(strings.TrimSpace(jti))).Result()
+	if err != nil {
+		return DelegationView{}, false, fmt.Errorf("load delegation token %s: %w", jti, err)
+	}
+	if len(values) == 0 {
+		return DelegationView{}, false, nil
+	}
+	view, err := delegationViewFromHash(strings.TrimSpace(jti), values)
+	if err != nil {
+		return DelegationView{}, false, fmt.Errorf("decode delegation token %s: %w", jti, err)
+	}
+	return view, true, nil
+}
+
+func delegationViewFromHash(jti string, values map[string]string) (DelegationView, error) {
+	view := DelegationView{
+		JTI:           jti,
+		Tenant:        strings.TrimSpace(values["tenant"]),
+		Issuer:        strings.TrimSpace(values["issuer"]),
+		Subject:       strings.TrimSpace(values["subject"]),
+		Audience:      strings.TrimSpace(values["audience"]),
+		Revoked:       values["revoked"] == "1",
+		RevokedReason: strings.TrimSpace(values["revoked_reason"]),
+		ParentJTI:     strings.TrimSpace(values["parent_jti"]),
+	}
+	if chainDepth := strings.TrimSpace(values["chain_depth"]); chainDepth != "" {
+		parsed, err := strconv.Atoi(chainDepth)
+		if err != nil {
+			return DelegationView{}, err
+		}
+		view.ChainDepth = parsed
+	}
+	if issuedAt := strings.TrimSpace(values["issued_at"]); issuedAt != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, issuedAt)
+		if err != nil {
+			return DelegationView{}, err
+		}
+		view.IssuedAt = parsed.UTC()
+	}
+	if expiresAt := strings.TrimSpace(values["expires_at"]); expiresAt != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, expiresAt)
+		if err != nil {
+			return DelegationView{}, err
+		}
+		view.ExpiresAt = parsed.UTC()
+	}
+	if revokedAt := strings.TrimSpace(values["revoked_at"]); revokedAt != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, revokedAt)
+		if err != nil {
+			return DelegationView{}, err
+		}
+		view.RevokedAt = parsed.UTC()
+	}
+	if raw := strings.TrimSpace(values["allowed_actions"]); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &view.AllowedActions); err != nil {
+			return DelegationView{}, err
+		}
+	}
+	if raw := strings.TrimSpace(values["allowed_topics"]); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &view.AllowedTopics); err != nil {
+			return DelegationView{}, err
+		}
+	}
+	if raw := strings.TrimSpace(values["chain"]); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &view.Chain); err != nil {
+			return DelegationView{}, err
+		}
+	}
+	return view, nil
+}
+
+func matchesDelegationFilter(view DelegationView, filter DelegationListFilter, now time.Time) bool {
+	status := strings.ToLower(strings.TrimSpace(filter.Status))
+	switch status {
+	case "", "all":
+	case "active":
+		if view.Revoked || (!view.ExpiresAt.IsZero() && view.ExpiresAt.Before(now)) {
+			return false
+		}
+	case "revoked":
+		if !view.Revoked {
+			return false
+		}
+	case "expired":
+		if view.Revoked || view.ExpiresAt.IsZero() || !view.ExpiresAt.Before(now) {
+			return false
+		}
+	default:
+		return false
+	}
+	if scope := strings.ToLower(strings.TrimSpace(filter.Scope)); scope != "" {
+		matched := false
+		for _, action := range view.AllowedActions {
+			if strings.Contains(strings.ToLower(strings.TrimSpace(action)), scope) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if !filter.BeforeExpiry.IsZero() && (view.ExpiresAt.IsZero() || view.ExpiresAt.After(filter.BeforeExpiry)) {
+		return false
+	}
+	if !filter.SinceIssued.IsZero() && view.IssuedAt.Before(filter.SinceIssued) {
+		return false
+	}
+	if !filter.UntilIssued.IsZero() && view.IssuedAt.After(filter.UntilIssued) {
+		return false
+	}
+	return true
+}
+
+func delegationTokenKey(jti string) string {
+	return delegationTokenKeyPrefix + strings.TrimSpace(jti)
+}
+
+func delegationByAgentKey(tenant, agentID string) string {
+	return delegationByAgentKeyPrefix + strings.TrimSpace(tenant) + ":" + strings.TrimSpace(agentID)
+}
+
+func delegationActiveKey(tenant string) string {
+	return delegationActiveKeyPrefix + strings.TrimSpace(tenant)
+}
+
+func delegationAllKey(tenant string) string {
+	return delegationAllKeyPrefix + strings.TrimSpace(tenant)
+}
+
+func delegationChildrenKey(jti string) string {
+	return delegationChildrenKeyPrefix + strings.TrimSpace(jti)
+}
+
+func normalizeDelegationLimit(limit int) int {
+	if limit <= 0 {
+		return 50
+	}
+	if limit > 200 {
+		return 200
+	}
+	return limit
+}
+
+func parseDelegationCursor(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	return value, nil
+}
+
+func boolToString(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
+}
+
+func formatOptionalTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}

--- a/core/auth/delegation/list_store_test.go
+++ b/core/auth/delegation/list_store_test.go
@@ -1,0 +1,133 @@
+package delegation
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRedisListStoreRoundTripAndFilters(t *testing.T) {
+	revocations, _ := newTestRevocationStore(t)
+	store := NewRedisListStoreFromClient(revocations.client)
+	now := time.Now().UTC()
+
+	views := []DelegationView{
+		{
+			JTI:            "dlg-active",
+			Tenant:         "default",
+			Issuer:         "agent-a",
+			Subject:        "agent-a",
+			Audience:       "agent-b",
+			AllowedActions: []string{"read", "write"},
+			AllowedTopics:  []string{"job.alpha"},
+			Chain:          []ChainLink{{AgentID: "agent-a"}},
+			ChainDepth:     1,
+			IssuedAt:       now.Add(-5 * time.Minute),
+			ExpiresAt:      now.Add(30 * time.Minute),
+		},
+		{
+			JTI:            "dlg-expired",
+			Tenant:         "default",
+			Issuer:         "agent-a",
+			Subject:        "agent-a",
+			Audience:       "agent-c",
+			AllowedActions: []string{"deploy"},
+			AllowedTopics:  []string{"job.beta"},
+			Chain:          []ChainLink{{AgentID: "agent-a"}},
+			ChainDepth:     1,
+			IssuedAt:       now.Add(-2 * time.Hour),
+			ExpiresAt:      now.Add(-time.Minute),
+		},
+		{
+			JTI:            "dlg-other-tenant",
+			Tenant:         "other",
+			Issuer:         "agent-a",
+			Subject:        "agent-a",
+			Audience:       "agent-d",
+			AllowedActions: []string{"read"},
+			AllowedTopics:  []string{"job.gamma"},
+			Chain:          []ChainLink{{AgentID: "agent-a"}},
+			ChainDepth:     1,
+			IssuedAt:       now.Add(-10 * time.Minute),
+			ExpiresAt:      now.Add(10 * time.Minute),
+		},
+	}
+	for _, view := range views {
+		if err := store.RecordIssuedToken(context.Background(), view); err != nil {
+			t.Fatalf("RecordIssuedToken(%s) error = %v", view.JTI, err)
+		}
+	}
+	if err := store.MarkRevoked(context.Background(), "default", "dlg-active", "manual", now); err != nil {
+		t.Fatalf("MarkRevoked() error = %v", err)
+	}
+
+	revokedPage, err := store.ListByAgent(context.Background(), "default", "agent-a", DelegationListFilter{Status: "revoked"}, "", 50)
+	if err != nil {
+		t.Fatalf("ListByAgent(revoked) error = %v", err)
+	}
+	if len(revokedPage.Items) != 1 || revokedPage.Items[0].JTI != "dlg-active" || !revokedPage.Items[0].Revoked {
+		t.Fatalf("unexpected revoked page: %#v", revokedPage.Items)
+	}
+
+	expiredPage, err := store.ListAll(context.Background(), "default", DelegationListFilter{Status: "expired"}, "", 50)
+	if err != nil {
+		t.Fatalf("ListAll(expired) error = %v", err)
+	}
+	if len(expiredPage.Items) != 1 || expiredPage.Items[0].JTI != "dlg-expired" {
+		t.Fatalf("unexpected expired page: %#v", expiredPage.Items)
+	}
+
+	scopePage, err := store.ListAll(context.Background(), "default", DelegationListFilter{Scope: "dep"}, "", 50)
+	if err != nil {
+		t.Fatalf("ListAll(scope) error = %v", err)
+	}
+	if len(scopePage.Items) != 1 || scopePage.Items[0].JTI != "dlg-expired" {
+		t.Fatalf("unexpected scope page: %#v", scopePage.Items)
+	}
+
+	expiringPage, err := store.ListAll(context.Background(), "default", DelegationListFilter{BeforeExpiry: now.Add(5 * time.Minute)}, "", 50)
+	if err != nil {
+		t.Fatalf("ListAll(before_expiry) error = %v", err)
+	}
+	if len(expiringPage.Items) != 1 || expiringPage.Items[0].JTI != "dlg-expired" {
+		t.Fatalf("unexpected before_expiry page: %#v", expiringPage.Items)
+	}
+}
+
+func TestRedisListStorePagination(t *testing.T) {
+	revocations, _ := newTestRevocationStore(t)
+	store := NewRedisListStoreFromClient(revocations.client)
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		if err := store.RecordIssuedToken(context.Background(), DelegationView{
+			JTI:            "dlg-page-" + string(rune('a'+i)),
+			Tenant:         "default",
+			Issuer:         "agent-a",
+			Subject:        "agent-a",
+			Audience:       "agent-b",
+			AllowedActions: []string{"read"},
+			AllowedTopics:  []string{"job.alpha"},
+			Chain:          []ChainLink{{AgentID: "agent-a"}},
+			ChainDepth:     1,
+			IssuedAt:       now.Add(time.Duration(i) * time.Minute),
+			ExpiresAt:      now.Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("RecordIssuedToken(page-%d) error = %v", i, err)
+		}
+	}
+
+	page1, err := store.ListAll(context.Background(), "default", DelegationListFilter{}, "", 1)
+	if err != nil {
+		t.Fatalf("ListAll(page1) error = %v", err)
+	}
+	if len(page1.Items) != 1 || page1.NextCursor == "" {
+		t.Fatalf("unexpected first page: %#v", page1)
+	}
+	page2, err := store.ListAll(context.Background(), "default", DelegationListFilter{}, page1.NextCursor, 1)
+	if err != nil {
+		t.Fatalf("ListAll(page2) error = %v", err)
+	}
+	if len(page2.Items) != 1 || page2.Items[0].JTI == page1.Items[0].JTI {
+		t.Fatalf("unexpected second page: %#v", page2)
+	}
+}

--- a/core/auth/delegation/revocation.go
+++ b/core/auth/delegation/revocation.go
@@ -1,0 +1,85 @@
+package delegation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/infra/redisutil"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	delegationRevocationPrefix = "delegation:revoked:"
+	delegationRevocationMarker = "1"
+)
+
+type RevocationStore interface {
+	Revoke(ctx context.Context, jti string, expiresAt time.Time) error
+	IsRevoked(ctx context.Context, jti string) (bool, error)
+}
+
+type RedisRevocationStore struct {
+	client redis.UniversalClient
+}
+
+func NewRedisRevocationStore(url string) (*RedisRevocationStore, error) {
+	client, err := redisutil.NewClient(url)
+	if err != nil {
+		return nil, fmt.Errorf("delegation revocation store: parse redis url: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("delegation revocation store: connect redis: %w", err)
+	}
+	return &RedisRevocationStore{client: client}, nil
+}
+
+func NewRedisRevocationStoreFromClient(client redis.UniversalClient) *RedisRevocationStore {
+	if client == nil {
+		return nil
+	}
+	return &RedisRevocationStore{client: client}
+}
+
+func (s *RedisRevocationStore) Revoke(ctx context.Context, jti string, expiresAt time.Time) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.client == nil {
+		return fmt.Errorf("delegation revocation store unavailable")
+	}
+	jti = strings.TrimSpace(jti)
+	if jti == "" {
+		return fmt.Errorf("delegation jti required")
+	}
+	ttl := time.Until(expiresAt.UTC())
+	if ttl <= 0 {
+		ttl = time.Second
+	}
+	return s.client.Set(ctx, delegationRevocationKey(jti), delegationRevocationMarker, ttl).Err()
+}
+
+func (s *RedisRevocationStore) IsRevoked(ctx context.Context, jti string) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil || s.client == nil {
+		return false, nil
+	}
+	jti = strings.TrimSpace(jti)
+	if jti == "" {
+		return false, nil
+	}
+	exists, err := s.client.Exists(ctx, delegationRevocationKey(jti)).Result()
+	if err != nil {
+		return false, err
+	}
+	return exists > 0, nil
+}
+
+func delegationRevocationKey(jti string) string {
+	return delegationRevocationPrefix + strings.TrimSpace(jti)
+}

--- a/core/auth/delegation/revocation_test.go
+++ b/core/auth/delegation/revocation_test.go
@@ -1,0 +1,58 @@
+package delegation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/cordum/cordum/core/infra/redisutil"
+)
+
+func newTestRevocationStore(t *testing.T) (*RedisRevocationStore, *miniredis.Miniredis) {
+	t.Helper()
+
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	client, err := redisutil.NewClient("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("redisutil.NewClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	return NewRedisRevocationStoreFromClient(client), srv
+}
+
+func TestRedisRevocationStoreRoundTrip(t *testing.T) {
+	store, srv := newTestRevocationStore(t)
+
+	expiresAt := time.Now().UTC().Add(10 * time.Minute)
+	if err := store.Revoke(context.Background(), "jti-1", expiresAt); err != nil {
+		t.Fatalf("Revoke() error = %v", err)
+	}
+	revoked, err := store.IsRevoked(context.Background(), "jti-1")
+	if err != nil {
+		t.Fatalf("IsRevoked() error = %v", err)
+	}
+	if !revoked {
+		t.Fatal("expected jti to be revoked")
+	}
+	if ttl := srv.TTL(delegationRevocationKey("jti-1")); ttl <= 0 {
+		t.Fatalf("expected redis TTL to be set, got %v", ttl)
+	}
+}
+
+func TestRedisRevocationStoreNilReceiverIsSafe(t *testing.T) {
+	var store *RedisRevocationStore
+	revoked, err := store.IsRevoked(context.Background(), "jti-1")
+	if err != nil {
+		t.Fatalf("IsRevoked() error = %v", err)
+	}
+	if revoked {
+		t.Fatal("nil store should report not revoked")
+	}
+}

--- a/core/auth/delegation/token.go
+++ b/core/auth/delegation/token.go
@@ -1,0 +1,515 @@
+package delegation
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/infra/env"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	envDelegationMaxDepth = "CORDUM_DELEGATION_MAX_DEPTH"
+	defaultMaxDepth       = 3
+	defaultTokenTTL       = 15 * time.Minute
+	maxTokenTTL           = 24 * time.Hour
+	defaultClockLeeway    = 30 * time.Second
+)
+
+type AgentPermissions struct {
+	AllowedActions []string
+	AllowedTopics  []string
+}
+
+type AgentPermissionsResolver interface {
+	ResolveAgentPermissions(ctx context.Context, agentID string) (AgentPermissions, error)
+}
+
+type IssueRequest struct {
+	Tenant            string
+	DelegatingAgentID string
+	TargetAgentID     string
+	AllowedActions    []string
+	AllowedTopics     []string
+	TTL               time.Duration
+	ParentToken       string
+}
+
+type ChainLink struct {
+	AgentID   string `json:"agent_id"`
+	IssuedAt  string `json:"issued_at"`
+	ExpiresAt string `json:"expires_at"`
+	JTI       string `json:"jti"`
+	ParentJTI string `json:"parent_jti,omitempty"`
+	IssuedBy  string `json:"issued_by"`
+}
+
+type DelegationClaims struct {
+	Tenant          string      `json:"tenant"`
+	AllowedActions  []string    `json:"allowed_actions,omitempty"`
+	AllowedTopics   []string    `json:"allowed_topics,omitempty"`
+	DelegationChain []ChainLink `json:"delegation_chain"`
+	ChainDepth      int         `json:"chain_depth"`
+	ParentTokenJTI  string      `json:"parent_token_jti,omitempty"`
+	jwt.RegisteredClaims
+}
+
+type VerifiedToken struct {
+	Token           string
+	KID             string
+	Subject         string
+	Audience        string
+	Tenant          string
+	AllowedActions  []string
+	AllowedTopics   []string
+	DelegationChain []ChainLink
+	ChainDepth      int
+	JTI             string
+	ParentTokenJTI  string
+	IssuedAt        time.Time
+	NotBefore       time.Time
+	ExpiresAt       time.Time
+	Claims          DelegationClaims
+}
+
+type TokenService struct {
+	signingKey       SigningKey
+	keyring          map[string]ed25519.PublicKey
+	agentPermissions AgentPermissionsResolver
+	revocations      RevocationStore
+	defaultTTL       time.Duration
+	maxTTL           time.Duration
+	leeway           time.Duration
+	maxDepth         int
+	now              func() time.Time
+}
+
+func NewTokenService(signingKey SigningKey, keyring map[string]ed25519.PublicKey, agentPermissions AgentPermissionsResolver, revocations RevocationStore) *TokenService {
+	copiedKeyring := make(map[string]ed25519.PublicKey, len(keyring)+1)
+	for kid, pub := range keyring {
+		copiedKeyring[kid] = append(ed25519.PublicKey(nil), pub...)
+	}
+	if pub := signingKey.PublicKey(); len(pub) == ed25519.PublicKeySize {
+		copiedKeyring[signingKey.KID] = pub
+	}
+	return &TokenService{
+		signingKey:       signingKey,
+		keyring:          copiedKeyring,
+		agentPermissions: agentPermissions,
+		revocations:      revocations,
+		defaultTTL:       defaultTokenTTL,
+		maxTTL:           maxTokenTTL,
+		leeway:           defaultClockLeeway,
+		maxDepth:         env.IntOr(envDelegationMaxDepth, defaultMaxDepth),
+		now:              time.Now,
+	}
+}
+
+func (s *TokenService) KeyID() string {
+	if s == nil {
+		return ""
+	}
+	return s.signingKey.KID
+}
+
+func (s *TokenService) MaxTTL() time.Duration {
+	if s == nil || s.maxTTL <= 0 {
+		return maxTokenTTL
+	}
+	return s.maxTTL
+}
+
+func (s *TokenService) IssueDelegationToken(ctx context.Context, req IssueRequest) (string, DelegationClaims, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil {
+		return "", DelegationClaims{}, fmt.Errorf("delegation token service unavailable")
+	}
+	if len(s.signingKey.PrivateKey) != ed25519.PrivateKeySize {
+		return "", DelegationClaims{}, ErrInvalidSigningKey
+	}
+	req, ttl, err := s.normalizeIssueRequest(req)
+	if err != nil {
+		return "", DelegationClaims{}, err
+	}
+
+	now := s.now().UTC()
+	parent, parentClaims, err := s.loadParentClaims(ctx, req)
+	if err != nil {
+		return "", DelegationClaims{}, err
+	}
+
+	agentPermissions, err := s.resolveAgentPermissions(ctx, req.DelegatingAgentID)
+	if err != nil {
+		return "", DelegationClaims{}, err
+	}
+
+	allowedActions := normalizeStringSet(req.AllowedActions)
+	allowedTopics := normalizeStringSet(req.AllowedTopics)
+	if len(allowedActions) == 0 {
+		allowedActions = normalizeStringSet(agentPermissions.AllowedActions)
+	}
+	if len(allowedTopics) == 0 {
+		allowedTopics = normalizeStringSet(agentPermissions.AllowedTopics)
+	}
+	if parent != nil {
+		if len(req.AllowedActions) == 0 {
+			allowedActions = intersectScopes(allowedActions, parent.AllowedActions)
+		}
+		if len(req.AllowedTopics) == 0 {
+			allowedTopics = intersectScopes(allowedTopics, parent.AllowedTopics)
+		}
+		if !isSubset(allowedActions, parent.AllowedActions) || !isSubset(allowedTopics, parent.AllowedTopics) {
+			return "", DelegationClaims{}, ErrScopeExceeded
+		}
+	}
+	if !isSubset(allowedActions, agentPermissions.AllowedActions) || !isSubset(allowedTopics, agentPermissions.AllowedTopics) {
+		return "", DelegationClaims{}, ErrScopeExceeded
+	}
+
+	jti, err := newTokenJTI()
+	if err != nil {
+		return "", DelegationClaims{}, err
+	}
+	expiresAt := now.Add(ttl)
+
+	chain := cloneChain(parentClaims.DelegationChain)
+	parentJTI := strings.TrimSpace(parentClaims.ID)
+	issuedBy := "cordum"
+	if parent != nil {
+		issuedBy = req.DelegatingAgentID
+	}
+	chain = append(chain, ChainLink{
+		AgentID:   req.DelegatingAgentID,
+		IssuedAt:  now.Format(time.RFC3339Nano),
+		ExpiresAt: expiresAt.Format(time.RFC3339Nano),
+		JTI:       jti,
+		ParentJTI: parentJTI,
+		IssuedBy:  issuedBy,
+	})
+	if len(chain) > s.maxDepth {
+		return "", DelegationClaims{}, ErrChainTooDeep
+	}
+
+	claims := DelegationClaims{
+		Tenant:          req.Tenant,
+		AllowedActions:  allowedActions,
+		AllowedTopics:   allowedTopics,
+		DelegationChain: chain,
+		ChainDepth:      len(chain),
+		ParentTokenJTI:  parentJTI,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "cordum",
+			Subject:   req.DelegatingAgentID,
+			Audience:  jwt.ClaimStrings{req.TargetAgentID},
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			NotBefore: jwt.NewNumericDate(now),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ID:        jti,
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	token.Header["kid"] = s.signingKey.KID
+	signed, err := token.SignedString(s.signingKey.PrivateKey)
+	if err != nil {
+		return "", DelegationClaims{}, fmt.Errorf("sign delegation token: %w", err)
+	}
+	return signed, claims, nil
+}
+
+func (s *TokenService) VerifyDelegationToken(ctx context.Context, tokenStr, expectedAudience string) (VerifiedToken, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if s == nil {
+		return VerifiedToken{}, fmt.Errorf("delegation token service unavailable")
+	}
+	tokenStr = strings.TrimSpace(tokenStr)
+	if tokenStr == "" {
+		return VerifiedToken{}, ErrMalformed
+	}
+	claims := &DelegationClaims{}
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{jwt.SigningMethodEdDSA.Alg()}),
+		jwt.WithLeeway(s.leeway),
+		jwt.WithIssuer("cordum"),
+		jwt.WithTimeFunc(func() time.Time { return s.now().UTC() }),
+	)
+	token, err := parser.ParseWithClaims(tokenStr, claims, s.lookupVerificationKey)
+	if err != nil {
+		return VerifiedToken{}, mapJWTError(err)
+	}
+	if !token.Valid {
+		return VerifiedToken{}, ErrMalformed
+	}
+	if expectedAudience != "" && !audienceContains(claims.Audience, expectedAudience) {
+		return VerifiedToken{}, ErrAudienceMismatch
+	}
+	verified := verifiedTokenFromClaims(tokenStr, headerString(token, "kid"), *claims)
+	if verified.ChainDepth == 0 || verified.ChainDepth != len(verified.DelegationChain) {
+		return VerifiedToken{}, ErrMalformed
+	}
+	if verified.ChainDepth > s.maxDepth {
+		return VerifiedToken{}, ErrChainTooDeep
+	}
+	if err := s.validateCurrentScope(ctx, verified); err != nil {
+		return VerifiedToken{}, err
+	}
+	if err := s.validateRevocation(ctx, verified); err != nil {
+		return VerifiedToken{}, err
+	}
+	return verified, nil
+}
+
+func (s *TokenService) normalizeIssueRequest(req IssueRequest) (IssueRequest, time.Duration, error) {
+	req.Tenant = strings.TrimSpace(req.Tenant)
+	req.DelegatingAgentID = strings.TrimSpace(req.DelegatingAgentID)
+	req.TargetAgentID = strings.TrimSpace(req.TargetAgentID)
+	if req.Tenant == "" || req.DelegatingAgentID == "" || req.TargetAgentID == "" {
+		return IssueRequest{}, 0, ErrMalformed
+	}
+	ttl := req.TTL
+	if ttl <= 0 {
+		ttl = s.defaultTTL
+	}
+	if ttl > s.maxTTL {
+		return IssueRequest{}, 0, fmt.Errorf("%w: ttl exceeds %s", ErrMalformed, s.maxTTL)
+	}
+	return req, ttl, nil
+}
+
+func (s *TokenService) loadParentClaims(ctx context.Context, req IssueRequest) (*VerifiedToken, DelegationClaims, error) {
+	parentToken := strings.TrimSpace(req.ParentToken)
+	if parentToken == "" {
+		return nil, DelegationClaims{}, nil
+	}
+	parent, err := s.VerifyDelegationToken(ctx, parentToken, req.DelegatingAgentID)
+	if err != nil {
+		return nil, DelegationClaims{}, err
+	}
+	return &parent, parent.Claims, nil
+}
+
+func (s *TokenService) resolveAgentPermissions(ctx context.Context, agentID string) (AgentPermissions, error) {
+	if s.agentPermissions == nil {
+		return AgentPermissions{}, nil
+	}
+	perms, err := s.agentPermissions.ResolveAgentPermissions(ctx, agentID)
+	if err != nil {
+		return AgentPermissions{}, fmt.Errorf("resolve delegation permissions: %w", err)
+	}
+	perms.AllowedActions = normalizeStringSet(perms.AllowedActions)
+	perms.AllowedTopics = normalizeStringSet(perms.AllowedTopics)
+	return perms, nil
+}
+
+func (s *TokenService) validateCurrentScope(ctx context.Context, verified VerifiedToken) error {
+	if s.agentPermissions == nil {
+		return nil
+	}
+	perms, err := s.resolveAgentPermissions(ctx, verified.Subject)
+	if err != nil {
+		return err
+	}
+	if !isSubset(verified.AllowedActions, perms.AllowedActions) || !isSubset(verified.AllowedTopics, perms.AllowedTopics) {
+		return ErrScopeExceeded
+	}
+	return nil
+}
+
+func (s *TokenService) validateRevocation(ctx context.Context, verified VerifiedToken) error {
+	if s.revocations == nil {
+		return nil
+	}
+	jtis := make([]string, 0, len(verified.DelegationChain)+1)
+	if verified.JTI != "" {
+		jtis = append(jtis, verified.JTI)
+	}
+	for _, link := range verified.DelegationChain {
+		if link.JTI != "" {
+			jtis = append(jtis, link.JTI)
+		}
+	}
+	for _, jti := range normalizeStringSet(jtis) {
+		revoked, err := s.revocations.IsRevoked(ctx, jti)
+		if err != nil {
+			return fmt.Errorf("check delegation revocation: %w", err)
+		}
+		if revoked {
+			return ErrRevoked
+		}
+	}
+	return nil
+}
+
+func (s *TokenService) lookupVerificationKey(token *jwt.Token) (any, error) {
+	if token == nil || token.Method == nil || token.Method.Alg() != jwt.SigningMethodEdDSA.Alg() {
+		return nil, ErrBadSignature
+	}
+	kid := normalizeKeyID(headerString(token, "kid"))
+	if kid == "" {
+		return nil, ErrUnknownKeyId
+	}
+	key, ok := s.keyring[kid]
+	if !ok {
+		return nil, ErrUnknownKeyId
+	}
+	return key, nil
+}
+
+func headerString(token *jwt.Token, key string) string {
+	if token == nil {
+		return ""
+	}
+	raw, _ := token.Header[key].(string)
+	return strings.TrimSpace(raw)
+}
+
+func verifiedTokenFromClaims(tokenStr, kid string, claims DelegationClaims) VerifiedToken {
+	audience := ""
+	if len(claims.Audience) > 0 {
+		audience = claims.Audience[0]
+	}
+	return VerifiedToken{
+		Token:           tokenStr,
+		KID:             normalizeKeyID(kid),
+		Subject:         claims.Subject,
+		Audience:        audience,
+		Tenant:          claims.Tenant,
+		AllowedActions:  normalizeStringSet(claims.AllowedActions),
+		AllowedTopics:   normalizeStringSet(claims.AllowedTopics),
+		DelegationChain: cloneChain(claims.DelegationChain),
+		ChainDepth:      claims.ChainDepth,
+		JTI:             claims.ID,
+		ParentTokenJTI:  claims.ParentTokenJTI,
+		IssuedAt:        numericDateTime(claims.IssuedAt),
+		NotBefore:       numericDateTime(claims.NotBefore),
+		ExpiresAt:       numericDateTime(claims.ExpiresAt),
+		Claims:          claims,
+	}
+}
+
+func numericDateTime(value *jwt.NumericDate) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return value.Time.UTC()
+}
+
+func normalizeStringSet(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func intersectScopes(left, right []string) []string {
+	if len(left) == 0 || len(right) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(right))
+	for _, value := range right {
+		allowed[value] = struct{}{}
+	}
+	out := make([]string, 0, len(left))
+	for _, value := range left {
+		if _, ok := allowed[value]; ok {
+			out = append(out, value)
+		}
+	}
+	return normalizeStringSet(out)
+}
+
+func isSubset(needles, haystack []string) bool {
+	if len(needles) == 0 {
+		return true
+	}
+	if len(haystack) == 0 {
+		return false
+	}
+	allowed := make(map[string]struct{}, len(haystack))
+	for _, value := range haystack {
+		allowed[value] = struct{}{}
+	}
+	for _, value := range needles {
+		if _, ok := allowed[value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneChain(chain []ChainLink) []ChainLink {
+	if len(chain) == 0 {
+		return nil
+	}
+	out := make([]ChainLink, len(chain))
+	copy(out, chain)
+	return out
+}
+
+func newTokenJTI() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate delegation jti: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func mapJWTError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrUnknownKeyId):
+		return ErrUnknownKeyId
+	case errors.Is(err, ErrBadSignature):
+		return ErrBadSignature
+	case errors.Is(err, jwt.ErrTokenMalformed):
+		return ErrMalformed
+	case errors.Is(err, jwt.ErrTokenExpired):
+		return ErrExpired
+	case errors.Is(err, jwt.ErrTokenNotValidYet):
+		return ErrNotYetValid
+	case errors.Is(err, jwt.ErrTokenSignatureInvalid):
+		return ErrBadSignature
+	case errors.Is(err, jwt.ErrTokenInvalidAudience):
+		return ErrAudienceMismatch
+	default:
+		return fmt.Errorf("%w: %v", ErrMalformed, err)
+	}
+}
+
+func audienceContains(values jwt.ClaimStrings, expected string) bool {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return true
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/core/auth/delegation/token_test.go
+++ b/core/auth/delegation/token_test.go
@@ -1,0 +1,323 @@
+package delegation
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/cordum/cordum/core/infra/redisutil"
+)
+
+type staticAgentPermissions struct {
+	entries map[string]AgentPermissions
+}
+
+func (s staticAgentPermissions) ResolveAgentPermissions(_ context.Context, agentID string) (AgentPermissions, error) {
+	if perms, ok := s.entries[agentID]; ok {
+		return perms, nil
+	}
+	return AgentPermissions{}, nil
+}
+
+func newTestTokenService(t *testing.T) (*TokenService, *RedisRevocationStore, *miniredis.Miniredis) {
+	t.Helper()
+
+	signingKey, err := GenerateSigningKey("dlg-1")
+	if err != nil {
+		t.Fatalf("GenerateSigningKey() error = %v", err)
+	}
+
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	client, err := redisutil.NewClient("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("redisutil.NewClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	revocations := NewRedisRevocationStoreFromClient(client)
+	service := NewTokenService(signingKey, map[string]ed25519.PublicKey{
+		signingKey.KID: signingKey.PublicKey(),
+	}, staticAgentPermissions{
+		entries: map[string]AgentPermissions{
+			"agent-a": {AllowedActions: []string{"read", "write", "deploy"}, AllowedTopics: []string{"job.alpha", "job.beta"}},
+			"agent-b": {AllowedActions: []string{"read", "write"}, AllowedTopics: []string{"job.alpha"}},
+			"agent-c": {AllowedActions: []string{"read"}, AllowedTopics: []string{"job.alpha"}},
+		},
+	}, revocations)
+	service.now = func() time.Time { return time.Unix(1_710_000_000, 0).UTC() }
+	return service, revocations, srv
+}
+
+func TestIssueAndVerifyDelegationToken(t *testing.T) {
+	service, _, _ := newTestTokenService(t)
+
+	token, claims, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"write", "read"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+	if claims.ChainDepth != 1 {
+		t.Fatalf("claims.ChainDepth = %d, want 1", claims.ChainDepth)
+	}
+
+	verified, err := service.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if err != nil {
+		t.Fatalf("VerifyDelegationToken() error = %v", err)
+	}
+	if verified.Subject != "agent-a" || verified.Audience != "agent-b" {
+		t.Fatalf("verified token = %+v", verified)
+	}
+	if strings.Join(verified.AllowedActions, ",") != "read,write" {
+		t.Fatalf("verified.AllowedActions = %v", verified.AllowedActions)
+	}
+}
+
+func TestVerifyDelegationTokenErrors(t *testing.T) {
+	service, _, _ := newTestTokenService(t)
+
+	baseToken, _, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	t.Run("audience mismatch", func(t *testing.T) {
+		_, err := service.VerifyDelegationToken(context.Background(), baseToken, "agent-c")
+		if !errors.Is(err, ErrAudienceMismatch) {
+			t.Fatalf("VerifyDelegationToken() error = %v, want ErrAudienceMismatch", err)
+		}
+	})
+
+	t.Run("bad signature", func(t *testing.T) {
+		parts := strings.Split(baseToken, ".")
+		if len(parts) != 3 {
+			t.Fatalf("unexpected JWT shape: %q", baseToken)
+		}
+		sig := []byte(parts[2])
+		if len(sig) < 4 {
+			t.Fatalf("signature segment too short: %q", parts[2])
+		}
+		idx := len(sig) / 2
+		if sig[idx] == 'x' {
+			sig[idx] = 'y'
+		} else {
+			sig[idx] = 'x'
+		}
+		badToken := strings.Join([]string{parts[0], parts[1], string(sig)}, ".")
+		_, err := service.VerifyDelegationToken(context.Background(), badToken, "agent-b")
+		if !errors.Is(err, ErrBadSignature) && !errors.Is(err, ErrMalformed) {
+			t.Fatalf("VerifyDelegationToken() error = %v, want ErrBadSignature/ErrMalformed", err)
+		}
+	})
+
+	t.Run("unknown kid", func(t *testing.T) {
+		otherKey, err := GenerateSigningKey("dlg-9")
+		if err != nil {
+			t.Fatalf("GenerateSigningKey() error = %v", err)
+		}
+		otherService := NewTokenService(otherKey, map[string]ed25519.PublicKey{
+			otherKey.KID: otherKey.PublicKey(),
+		}, service.agentPermissions, nil)
+		otherService.now = service.now
+		token, _, err := otherService.IssueDelegationToken(context.Background(), IssueRequest{
+			Tenant:            "tenant-a",
+			DelegatingAgentID: "agent-a",
+			TargetAgentID:     "agent-b",
+			AllowedActions:    []string{"read"},
+			AllowedTopics:     []string{"job.alpha"},
+		})
+		if err != nil {
+			t.Fatalf("IssueDelegationToken() error = %v", err)
+		}
+		_, err = service.VerifyDelegationToken(context.Background(), token, "agent-b")
+		if !errors.Is(err, ErrUnknownKeyId) {
+			t.Fatalf("VerifyDelegationToken() error = %v, want ErrUnknownKeyId", err)
+		}
+	})
+}
+
+func TestVerifyDelegationTokenExpiredAndNotYetValid(t *testing.T) {
+	service, _, _ := newTestTokenService(t)
+
+	token, _, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		TTL:               time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	service.now = func() time.Time { return time.Unix(1_710_000_000, 0).UTC().Add(2 * time.Minute) }
+	_, err = service.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("VerifyDelegationToken() error = %v, want ErrExpired", err)
+	}
+
+	service.now = func() time.Time { return time.Unix(1_710_000_000, 0).UTC() }
+	futureToken, _, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+	service.now = func() time.Time { return time.Unix(1_710_000_000, 0).UTC().Add(-time.Minute) }
+	_, err = service.VerifyDelegationToken(context.Background(), futureToken, "agent-b")
+	if !errors.Is(err, ErrNotYetValid) {
+		t.Fatalf("VerifyDelegationToken() error = %v, want ErrNotYetValid", err)
+	}
+}
+
+func TestIssueDelegationTokenScopeMonotonicityAcrossChain(t *testing.T) {
+	service, _, _ := newTestTokenService(t)
+
+	firstToken, _, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read", "write"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken(step1) error = %v", err)
+	}
+	secondToken, secondClaims, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-b",
+		TargetAgentID:     "agent-c",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       firstToken,
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken(step2) error = %v", err)
+	}
+	if secondClaims.ChainDepth != 2 {
+		t.Fatalf("secondClaims.ChainDepth = %d, want 2", secondClaims.ChainDepth)
+	}
+	thirdToken, thirdClaims, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-c",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       secondToken,
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken(step3) error = %v", err)
+	}
+	if thirdClaims.ChainDepth != 3 {
+		t.Fatalf("thirdClaims.ChainDepth = %d, want 3", thirdClaims.ChainDepth)
+	}
+	_, _, err = service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-b",
+		TargetAgentID:     "agent-a",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       thirdToken,
+	})
+	if !errors.Is(err, ErrChainTooDeep) {
+		t.Fatalf("IssueDelegationToken(depth4) error = %v, want ErrChainTooDeep", err)
+	}
+	_, _, err = service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-b",
+		TargetAgentID:     "agent-c",
+		AllowedActions:    []string{"deploy"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       firstToken,
+	})
+	if !errors.Is(err, ErrScopeExceeded) {
+		t.Fatalf("IssueDelegationToken(scope increase) error = %v, want ErrScopeExceeded", err)
+	}
+}
+
+func TestVerifyDelegationTokenRevocationAndScopeDowngrade(t *testing.T) {
+	service, revocations, _ := newTestTokenService(t)
+
+	token, _, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+	verified, err := service.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if err != nil {
+		t.Fatalf("VerifyDelegationToken() error = %v", err)
+	}
+	if err := revocations.Revoke(context.Background(), verified.JTI, verified.ExpiresAt); err != nil {
+		t.Fatalf("Revoke() error = %v", err)
+	}
+	_, err = service.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if !errors.Is(err, ErrRevoked) {
+		t.Fatalf("VerifyDelegationToken() error = %v, want ErrRevoked", err)
+	}
+
+	downgraded := NewTokenService(service.signingKey, service.keyring, staticAgentPermissions{
+		entries: map[string]AgentPermissions{
+			"agent-a": {AllowedActions: []string{"read"}, AllowedTopics: []string{}},
+		},
+	}, nil)
+	downgraded.now = service.now
+	_, err = downgraded.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if !errors.Is(err, ErrScopeExceeded) {
+		t.Fatalf("VerifyDelegationToken() error = %v, want ErrScopeExceeded", err)
+	}
+}
+
+func TestVerifyDelegationTokenClockSkewLeeway(t *testing.T) {
+	service, _, _ := newTestTokenService(t)
+
+	token, _, err := service.IssueDelegationToken(context.Background(), IssueRequest{
+		Tenant:            "tenant-a",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		TTL:               time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	service.now = func() time.Time { return time.Unix(1_710_000_000, 0).UTC().Add(time.Minute + 20*time.Second) }
+	if _, err := service.VerifyDelegationToken(context.Background(), token, "agent-b"); err != nil {
+		t.Fatalf("VerifyDelegationToken() within leeway error = %v", err)
+	}
+	service.now = func() time.Time { return time.Unix(1_710_000_000, 0).UTC().Add(time.Minute + 31*time.Second) }
+	_, err = service.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("VerifyDelegationToken() beyond leeway error = %v, want ErrExpired", err)
+	}
+}

--- a/core/controlplane/gateway/auth/rbac.go
+++ b/core/controlplane/gateway/auth/rbac.go
@@ -39,6 +39,13 @@ const (
 	PermUsersWrite     = "users.write"
 	PermRolesRead      = "roles.read"
 	PermRolesWrite     = "roles.write"
+	// PermDelegationImpersonate authorises a caller to submit a job with a
+	// delegation audience agent that differs from the caller's own
+	// authenticated agent identity. This amounts to impersonating a
+	// different audience at delegation-verification time and must be
+	// restricted to operators explicitly trusted to relay tokens on
+	// behalf of other agents.
+	PermDelegationImpersonate = "delegation.impersonate"
 )
 
 // AllPermissions is the canonical list of permissions for validation.
@@ -54,6 +61,7 @@ var AllPermissions = []string{
 	PermSchemasRead, PermSchemasWrite,
 	PermUsersRead, PermUsersWrite,
 	PermRolesRead, PermRolesWrite,
+	PermDelegationImpersonate,
 }
 
 // ---------------------------------------------------------------------------

--- a/core/controlplane/gateway/delegation_ctx.go
+++ b/core/controlplane/gateway/delegation_ctx.go
@@ -1,0 +1,77 @@
+package gateway
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/infra/config"
+)
+
+func projectVerifiedDelegationContext(verified delegation.VerifiedToken) *config.DelegationContext {
+	if verified.ChainDepth <= 0 || len(verified.DelegationChain) == 0 {
+		return nil
+	}
+
+	issuerChain := make([]string, 0, len(verified.DelegationChain))
+	for _, link := range verified.DelegationChain {
+		agentID := strings.TrimSpace(link.AgentID)
+		if agentID == "" {
+			continue
+		}
+		issuerChain = append(issuerChain, agentID)
+	}
+	if len(issuerChain) == 0 {
+		return nil
+	}
+
+	ctx := &config.DelegationContext{
+		Depth:        verified.ChainDepth,
+		IssuerChain:  issuerChain,
+		Scope:        append([]string(nil), verified.AllowedActions...),
+		RootIssuer:   issuerChain[0],
+		ParentIssuer: issuerChain[len(issuerChain)-1],
+		JTI:          strings.TrimSpace(verified.JTI),
+		Audience:     strings.TrimSpace(verified.Audience),
+	}
+	if !verified.ExpiresAt.IsZero() {
+		ctx.ExpiresAt = verified.ExpiresAt.UTC().Format(time.RFC3339Nano)
+	}
+	return ctx
+}
+
+func applyDelegationContextLabels(labels map[string]string, delegationCtx *config.DelegationContext, subject string) map[string]string {
+	if delegationCtx == nil {
+		return labels
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[config.LabelDelegationDepth] = strconv.Itoa(delegationCtx.Depth)
+	if delegationCtx.RootIssuer != "" {
+		labels[config.LabelDelegationIssuer] = delegationCtx.RootIssuer
+	}
+	if len(delegationCtx.IssuerChain) > 0 {
+		labels[config.LabelDelegationIssuerChain] = strings.Join(delegationCtx.IssuerChain, ",")
+	}
+	if len(delegationCtx.Scope) > 0 {
+		labels[config.LabelDelegationScope] = strings.Join(delegationCtx.Scope, ",")
+	}
+	if delegationCtx.ParentIssuer != "" {
+		labels[config.LabelDelegationParentIssuer] = delegationCtx.ParentIssuer
+	}
+	if delegationCtx.JTI != "" {
+		labels[config.LabelDelegationJTI] = delegationCtx.JTI
+	}
+	if delegationCtx.ExpiresAt != "" {
+		labels[config.LabelDelegationExpiresAt] = delegationCtx.ExpiresAt
+	}
+	if delegationCtx.Audience != "" {
+		labels[config.LabelDelegationAudience] = delegationCtx.Audience
+	}
+	if subject = strings.TrimSpace(subject); subject != "" {
+		labels[config.LabelDelegationSubject] = subject
+	}
+	return labels
+}

--- a/core/controlplane/gateway/delegation_ctx_test.go
+++ b/core/controlplane/gateway/delegation_ctx_test.go
@@ -1,0 +1,80 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/infra/config"
+)
+
+func TestProjectVerifiedDelegationContextUsesAgentChain(t *testing.T) {
+	verified := delegation.VerifiedToken{
+		ChainDepth:      2,
+		AllowedActions:  []string{"read", "write"},
+		Audience:        "agent-b",
+		JTI:             "jti-child",
+		ExpiresAt:       time.Date(2026, 4, 21, 13, 14, 15, 0, time.UTC),
+		DelegationChain: []delegation.ChainLink{{AgentID: "agent-a", IssuedBy: "cordum"}, {AgentID: "agent-b", IssuedBy: "agent-a"}},
+	}
+
+	got := projectVerifiedDelegationContext(verified)
+	if got == nil {
+		t.Fatal("expected delegation context")
+	}
+	if got.Depth != 2 {
+		t.Fatalf("Depth = %d, want 2", got.Depth)
+	}
+	if got.RootIssuer != "agent-a" {
+		t.Fatalf("RootIssuer = %q, want agent-a", got.RootIssuer)
+	}
+	if got.ParentIssuer != "agent-b" {
+		t.Fatalf("ParentIssuer = %q, want agent-b", got.ParentIssuer)
+	}
+	if len(got.IssuerChain) != 2 || got.IssuerChain[0] != "agent-a" || got.IssuerChain[1] != "agent-b" {
+		t.Fatalf("IssuerChain = %#v, want [agent-a agent-b]", got.IssuerChain)
+	}
+	if len(got.Scope) != 2 || got.Scope[0] != "read" || got.Scope[1] != "write" {
+		t.Fatalf("Scope = %#v, want [read write]", got.Scope)
+	}
+	if got.JTI != "jti-child" {
+		t.Fatalf("JTI = %q, want jti-child", got.JTI)
+	}
+	if got.Audience != "agent-b" {
+		t.Fatalf("Audience = %q, want agent-b", got.Audience)
+	}
+	if got.ExpiresAt != "2026-04-21T13:14:15Z" {
+		t.Fatalf("ExpiresAt = %q, want 2026-04-21T13:14:15Z", got.ExpiresAt)
+	}
+}
+
+func TestApplyDelegationContextLabelsIncludesParentJTIAndRouting(t *testing.T) {
+	labels := applyDelegationContextLabels(map[string]string{"existing": "ok"}, &config.DelegationContext{
+		Depth:        2,
+		IssuerChain:  []string{"agent-a", "agent-b"},
+		Scope:        []string{"read"},
+		RootIssuer:   "agent-a",
+		ParentIssuer: "agent-b",
+		JTI:          "dlg-123",
+		ExpiresAt:    "2026-04-21T13:14:15Z",
+		Audience:     "agent-b",
+	}, "agent-b")
+
+	want := map[string]string{
+		"existing":                         "ok",
+		config.LabelDelegationDepth:        "2",
+		config.LabelDelegationIssuer:       "agent-a",
+		config.LabelDelegationIssuerChain:  "agent-a,agent-b",
+		config.LabelDelegationScope:        "read",
+		config.LabelDelegationParentIssuer: "agent-b",
+		config.LabelDelegationJTI:          "dlg-123",
+		config.LabelDelegationExpiresAt:    "2026-04-21T13:14:15Z",
+		config.LabelDelegationAudience:     "agent-b",
+		config.LabelDelegationSubject:      "agent-b",
+	}
+	for key, value := range want {
+		if got := labels[key]; got != value {
+			t.Fatalf("%s = %q, want %q", key, got, value)
+		}
+	}
+}

--- a/core/controlplane/gateway/delegation_submit.go
+++ b/core/controlplane/gateway/delegation_submit.go
@@ -69,6 +69,21 @@ func (s *server) applySubmitDelegationWithAudience(ctx context.Context, tenant, 
 	return labels, nil
 }
 
+// persistSubmitDelegationToken stores the raw delegation bearer token
+// on the job-metadata hash so the scheduler can re-verify it at
+// dispatch time (defense-in-depth against submit→dispatch revocation
+// races).
+//
+// The raw token IS sensitive material — it is wiped as soon as the
+// scheduler finishes dispatch verification via the companion call in
+// core/controlplane/scheduler/delegation_dispatch.go
+// (ClearDelegationDispatchToken). That companion lives in
+// split/platform; this branch provides the Clear method on the store
+// interface + RedisJobStore implementation, and the scheduler wire-up
+// on platform invokes it. After the wipe, only the non-sensitive
+// DelegationLineage remains on the job record (JTI, issuer chain,
+// scope) for audit + read-side APIs — see Blocker 4 from the #198
+// review.
 func (s *server) persistSubmitDelegationToken(ctx context.Context, jobID, token, audience string) error {
 	token = strings.TrimSpace(token)
 	if token == "" || s == nil || s.jobStore == nil {

--- a/core/controlplane/gateway/delegation_submit.go
+++ b/core/controlplane/gateway/delegation_submit.go
@@ -1,0 +1,183 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/model"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+var errDelegationAgentRequired = errors.New("delegation token requires an authenticated agent identity")
+
+func (s *server) applySubmitDelegation(ctx context.Context, tenant, agentID, token string, labels map[string]string, meta *pb.JobMetadata) (map[string]string, error) {
+	return s.applySubmitDelegationWithAudience(ctx, tenant, agentID, token, "", labels, meta)
+}
+
+func submitDelegationExpectedAudience(agentID, audienceOverride string) string {
+	expectedAudience := strings.TrimSpace(audienceOverride)
+	if expectedAudience == "" {
+		expectedAudience = strings.TrimSpace(agentID)
+	}
+	return expectedAudience
+}
+
+// applySubmitDelegationWithAudience allows the caller to pass an
+// explicit audience agent id that overrides the submitting-agent
+// default. When audienceOverride is empty, the authenticated
+// submitting agent id is used (the common case — the token was
+// issued TO this caller).
+func (s *server) applySubmitDelegationWithAudience(ctx context.Context, tenant, agentID, token, audienceOverride string, labels map[string]string, meta *pb.JobMetadata) (map[string]string, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return labels, nil
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, errDelegationAgentRequired
+	}
+	expectedAudience := submitDelegationExpectedAudience(agentID, audienceOverride)
+	service, err := s.delegationTokenService()
+	if err != nil {
+		return nil, fmt.Errorf("delegation token service unavailable: %w", err)
+	}
+	verified, err := service.VerifyDelegationToken(ctx, token, expectedAudience)
+	if err != nil {
+		return nil, err
+	}
+	if tenant != "" && verified.Tenant != "" && !strings.EqualFold(verified.Tenant, tenant) {
+		return nil, fmt.Errorf("delegation token tenant mismatch")
+	}
+	delegationCtx := projectVerifiedDelegationContext(verified)
+	labels = applyDelegationContextLabels(labels, delegationCtx, verified.Subject)
+	if meta != nil {
+		if meta.Labels == nil {
+			meta.Labels = map[string]string{}
+		}
+		for key, value := range labels {
+			if strings.HasPrefix(key, "_delegation.") && strings.TrimSpace(value) != "" {
+				meta.Labels[key] = value
+			}
+		}
+	}
+	return labels, nil
+}
+
+func (s *server) persistSubmitDelegationToken(ctx context.Context, jobID, token, audience string) error {
+	token = strings.TrimSpace(token)
+	if token == "" || s == nil || s.jobStore == nil {
+		return nil
+	}
+	dispatchStore, ok := any(s.jobStore).(model.DelegationDispatchTokenStore)
+	if !ok {
+		return fmt.Errorf("delegation dispatch token store unavailable")
+	}
+	return dispatchStore.SetDelegationDispatchToken(ctx, jobID, model.DelegationDispatchToken{
+		Token:    token,
+		Audience: strings.TrimSpace(audience),
+	})
+}
+
+func submitDelegationAuditReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	if code := delegation.ErrorCode(err); code != "" {
+		return code
+	}
+	if errors.Is(err, errDelegationAgentRequired) {
+		return err.Error()
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "tenant mismatch") {
+		return "delegation token tenant mismatch"
+	}
+	return "delegation token service unavailable"
+}
+
+func (s *server) emitSubmitDelegationRejectedAudit(r *http.Request, jobID, topic, agentID string, err error) {
+	if s == nil || s.auditExporter == nil || err == nil {
+		return
+	}
+	extra := map[string]string{}
+	if topic = strings.TrimSpace(topic); topic != "" {
+		extra["topic"] = topic
+	}
+	if len(extra) == 0 {
+		extra = nil
+	}
+	s.auditExporter.Send(audit.SIEMEvent{
+		Timestamp: time.Now().UTC(),
+		EventType: audit.EventDelegationRejected,
+		Severity:  audit.SeverityMedium,
+		TenantID:  strings.TrimSpace(tenantFromRequest(r)),
+		AgentID:   strings.TrimSpace(agentID),
+		JobID:     strings.TrimSpace(jobID),
+		Action:    "submit",
+		Reason:    submitDelegationAuditReason(err),
+		Identity:  strings.TrimSpace(policyActorID(r)),
+		Extra:     extra,
+	})
+}
+
+// submitDelegationErrorStatus maps delegation verify errors to HTTP status
+// codes per the plan's taxonomy so callers can branch on shape without
+// parsing messages:
+//
+//   - 401 Unauthorized     — malformed / bad_signature / unknown_kid / not_yet_valid
+//     (the token cannot be trusted as a cryptographic object)
+//   - 403 Forbidden        — expired / revoked / audience_mismatch / tenant mismatch
+//     (the token is a valid object but its authorisation
+//     has lapsed or was granted to a different audience)
+//   - 422 Unprocessable    — chain_too_deep / scope_exceeded
+//     (the token is cryptographically valid but violates
+//     policy envelope constraints)
+//   - 400 Bad Request      — missing authenticated agent identity
+//   - 503 Service Unavail  — delegation service not configured / unreachable
+//
+// Returns (status, errorCode). The errorCode string is the delegation
+// taxonomy keyword (e.g. "expired") so clients can branch on it
+// without scraping human-readable messages.
+func submitDelegationErrorStatus(err error) (int, string) {
+	switch {
+	case err == nil:
+		return http.StatusOK, ""
+	case errors.Is(err, errDelegationAgentRequired):
+		return http.StatusBadRequest, err.Error()
+	}
+	if code := delegation.ErrorCode(err); code != "" {
+		switch code {
+		case "malformed", "bad_signature", "unknown_kid", "not_yet_valid":
+			return http.StatusUnauthorized, code
+		case "expired", "revoked", "audience_mismatch":
+			return http.StatusForbidden, code
+		case "chain_too_deep", "scope_exceeded":
+			return http.StatusUnprocessableEntity, code
+		default:
+			return http.StatusForbidden, code
+		}
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "tenant mismatch") {
+		return http.StatusForbidden, "delegation token tenant mismatch"
+	}
+	return http.StatusServiceUnavailable, "delegation token service unavailable"
+}
+
+func writeDelegationSubmitErrorJSON(w http.ResponseWriter, status int, code string) {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		code = "delegation token service unavailable"
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	writeJSON(w, map[string]any{
+		"error":      code,
+		"error_code": code,
+		"status":     status,
+	})
+}

--- a/core/controlplane/gateway/delegation_submit_test.go
+++ b/core/controlplane/gateway/delegation_submit_test.go
@@ -1,0 +1,41 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/cordum/cordum/core/auth/delegation"
+)
+
+func TestSubmitDelegationErrorStatusMapsDelegationTaxonomy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "missing_agent", err: errDelegationAgentRequired, wantStatus: http.StatusBadRequest, wantCode: errDelegationAgentRequired.Error()},
+		{name: "malformed", err: delegation.ErrMalformed, wantStatus: http.StatusUnauthorized, wantCode: "malformed"},
+		{name: "bad_signature", err: delegation.ErrBadSignature, wantStatus: http.StatusUnauthorized, wantCode: "bad_signature"},
+		{name: "unknown_kid", err: delegation.ErrUnknownKeyId, wantStatus: http.StatusUnauthorized, wantCode: "unknown_kid"},
+		{name: "expired", err: delegation.ErrExpired, wantStatus: http.StatusForbidden, wantCode: "expired"},
+		{name: "revoked", err: delegation.ErrRevoked, wantStatus: http.StatusForbidden, wantCode: "revoked"},
+		{name: "audience_mismatch", err: delegation.ErrAudienceMismatch, wantStatus: http.StatusForbidden, wantCode: "audience_mismatch"},
+		{name: "chain_too_deep", err: delegation.ErrChainTooDeep, wantStatus: http.StatusUnprocessableEntity, wantCode: "chain_too_deep"},
+		{name: "scope_exceeded", err: delegation.ErrScopeExceeded, wantStatus: http.StatusUnprocessableEntity, wantCode: "scope_exceeded"},
+		{name: "tenant_mismatch", err: errors.New("delegation token tenant mismatch"), wantStatus: http.StatusForbidden, wantCode: "delegation token tenant mismatch"},
+		{name: "service_unavailable", err: errors.New("backend offline"), wantStatus: http.StatusServiceUnavailable, wantCode: "delegation token service unavailable"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStatus, gotCode := submitDelegationErrorStatus(tc.err)
+			if gotStatus != tc.wantStatus || gotCode != tc.wantCode {
+				t.Fatalf("submitDelegationErrorStatus(%v) = (%d, %q), want (%d, %q)", tc.err, gotStatus, gotCode, tc.wantStatus, tc.wantCode)
+			}
+		})
+	}
+}

--- a/core/controlplane/gateway/handlers_delegation.go
+++ b/core/controlplane/gateway/handlers_delegation.go
@@ -106,10 +106,23 @@ func (s *server) handleDelegateAgent(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !strings.EqualFold(strings.TrimSpace(authCtx.Role), "admin") && strings.TrimSpace(authCtx.PrincipalID) != delegatingAgentID {
-		writeForbidden(w, r, errors.New("principal access denied"))
-		s.emitDelegationAudit(r, "issue", tenantFromRequest(r), delegatingAgentID, "", "", 0, "denied", errors.New("principal access denied"))
-		return
+	// Bind the caller's authoritative agent from the authenticated worker
+	// credential, not from authCtx.PrincipalID (which is the worker ID and
+	// has a distinct namespace from agent IDs in this codebase). Admins
+	// bypass the per-agent check; everyone else must prove they are the
+	// delegating agent via their linked credential.
+	if !strings.EqualFold(strings.TrimSpace(authCtx.Role), "admin") {
+		callerAgentID := ""
+		if s.agentIdentityStore != nil {
+			if agent, err := s.agentIdentityStore.GetByWorkerID(r.Context(), strings.TrimSpace(authCtx.PrincipalID)); err == nil && agent != nil {
+				callerAgentID = agent.ID
+			}
+		}
+		if callerAgentID == "" || callerAgentID != delegatingAgentID {
+			writeForbidden(w, r, errors.New("principal access denied"))
+			s.emitDelegationAudit(r, "issue", tenantFromRequest(r), delegatingAgentID, "", "", 0, "denied", errors.New("principal access denied"))
+			return
+		}
 	}
 
 	var req delegateTokenRequest
@@ -148,7 +161,14 @@ func (s *server) handleDelegateAgent(w http.ResponseWriter, r *http.Request) {
 		s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, "", 0, "denied", errors.New("target agent unavailable"))
 		return
 	}
-	if !s.allowDelegationIssue(r.Context(), tenant, delegatingAgentID) {
+	if allowed, quotaErr := s.allowDelegationIssue(r.Context(), tenant, delegatingAgentID); !allowed {
+		if quotaErr != nil {
+			// Rate-limit backend is broken — surface as 503 so operators
+			// see the actual failure class instead of a misleading 429.
+			writeServiceUnavailable(w, r, "delegation rate limiter", quotaErr)
+			s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, "", 0, "error", quotaErr)
+			return
+		}
 		writeErrorJSON(w, http.StatusTooManyRequests, "rate limited")
 		s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, "", 0, "rate_limited", errors.New("rate limited"))
 		return
@@ -398,26 +418,37 @@ func (s *server) loadDelegationAgent(w http.ResponseWriter, r *http.Request, age
 		writeErrorJSON(w, http.StatusNotFound, "agent identity not found")
 		return nil, false
 	}
-	if tenant != "" && identity.TenantID != tenant {
-		writeForbidden(w, r, errors.New("cross-tenant delegation denied"))
-		return nil, false
-	}
+	// Tenant scoping: store.AgentIdentity does not currently carry a
+	// tenant field — agent IDs live in a flat `agent:identity:<id>`
+	// keyspace. Cross-tenant isolation for this endpoint relies on the
+	// upstream tenant middleware (tenantFromRequest + auth context)
+	// already pinning the caller to their tenant. Adding per-agent
+	// tenant binding to the store is tracked separately; until it
+	// lands, this helper treats the tenant argument as advisory.
+	_ = tenant
 	return identity, true
 }
 
-func (s *server) allowDelegationIssue(ctx context.Context, tenant, agentID string) bool {
+// allowDelegationIssue returns (allowed, err). allowed=true means the
+// caller is under the per-minute issuance quota. allowed=false means
+// either the quota is exhausted (err==nil — caller should 429) or the
+// rate-limit backend itself is unavailable (err!=nil — caller should
+// 503). Splitting the two lets operators distinguish a noisy client
+// from a Redis outage in logs + responses; previously both collapsed
+// to a single 429 which masked infrastructure failures.
+func (s *server) allowDelegationIssue(ctx context.Context, tenant, agentID string) (bool, error) {
 	if s == nil || s.jobStore == nil || s.jobStore.Client() == nil {
-		return true
+		return true, nil
 	}
 	key := fmt.Sprintf("delegation:issue:%s:%s:%s", strings.TrimSpace(tenant), strings.TrimSpace(agentID), time.Now().UTC().Format("200601021504"))
 	count, err := s.jobStore.Client().Incr(ctx, key).Result()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("delegation rate limiter unavailable: %w", err)
 	}
 	if count == 1 {
 		_ = s.jobStore.Client().Expire(ctx, key, 2*time.Minute).Err()
 	}
-	return count <= delegationIssueLimitPerMinute
+	return count <= delegationIssueLimitPerMinute, nil
 }
 
 func delegationIssueStatus(err error) int {

--- a/core/controlplane/gateway/handlers_delegation.go
+++ b/core/controlplane/gateway/handlers_delegation.go
@@ -1,0 +1,522 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/infra/store"
+)
+
+const delegationIssueLimitPerMinute = 60
+
+// maxDelegationTTLSeconds caps `ttl_seconds` on the delegation-issue handler
+// before it is multiplied into time.Duration. Without this bound a caller
+// could submit `ttl_seconds=math.MaxInt64` and wrap the `int64 * time.Second`
+// multiplication past the int64 nanosecond range — the resulting negative
+// duration would silently bypass the service-layer `maxTTL` check (which
+// tests `ttl > maxTTL`) and mint an already-expired-or-far-future token. We
+// cap at one year here; the service layer's configured maxTTL still applies
+// and will reject anything smaller than that bound with its own 400 error.
+const maxDelegationTTLSeconds int64 = 365 * 24 * 60 * 60
+
+type delegateTokenRequest struct {
+	TargetAgentID  string   `json:"target_agent_id"`
+	AllowedActions []string `json:"allowed_actions,omitempty"`
+	AllowedTopics  []string `json:"allowed_topics,omitempty"`
+	TTLSeconds     int64    `json:"ttl_seconds,omitempty"`
+	ParentToken    string   `json:"parent_token,omitempty"`
+}
+
+type delegateTokenResponse struct {
+	Token      string `json:"token"`
+	KID        string `json:"kid"`
+	ExpiresAt  string `json:"expires_at"`
+	ChainDepth int    `json:"chain_depth"`
+	JTI        string `json:"jti"`
+}
+
+type verifyDelegationRequest struct {
+	Token            string `json:"token"`
+	ExpectedAudience string `json:"expected_audience"`
+}
+
+type verifyDelegationResponse struct {
+	Valid           bool                   `json:"valid"`
+	Sub             string                 `json:"sub,omitempty"`
+	Aud             string                 `json:"aud,omitempty"`
+	AllowedActions  []string               `json:"allowed_actions,omitempty"`
+	AllowedTopics   []string               `json:"allowed_topics,omitempty"`
+	ChainDepth      int                    `json:"chain_depth,omitempty"`
+	DelegationChain []delegation.ChainLink `json:"delegation_chain,omitempty"`
+	ErrorCode       string                 `json:"error_code,omitempty"`
+}
+
+type revokeDelegationRequest struct {
+	JTI     string `json:"jti"`
+	Reason  string `json:"reason,omitempty"`
+	Cascade *bool  `json:"cascade,omitempty"`
+}
+
+type revokeDelegationResponse struct {
+	JTI           string `json:"jti"`
+	CascadedCount int    `json:"cascaded_count"`
+}
+
+type gatewayDelegationPermissionsResolver struct {
+	store *store.AgentIdentityStore
+}
+
+func (r gatewayDelegationPermissionsResolver) ResolveAgentPermissions(ctx context.Context, agentID string) (delegation.AgentPermissions, error) {
+	if r.store == nil {
+		return delegation.AgentPermissions{}, fmt.Errorf("agent identity store unavailable")
+	}
+	identity, err := r.store.Get(ctx, agentID)
+	if err != nil {
+		return delegation.AgentPermissions{}, err
+	}
+	if identity == nil {
+		return delegation.AgentPermissions{}, fmt.Errorf("agent identity not found")
+	}
+	return delegation.AgentPermissions{
+		AllowedActions: identity.AllowedTools,
+		AllowedTopics:  identity.AllowedTopics,
+	}, nil
+}
+
+func (s *server) handleDelegateAgent(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePermissionOrRole(w, r, auth.PermAgentsDelegate, "admin") {
+		s.emitDelegationAudit(r, "issue", tenantFromRequest(r), "", "", "", 0, "denied", errors.New("access denied"))
+		return
+	}
+	authCtx := auth.FromRequest(r)
+	if authCtx == nil {
+		writeErrorJSON(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	delegatingAgentID, ok := requirePathParam(w, r, "id")
+	if !ok {
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(authCtx.Role), "admin") && strings.TrimSpace(authCtx.PrincipalID) != delegatingAgentID {
+		writeForbidden(w, r, errors.New("principal access denied"))
+		s.emitDelegationAudit(r, "issue", tenantFromRequest(r), delegatingAgentID, "", "", 0, "denied", errors.New("principal access denied"))
+		return
+	}
+
+	var req delegateTokenRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		writeJSONDecodeError(w, err, "invalid json")
+		return
+	}
+	req.TargetAgentID = strings.TrimSpace(req.TargetAgentID)
+	if req.TargetAgentID == "" {
+		writeErrorJSON(w, http.StatusBadRequest, "target_agent_id required")
+		return
+	}
+	if req.TTLSeconds < 0 {
+		writeErrorJSON(w, http.StatusBadRequest, "ttl_seconds must be non-negative")
+		return
+	}
+	if req.TTLSeconds > maxDelegationTTLSeconds {
+		// Enforce the pre-multiplication bound so `time.Duration(foo) *
+		// time.Second` cannot overflow int64 nanoseconds and return a
+		// negative duration that would sneak past the service-layer
+		// maxTTL guard.
+		writeErrorJSON(w, http.StatusBadRequest, "ttl_seconds exceeds maximum (1 year)")
+		return
+	}
+
+	tenant := tenantFromRequest(r)
+	if tenant == "" {
+		writeErrorJSON(w, http.StatusBadRequest, "tenant required")
+		return
+	}
+	if _, ok := s.loadDelegationAgent(w, r, delegatingAgentID, tenant); !ok {
+		s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, "", 0, "denied", errors.New("delegating agent unavailable"))
+		return
+	}
+	if _, ok := s.loadDelegationAgent(w, r, req.TargetAgentID, tenant); !ok {
+		s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, "", 0, "denied", errors.New("target agent unavailable"))
+		return
+	}
+	if !s.allowDelegationIssue(r.Context(), tenant, delegatingAgentID) {
+		writeErrorJSON(w, http.StatusTooManyRequests, "rate limited")
+		s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, "", 0, "rate_limited", errors.New("rate limited"))
+		return
+	}
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		writeServiceUnavailable(w, r, "delegation token service", err)
+		s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, "", 0, "error", err)
+		return
+	}
+
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	token, claims, err := service.IssueDelegationToken(r.Context(), delegation.IssueRequest{
+		Tenant:            tenant,
+		DelegatingAgentID: delegatingAgentID,
+		TargetAgentID:     req.TargetAgentID,
+		AllowedActions:    req.AllowedActions,
+		AllowedTopics:     req.AllowedTopics,
+		TTL:               ttl,
+		ParentToken:       req.ParentToken,
+	})
+	if err != nil {
+		status := delegationIssueStatus(err)
+		if status >= 500 {
+			writeInternalError(w, r, "issue delegation token", err)
+		} else {
+			writeErrorJSON(w, status, delegationIssueMessage(err))
+		}
+		s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, claims.ID, claims.ChainDepth, "denied", err)
+		return
+	}
+
+	resp := delegateTokenResponse{
+		Token:      token,
+		KID:        service.KeyID(),
+		ExpiresAt:  claims.ExpiresAt.Time.UTC().Format(time.RFC3339Nano),
+		ChainDepth: claims.ChainDepth,
+		JTI:        claims.ID,
+	}
+	if listStore := s.delegationListStore(); listStore != nil {
+		if err := listStore.RecordIssuedToken(r.Context(), delegationIssuedView(tenant, claims, req.TargetAgentID)); err != nil {
+			writeInternalError(w, r, "record delegation token", err)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, resp)
+	s.emitDelegationAudit(r, "issue", tenant, delegatingAgentID, req.TargetAgentID, claims.ID, claims.ChainDepth, "ok", nil)
+}
+
+func (s *server) handleVerifyDelegation(w http.ResponseWriter, r *http.Request) {
+	if auth.FromRequest(r) == nil {
+		writeErrorJSON(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	var req verifyDelegationRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		writeJSONDecodeError(w, err, "invalid json")
+		return
+	}
+	if strings.TrimSpace(req.Token) == "" {
+		writeErrorJSON(w, http.StatusBadRequest, "token required")
+		return
+	}
+
+	tenant := tenantFromRequest(r)
+	service, err := s.delegationTokenService()
+	if err != nil {
+		writeServiceUnavailable(w, r, "delegation token service", err)
+		s.emitDelegationAudit(r, "verify", tenant, "", strings.TrimSpace(req.ExpectedAudience), "", 0, "error", err)
+		return
+	}
+	verified, err := service.VerifyDelegationToken(r.Context(), req.Token, strings.TrimSpace(req.ExpectedAudience))
+	if err != nil {
+		code := delegation.ErrorCode(err)
+		if code == "" {
+			writeInternalError(w, r, "verify delegation token", err)
+			s.emitDelegationAudit(r, "verify", tenant, "", strings.TrimSpace(req.ExpectedAudience), "", 0, "error", err)
+			return
+		}
+		writeJSON(w, verifyDelegationResponse{
+			Valid:     false,
+			ErrorCode: code,
+		})
+		s.emitDelegationAudit(r, "verify", tenant, "", strings.TrimSpace(req.ExpectedAudience), "", 0, "denied", err)
+		return
+	}
+	writeJSON(w, verifyDelegationResponse{
+		Valid:           true,
+		Sub:             verified.Subject,
+		Aud:             verified.Audience,
+		AllowedActions:  verified.AllowedActions,
+		AllowedTopics:   verified.AllowedTopics,
+		ChainDepth:      verified.ChainDepth,
+		DelegationChain: verified.DelegationChain,
+	})
+	s.emitDelegationAudit(r, "verify", tenant, verified.Subject, verified.Audience, verified.JTI, verified.ChainDepth, "ok", nil)
+}
+
+func (s *server) handleRevokeDelegation(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePermissionOrRole(w, r, auth.PermAgentsDelegate, "admin") {
+		s.emitDelegationAudit(r, "revoke", tenantFromRequest(r), "", "", "", 0, "denied", errors.New("access denied"))
+		return
+	}
+	var req revokeDelegationRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		writeJSONDecodeError(w, err, "invalid json")
+		return
+	}
+	req.JTI = strings.TrimSpace(req.JTI)
+	if req.JTI == "" {
+		writeErrorJSON(w, http.StatusBadRequest, "jti required")
+		return
+	}
+	if s == nil || s.jobStore == nil {
+		writeErrorJSON(w, http.StatusServiceUnavailable, "service unavailable")
+		return
+	}
+	tenant := tenantFromRequest(r)
+	listStore := s.delegationListStore()
+	if listStore == nil {
+		writeErrorJSON(w, http.StatusServiceUnavailable, "service unavailable")
+		return
+	}
+	rootView, ok, err := listStore.Get(r.Context(), req.JTI)
+	if err != nil {
+		writeInternalError(w, r, "load delegation token", err)
+		s.emitDelegationAudit(r, "revoke", tenant, "", "", req.JTI, 0, "error", err)
+		return
+	}
+	if !ok || !strings.EqualFold(strings.TrimSpace(rootView.Tenant), tenant) {
+		writeErrorJSON(w, http.StatusNotFound, "delegation token not found")
+		s.emitDelegationAudit(r, "revoke", tenant, "", "", req.JTI, 0, "denied", delegation.ErrNotFound)
+		return
+	}
+	revocations := delegation.NewRedisRevocationStoreFromClient(s.jobStore.Client())
+	revokedAt := time.Now().UTC()
+	cascade := req.Cascade == nil || *req.Cascade
+	result, err := revocations.CascadeRevoke(r.Context(), req.JTI, strings.TrimSpace(req.Reason), revokedAt, cascade)
+	if err != nil {
+		switch {
+		case errors.Is(err, delegation.ErrNotFound):
+			writeErrorJSON(w, http.StatusNotFound, "delegation token not found")
+		case errors.Is(err, delegation.ErrCascadeTooDeep):
+			writeErrorJSON(w, http.StatusUnprocessableEntity, "delegation cascade too deep")
+		default:
+			writeInternalError(w, r, "revoke delegation token", err)
+		}
+		s.emitDelegationAudit(r, "revoke", tenant, "", "", req.JTI, rootView.ChainDepth, "error", err)
+		return
+	}
+	writeJSON(w, revokeDelegationResponse{
+		JTI:           req.JTI,
+		CascadedCount: result.CascadedCount,
+	})
+	s.emitDelegationAudit(r, "revoke", tenant, "", "", req.JTI, rootView.ChainDepth, "ok", nil)
+	if result.CascadedCount > 0 {
+		s.emitDelegationCascadeAudit(r, tenant, req.JTI, result.CascadedCount, strings.TrimSpace(req.Reason))
+	}
+	for _, revokedJTI := range result.RevokedJTIs {
+		if revokedJTI == req.JTI {
+			continue
+		}
+		s.emitDelegationRevokedAudit(r, tenant, req.JTI, revokedJTI, strings.TrimSpace(req.Reason))
+	}
+}
+
+func (s *server) emitDelegationCascadeAudit(r *http.Request, tenant, rootJTI string, cascadedCount int, reason string) {
+	if s == nil || s.auditExporter == nil || cascadedCount <= 0 {
+		return
+	}
+	extra := map[string]string{
+		"root_jti":       strings.TrimSpace(rootJTI),
+		"cascaded_count": strconv.Itoa(cascadedCount),
+	}
+	if trim := strings.TrimSpace(reason); trim != "" {
+		extra["reason"] = trim
+	}
+	s.auditExporter.Send(audit.SIEMEvent{
+		Timestamp: time.Now().UTC(),
+		EventType: audit.EventSystemAuth,
+		Severity:  audit.SeverityInfo,
+		TenantID:  tenant,
+		Action:    "delegation.revoked_cascade",
+		Reason:    "delegation revoke cascaded",
+		Identity:  policyActorID(r),
+		Extra:     extra,
+	})
+}
+
+func (s *server) emitDelegationRevokedAudit(r *http.Request, tenant, rootJTI, jti, reason string) {
+	if s == nil || s.auditExporter == nil {
+		return
+	}
+	extra := map[string]string{
+		"jti":      strings.TrimSpace(jti),
+		"root_jti": strings.TrimSpace(rootJTI),
+		"outcome":  "ok",
+	}
+	if trim := strings.TrimSpace(reason); trim != "" {
+		extra["reason"] = trim
+	}
+	s.auditExporter.Send(audit.SIEMEvent{
+		Timestamp: time.Now().UTC(),
+		EventType: audit.EventSystemAuth,
+		Severity:  audit.SeverityInfo,
+		TenantID:  tenant,
+		Action:    "delegation.revoked",
+		Reason:    "delegation revoked",
+		Identity:  policyActorID(r),
+		Extra:     extra,
+	})
+}
+
+func (s *server) delegationTokenService() (*delegation.TokenService, error) {
+	if s == nil || s.jobStore == nil || s.agentIdentityStore == nil {
+		return nil, fmt.Errorf("delegation token service unavailable")
+	}
+	signingKey, err := delegation.LoadSigningKeyFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	keyring, err := delegation.LoadVerificationKeysFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return delegation.NewTokenService(
+		signingKey,
+		keyring,
+		gatewayDelegationPermissionsResolver{store: s.agentIdentityStore},
+		delegation.NewRedisRevocationStoreFromClient(s.jobStore.Client()),
+	), nil
+}
+
+func (s *server) loadDelegationAgent(w http.ResponseWriter, r *http.Request, agentID, tenant string) (*store.AgentIdentity, bool) {
+	if s == nil || s.agentIdentityStore == nil {
+		writeErrorJSON(w, http.StatusServiceUnavailable, "service unavailable")
+		return nil, false
+	}
+	identity, err := s.agentIdentityStore.Get(r.Context(), agentID)
+	if err != nil {
+		writeInternalError(w, r, "load delegation agent", err)
+		return nil, false
+	}
+	if identity == nil {
+		writeErrorJSON(w, http.StatusNotFound, "agent identity not found")
+		return nil, false
+	}
+	if tenant != "" && identity.TenantID != tenant {
+		writeForbidden(w, r, errors.New("cross-tenant delegation denied"))
+		return nil, false
+	}
+	return identity, true
+}
+
+func (s *server) allowDelegationIssue(ctx context.Context, tenant, agentID string) bool {
+	if s == nil || s.jobStore == nil || s.jobStore.Client() == nil {
+		return true
+	}
+	key := fmt.Sprintf("delegation:issue:%s:%s:%s", strings.TrimSpace(tenant), strings.TrimSpace(agentID), time.Now().UTC().Format("200601021504"))
+	count, err := s.jobStore.Client().Incr(ctx, key).Result()
+	if err != nil {
+		return false
+	}
+	if count == 1 {
+		_ = s.jobStore.Client().Expire(ctx, key, 2*time.Minute).Err()
+	}
+	return count <= delegationIssueLimitPerMinute
+}
+
+func delegationIssueStatus(err error) int {
+	switch {
+	case errors.Is(err, delegation.ErrMalformed),
+		errors.Is(err, delegation.ErrExpired),
+		errors.Is(err, delegation.ErrNotYetValid),
+		errors.Is(err, delegation.ErrAudienceMismatch),
+		errors.Is(err, delegation.ErrChainTooDeep),
+		errors.Is(err, delegation.ErrScopeExceeded),
+		errors.Is(err, delegation.ErrRevoked),
+		errors.Is(err, delegation.ErrUnknownKeyId),
+		errors.Is(err, delegation.ErrBadSignature):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func delegationIssueMessage(err error) string {
+	code := delegation.ErrorCode(err)
+	if code != "" {
+		return code
+	}
+	return "delegation issue failed"
+}
+
+func (s *server) delegationListStore() *delegation.RedisListStore {
+	if s == nil || s.jobStore == nil {
+		return nil
+	}
+	return delegation.NewRedisListStoreFromClient(s.jobStore.Client())
+}
+
+func delegationIssuedView(tenant string, claims delegation.DelegationClaims, audience string) delegation.DelegationView {
+	rootIssuer := strings.TrimSpace(claims.Subject)
+	if len(claims.DelegationChain) > 0 {
+		if first := strings.TrimSpace(claims.DelegationChain[0].AgentID); first != "" {
+			rootIssuer = first
+		}
+	}
+	return delegation.DelegationView{
+		JTI:            strings.TrimSpace(claims.ID),
+		Tenant:         strings.TrimSpace(tenant),
+		Issuer:         rootIssuer,
+		Subject:        strings.TrimSpace(claims.Subject),
+		Audience:       strings.TrimSpace(audience),
+		AllowedActions: append([]string(nil), claims.AllowedActions...),
+		AllowedTopics:  append([]string(nil), claims.AllowedTopics...),
+		Chain:          append([]delegation.ChainLink(nil), claims.DelegationChain...),
+		ChainDepth:     claims.ChainDepth,
+		IssuedAt:       claims.IssuedAt.Time.UTC(),
+		ExpiresAt:      claims.ExpiresAt.Time.UTC(),
+		ParentJTI:      strings.TrimSpace(claims.ParentTokenJTI),
+	}
+}
+
+func (s *server) emitDelegationAudit(r *http.Request, action, tenant, agentID, target, jti string, chainDepth int, outcome string, err error) {
+	if s == nil || s.auditExporter == nil {
+		return
+	}
+	extra := map[string]string{
+		"outcome": outcome,
+	}
+	if target != "" {
+		extra["target"] = target
+	}
+	if jti != "" {
+		extra["jti"] = jti
+	}
+	if chainDepth > 0 {
+		extra["chain_depth"] = strconv.Itoa(chainDepth)
+	}
+	if code := delegation.ErrorCode(err); code != "" {
+		extra["error_code"] = code
+	}
+	s.auditExporter.Send(audit.SIEMEvent{
+		Timestamp: time.Now().UTC(),
+		EventType: audit.EventSystemAuth,
+		Severity:  delegationAuditSeverity(outcome),
+		TenantID:  tenant,
+		AgentID:   agentID,
+		Action:    "delegation." + action,
+		Reason:    delegationAuditReason(action, outcome, err),
+		Identity:  policyActorID(r),
+		Extra:     extra,
+	})
+}
+
+func delegationAuditSeverity(outcome string) string {
+	if outcome == "ok" {
+		return audit.SeverityInfo
+	}
+	return audit.SeverityMedium
+}
+
+func delegationAuditReason(action, outcome string, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return "delegation " + action + " " + outcome
+}

--- a/core/controlplane/gateway/handlers_delegation_list.go
+++ b/core/controlplane/gateway/handlers_delegation_list.go
@@ -35,7 +35,11 @@ func (s *server) handleListAgentDelegations(w http.ResponseWriter, r *http.Reque
 	}
 	page, err := store.ListByAgent(r.Context(), tenant, agentID, filter, cursor, limit)
 	if err != nil {
-		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		// The parse layer already returned 400 on invalid input; any
+		// error surfacing here is a store / Redis failure that the
+		// client did not cause. Return 503 so operators + clients can
+		// distinguish "bad request" from "infrastructure broken".
+		writeServiceUnavailable(w, r, "list agent delegations", err)
 		return
 	}
 	writeJSON(w, delegationListResponse{Items: page.Items, NextCursor: page.NextCursor})
@@ -57,16 +61,34 @@ func (s *server) handleListDelegations(w http.ResponseWriter, r *http.Request) {
 	}
 	page, err := store.ListAll(r.Context(), tenant, filter, cursor, limit)
 	if err != nil {
-		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		writeServiceUnavailable(w, r, "list delegations", err)
 		return
 	}
 	writeJSON(w, delegationListResponse{Items: page.Items, NextCursor: page.NextCursor})
 }
 
+// validDelegationStatuses enumerates the status filter values the list
+// store knows how to interpret (plus the empty value, which is the
+// "no filter" sentinel). Kept in sync with matchesDelegationFilter in
+// core/auth/delegation/list_store.go — unknown values would silently
+// match nothing there, which would masquerade as a valid empty page.
+var validDelegationStatuses = map[string]struct{}{
+	"":        {},
+	"all":     {},
+	"active":  {},
+	"revoked": {},
+	"expired": {},
+}
+
 func parseDelegationListParams(w http.ResponseWriter, r *http.Request) (delegation.DelegationListFilter, int, string, bool) {
 	q := r.URL.Query()
+	status := strings.ToLower(strings.TrimSpace(q.Get("status")))
+	if _, valid := validDelegationStatuses[status]; !valid {
+		writeErrorJSON(w, http.StatusBadRequest, "status must be one of: all, active, revoked, expired")
+		return delegation.DelegationListFilter{}, 0, "", false
+	}
 	filter := delegation.DelegationListFilter{
-		Status: strings.TrimSpace(q.Get("status")),
+		Status: status,
 		Scope:  strings.TrimSpace(q.Get("scope")),
 	}
 	if raw := strings.TrimSpace(q.Get("before_expiry")); raw != "" {

--- a/core/controlplane/gateway/handlers_delegation_list.go
+++ b/core/controlplane/gateway/handlers_delegation_list.go
@@ -1,0 +1,106 @@
+package gateway
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+)
+
+type delegationListResponse struct {
+	Items      []delegation.DelegationView `json:"items"`
+	NextCursor string                      `json:"next_cursor,omitempty"`
+}
+
+func (s *server) handleListAgentDelegations(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePermissionOrRole(w, r, auth.PermDelegationRead, "admin") {
+		return
+	}
+	agentID, ok := requirePathParam(w, r, "id")
+	if !ok {
+		return
+	}
+	tenant := tenantFromRequest(r)
+	filter, limit, cursor, ok := parseDelegationListParams(w, r)
+	if !ok {
+		return
+	}
+	store := s.delegationListStore()
+	if store == nil {
+		writeErrorJSON(w, http.StatusServiceUnavailable, "service unavailable")
+		return
+	}
+	page, err := store.ListByAgent(r.Context(), tenant, agentID, filter, cursor, limit)
+	if err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, delegationListResponse{Items: page.Items, NextCursor: page.NextCursor})
+}
+
+func (s *server) handleListDelegations(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePermissionOrRole(w, r, auth.PermDelegationRead, "admin") {
+		return
+	}
+	tenant := tenantFromRequest(r)
+	filter, limit, cursor, ok := parseDelegationListParams(w, r)
+	if !ok {
+		return
+	}
+	store := s.delegationListStore()
+	if store == nil {
+		writeErrorJSON(w, http.StatusServiceUnavailable, "service unavailable")
+		return
+	}
+	page, err := store.ListAll(r.Context(), tenant, filter, cursor, limit)
+	if err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, delegationListResponse{Items: page.Items, NextCursor: page.NextCursor})
+}
+
+func parseDelegationListParams(w http.ResponseWriter, r *http.Request) (delegation.DelegationListFilter, int, string, bool) {
+	q := r.URL.Query()
+	filter := delegation.DelegationListFilter{
+		Status: strings.TrimSpace(q.Get("status")),
+		Scope:  strings.TrimSpace(q.Get("scope")),
+	}
+	if raw := strings.TrimSpace(q.Get("before_expiry")); raw != "" {
+		value, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			writeErrorJSON(w, http.StatusBadRequest, "before_expiry must be RFC3339")
+			return delegation.DelegationListFilter{}, 0, "", false
+		}
+		filter.BeforeExpiry = value.UTC()
+	}
+	if raw := strings.TrimSpace(q.Get("since_issued")); raw != "" {
+		value, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			writeErrorJSON(w, http.StatusBadRequest, "since_issued must be RFC3339")
+			return delegation.DelegationListFilter{}, 0, "", false
+		}
+		filter.SinceIssued = value.UTC()
+	}
+	if raw := strings.TrimSpace(q.Get("until_issued")); raw != "" {
+		value, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			writeErrorJSON(w, http.StatusBadRequest, "until_issued must be RFC3339")
+			return delegation.DelegationListFilter{}, 0, "", false
+		}
+		filter.UntilIssued = value.UTC()
+	}
+	limit := 50
+	if raw := strings.TrimSpace(q.Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > 200 {
+			writeErrorJSON(w, http.StatusBadRequest, "limit must be between 1 and 200")
+			return delegation.DelegationListFilter{}, 0, "", false
+		}
+		limit = parsed
+	}
+	return filter, limit, strings.TrimSpace(q.Get("cursor")), true
+}

--- a/core/controlplane/gateway/handlers_delegation_list_test.go
+++ b/core/controlplane/gateway/handlers_delegation_list_test.go
@@ -1,0 +1,212 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/licensing"
+)
+
+func TestHandleListDelegationsFiltersAndPagination(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.RBAC = true
+	})
+	putTestRole(t, s, "delegation-reader", auth.PermDelegationRead)
+	putTestRole(t, s, "restricted", auth.PermJobsRead)
+
+	store := s.delegationListStore()
+	now := time.Now().UTC()
+	seedDelegationView(t, store, delegation.DelegationView{
+		JTI:            "dlg-active",
+		Tenant:         "default",
+		Issuer:         "agent-a",
+		Subject:        "agent-a",
+		Audience:       "agent-b",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.alpha"},
+		Chain:          []delegation.ChainLink{{AgentID: "agent-a"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+	})
+	seedDelegationView(t, store, delegation.DelegationView{
+		JTI:            "dlg-revoked",
+		Tenant:         "default",
+		Issuer:         "agent-a",
+		Subject:        "agent-a",
+		Audience:       "agent-c",
+		AllowedActions: []string{"deploy"},
+		AllowedTopics:  []string{"job.beta"},
+		Chain:          []delegation.ChainLink{{AgentID: "agent-a"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-2 * time.Minute),
+		ExpiresAt:      now.Add(2 * time.Hour),
+		Revoked:        true,
+		RevokedAt:      now.Add(-30 * time.Second),
+		RevokedReason:  "manual",
+	})
+	seedDelegationView(t, store, delegation.DelegationView{
+		JTI:            "dlg-expired",
+		Tenant:         "default",
+		Issuer:         "agent-z",
+		Subject:        "agent-z",
+		Audience:       "agent-y",
+		AllowedActions: []string{"delete"},
+		AllowedTopics:  []string{"job.gamma"},
+		Chain:          []delegation.ChainLink{{AgentID: "agent-z"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-3 * time.Minute),
+		ExpiresAt:      now.Add(-time.Minute),
+	})
+	seedDelegationView(t, store, delegation.DelegationView{
+		JTI:            "dlg-other",
+		Tenant:         "other",
+		Issuer:         "other-agent",
+		Subject:        "other-agent",
+		Audience:       "other-target",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.other"},
+		Chain:          []delegation.ChainLink{{AgentID: "other-agent"}},
+		ChainDepth:     1,
+		IssuedAt:       now,
+		ExpiresAt:      now.Add(time.Hour),
+	})
+
+	rr := delegationList(t, s, "/api/v1/delegations?status=revoked&limit=10", "delegation-reader")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	page := decodeDelegationListPage(t, rr)
+	if len(page.Items) != 1 || page.Items[0].JTI != "dlg-revoked" {
+		t.Fatalf("unexpected revoked page: %#v", page)
+	}
+
+	rr = delegationList(t, s, "/api/v1/delegations?scope=ploy", "delegation-reader")
+	page = decodeDelegationListPage(t, rr)
+	if len(page.Items) != 1 || page.Items[0].JTI != "dlg-revoked" {
+		t.Fatalf("unexpected scope page: %#v", page)
+	}
+
+	rr = delegationList(t, s, "/api/v1/delegations?before_expiry="+now.Add(5*time.Minute).Format(time.RFC3339), "delegation-reader")
+	page = decodeDelegationListPage(t, rr)
+	if len(page.Items) != 1 || page.Items[0].JTI != "dlg-expired" {
+		t.Fatalf("unexpected before_expiry page: %#v", page)
+	}
+
+	rr = delegationList(t, s, "/api/v1/delegations?limit=1", "delegation-reader")
+	page = decodeDelegationListPage(t, rr)
+	if len(page.Items) != 1 || page.NextCursor == "" {
+		t.Fatalf("expected paginated page, got %#v", page)
+	}
+	rr = delegationList(t, s, "/api/v1/delegations?limit=1&cursor="+page.NextCursor, "delegation-reader")
+	page2 := decodeDelegationListPage(t, rr)
+	if len(page2.Items) != 1 || page2.Items[0].JTI == page.Items[0].JTI {
+		t.Fatalf("unexpected second page: %#v", page2)
+	}
+}
+
+func TestHandleListAgentDelegationsAndRBAC(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.RBAC = true
+	})
+	putTestRole(t, s, "delegation-reader", auth.PermDelegationRead)
+
+	store := s.delegationListStore()
+	now := time.Now().UTC()
+	seedDelegationView(t, store, delegation.DelegationView{
+		JTI:            "dlg-agent-a",
+		Tenant:         "default",
+		Issuer:         "agent-a",
+		Subject:        "agent-a",
+		Audience:       "agent-b",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.alpha"},
+		Chain:          []delegation.ChainLink{{AgentID: "agent-a"}},
+		ChainDepth:     1,
+		IssuedAt:       now,
+		ExpiresAt:      now.Add(time.Hour),
+	})
+	seedDelegationView(t, store, delegation.DelegationView{
+		JTI:            "dlg-agent-z",
+		Tenant:         "default",
+		Issuer:         "agent-z",
+		Subject:        "agent-z",
+		Audience:       "agent-y",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.alpha"},
+		Chain:          []delegation.ChainLink{{AgentID: "agent-z"}},
+		ChainDepth:     1,
+		IssuedAt:       now.Add(-time.Minute),
+		ExpiresAt:      now.Add(time.Hour),
+	})
+
+	req := withAuth(httptest.NewRequest(http.MethodGet, "/api/v1/agents/agent-a/delegations", nil), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "reader",
+		Role:        "delegation-reader",
+	})
+	req.SetPathValue("id", "agent-a")
+	rr := httptest.NewRecorder()
+	s.handleListAgentDelegations(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	page := decodeDelegationListPage(t, rr)
+	if len(page.Items) != 1 || page.Items[0].JTI != "dlg-agent-a" {
+		t.Fatalf("unexpected agent page: %#v", page)
+	}
+
+	deniedReq := withAuth(httptest.NewRequest(http.MethodGet, "/api/v1/delegations", nil), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "viewer",
+		Role:        "restricted",
+	})
+	deniedRec := httptest.NewRecorder()
+	s.handleListDelegations(deniedRec, deniedReq)
+	if deniedRec.Code != http.StatusForbidden {
+		t.Fatalf("expected forbidden without delegation permission, got %d", deniedRec.Code)
+	}
+}
+
+func seedDelegationView(t *testing.T, store *delegation.RedisListStore, view delegation.DelegationView) {
+	t.Helper()
+	if err := store.RecordIssuedToken(context.Background(), view); err != nil {
+		t.Fatalf("RecordIssuedToken(%s) error = %v", view.JTI, err)
+	}
+	if view.Revoked {
+		if err := store.MarkRevoked(context.Background(), view.Tenant, view.JTI, view.RevokedReason, view.RevokedAt); err != nil {
+			t.Fatalf("MarkRevoked(%s) error = %v", view.JTI, err)
+		}
+	}
+}
+
+func delegationList(t *testing.T, s *server, path, role string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := withAuth(httptest.NewRequest(http.MethodGet, path, nil), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "reader",
+		Role:        role,
+	})
+	rr := httptest.NewRecorder()
+	s.handleListDelegations(rr, req)
+	return rr
+}
+
+func decodeDelegationListPage(t *testing.T, rr *httptest.ResponseRecorder) delegationListResponse {
+	t.Helper()
+	var page delegationListResponse
+	if err := json.NewDecoder(rr.Body).Decode(&page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	return page
+}

--- a/core/controlplane/gateway/handlers_delegation_test.go
+++ b/core/controlplane/gateway/handlers_delegation_test.go
@@ -1,0 +1,518 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/infra/store"
+	"github.com/cordum/cordum/core/licensing"
+)
+
+func setDelegationKeys(t *testing.T) delegation.SigningKey {
+	t.Helper()
+
+	signingKey, err := delegation.GenerateSigningKey("dlg-1")
+	if err != nil {
+		t.Fatalf("GenerateSigningKey() error = %v", err)
+	}
+	privatePEM, err := delegation.EncodePrivateKeyPEM(signingKey.PrivateKey)
+	if err != nil {
+		t.Fatalf("EncodePrivateKeyPEM() error = %v", err)
+	}
+	publicKey, err := delegation.EncodePublicKeyBase64(signingKey.PublicKey())
+	if err != nil {
+		t.Fatalf("EncodePublicKeyBase64() error = %v", err)
+	}
+	t.Setenv("CORDUM_DELEGATION_PRIVATE_KEY", string(privatePEM))
+	t.Setenv("CORDUM_DELEGATION_PUBLIC_KEY_DLG_1", publicKey)
+	t.Setenv("CORDUM_DELEGATION_KEY_ID", "dlg-1")
+	return signingKey
+}
+
+func createDelegationAgent(t *testing.T, s *server, tenant, id string, actions, topics []string) *store.AgentIdentity {
+	t.Helper()
+
+	created, err := s.agentIdentityStore.Create(context.Background(), store.AgentIdentity{
+		ID:            id,
+		TenantID:      tenant,
+		Name:          id,
+		Owner:         "admin",
+		RiskTier:      "low",
+		Status:        "active",
+		AllowedTools:  actions,
+		AllowedTopics: topics,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	return created
+}
+
+func TestHandleDelegateAgentIssuesTokenAndAudits(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+	})
+	setDelegationKeys(t)
+	sink := &recordingAuditSender{}
+	s.auditExporter = sink
+
+	delegating := createDelegationAgent(t, s, "default", "agent-a", []string{"read", "write"}, []string{"job.alpha"})
+	target := createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.alpha"})
+
+	body := bytes.NewBufferString(`{"target_agent_id":"` + target.ID + `","allowed_actions":["read"],"allowed_topics":["job.alpha"]}`)
+	req := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+delegating.ID+"/delegate", body))
+	req.SetPathValue("id", delegating.ID)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleDelegateAgent(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp delegateTokenResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Token == "" || resp.KID != "dlg-1" || resp.ChainDepth != 1 || resp.JTI == "" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	verified, err := service.VerifyDelegationToken(context.Background(), resp.Token, target.ID)
+	if err != nil {
+		t.Fatalf("VerifyDelegationToken() error = %v", err)
+	}
+	if verified.Subject != delegating.ID || verified.Audience != target.ID {
+		t.Fatalf("verified token = %+v", verified)
+	}
+	if len(sink.events) == 0 {
+		t.Fatal("expected delegation audit event")
+	}
+	event := sink.events[len(sink.events)-1]
+	if event.Action != "delegation.issue" || event.Extra["outcome"] != "ok" || event.Extra["target"] != target.ID {
+		t.Fatalf("unexpected audit event: %+v", event)
+	}
+}
+
+func TestHandleDelegateAgentRequiresMatchingPrincipalOrAdmin(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+		entitlements.RBAC = true
+	})
+	setDelegationKeys(t)
+	putTestRole(t, s, "delegator", auth.PermAgentsDelegate)
+
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.alpha"})
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-a/delegate", strings.NewReader(`{"target_agent_id":"agent-b","allowed_actions":["read"],"allowed_topics":["job.alpha"]}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "someone-else",
+		Role:        "delegator",
+	})
+	req.SetPathValue("id", "agent-a")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleDelegateAgent(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDelegateAgentCrossTenantAndScopeErrors(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+	})
+	setDelegationKeys(t)
+
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read", "write"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "other", "agent-x", []string{"read"}, []string{"job.alpha"})
+
+	req := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-a/delegate", strings.NewReader(`{"target_agent_id":"agent-x","allowed_actions":["read"],"allowed_topics":["job.alpha"]}`)))
+	req.SetPathValue("id", "agent-a")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.handleDelegateAgent(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-tenant status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read", "write"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-c", []string{"read"}, []string{"job.alpha"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	parentToken, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	scopeReq := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-b/delegate", strings.NewReader(`{"target_agent_id":"agent-c","allowed_actions":["write"],"allowed_topics":["job.alpha"],"parent_token":"`+parentToken+`"}`)))
+	scopeReq.SetPathValue("id", "agent-b")
+	scopeReq.Header.Set("Content-Type", "application/json")
+	scopeRec := httptest.NewRecorder()
+	s.handleDelegateAgent(scopeRec, scopeReq)
+	if scopeRec.Code != http.StatusBadRequest || !strings.Contains(scopeRec.Body.String(), "scope_exceeded") {
+		t.Fatalf("scope status=%d body=%s", scopeRec.Code, scopeRec.Body.String())
+	}
+}
+
+func TestHandleDelegateAgentRejectsTooDeepChain(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+	})
+	setDelegationKeys(t)
+
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read", "write"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read", "write"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-c", []string{"read"}, []string{"job.alpha"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	tokenAB, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken(ab) error = %v", err)
+	}
+	tokenBC, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-b",
+		TargetAgentID:     "agent-c",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       tokenAB,
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken(bc) error = %v", err)
+	}
+	tokenCB, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-c",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       tokenBC,
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken(cb) error = %v", err)
+	}
+
+	req := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-b/delegate", strings.NewReader(`{"target_agent_id":"agent-a","allowed_actions":["read"],"allowed_topics":["job.alpha"],"parent_token":"`+tokenCB+`"}`)))
+	req.SetPathValue("id", "agent-b")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.handleDelegateAgent(rec, req)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "chain_too_deep") {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleVerifyAndRevokeDelegationStructuredVerdicts(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+	})
+	setDelegationKeys(t)
+	sink := &recordingAuditSender{}
+	s.auditExporter = sink
+
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.alpha"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	verifyReq := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/verify-delegation", strings.NewReader(`{"token":"`+token+`","expected_audience":"agent-x"}`)))
+	verifyReq.Header.Set("Content-Type", "application/json")
+	verifyRec := httptest.NewRecorder()
+	s.handleVerifyDelegation(verifyRec, verifyReq)
+	if verifyRec.Code != http.StatusOK {
+		t.Fatalf("verify status=%d body=%s", verifyRec.Code, verifyRec.Body.String())
+	}
+	var invalidResp verifyDelegationResponse
+	if err := json.NewDecoder(verifyRec.Body).Decode(&invalidResp); err != nil {
+		t.Fatalf("decode invalid verify response: %v", err)
+	}
+	if invalidResp.Valid || invalidResp.ErrorCode != "audience_mismatch" {
+		t.Fatalf("unexpected invalid response: %+v", invalidResp)
+	}
+
+	revokeReq := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/revoke-delegation", strings.NewReader(`{"jti":"`+service.KeyID()+`"}`)))
+	revokeReq.Header.Set("Content-Type", "application/json")
+	// revoke the actual token jti
+	verified, err := service.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if err != nil {
+		t.Fatalf("VerifyDelegationToken() error = %v", err)
+	}
+	if err := s.delegationListStore().RecordIssuedToken(context.Background(), delegation.DelegationView{
+		JTI:            verified.JTI,
+		Tenant:         "default",
+		Issuer:         "agent-a",
+		Subject:        verified.Subject,
+		Audience:       verified.Audience,
+		AllowedActions: append([]string(nil), verified.AllowedActions...),
+		AllowedTopics:  append([]string(nil), verified.AllowedTopics...),
+		Chain:          append([]delegation.ChainLink(nil), verified.DelegationChain...),
+		ChainDepth:     verified.ChainDepth,
+		IssuedAt:       verified.IssuedAt,
+		ExpiresAt:      verified.ExpiresAt,
+		ParentJTI:      verified.ParentTokenJTI,
+	}); err != nil {
+		t.Fatalf("RecordIssuedToken() error = %v", err)
+	}
+	revokeReq = adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/revoke-delegation", strings.NewReader(`{"jti":"`+verified.JTI+`"}`)))
+	revokeReq.Header.Set("Content-Type", "application/json")
+	revokeRec := httptest.NewRecorder()
+	s.handleRevokeDelegation(revokeRec, revokeReq)
+	if revokeRec.Code != http.StatusOK {
+		t.Fatalf("revoke status=%d body=%s", revokeRec.Code, revokeRec.Body.String())
+	}
+	var revokeResp revokeDelegationResponse
+	if err := json.NewDecoder(revokeRec.Body).Decode(&revokeResp); err != nil {
+		t.Fatalf("decode revoke response: %v", err)
+	}
+	if revokeResp.JTI != verified.JTI || revokeResp.CascadedCount != 0 {
+		t.Fatalf("unexpected revoke response: %+v", revokeResp)
+	}
+
+	verifyValidReq := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/verify-delegation", strings.NewReader(`{"token":"`+token+`","expected_audience":"agent-b"}`)))
+	verifyValidReq.Header.Set("Content-Type", "application/json")
+	verifyValidRec := httptest.NewRecorder()
+	s.handleVerifyDelegation(verifyValidRec, verifyValidReq)
+	if verifyValidRec.Code != http.StatusOK {
+		t.Fatalf("verify revoked status=%d body=%s", verifyValidRec.Code, verifyValidRec.Body.String())
+	}
+	var revokedResp verifyDelegationResponse
+	if err := json.NewDecoder(verifyValidRec.Body).Decode(&revokedResp); err != nil {
+		t.Fatalf("decode revoked response: %v", err)
+	}
+	if revokedResp.Valid || revokedResp.ErrorCode != "revoked" {
+		t.Fatalf("unexpected revoked response: %+v", revokedResp)
+	}
+
+	if len(sink.events) < 3 {
+		t.Fatalf("expected verify+revoke audit events, got %d", len(sink.events))
+	}
+}
+
+func TestHandleRevokeDelegationCascadesAndAudits(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+	})
+	setDelegationKeys(t)
+	sink := &recordingAuditSender{}
+	s.auditExporter = sink
+
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-c", []string{"read"}, []string{"job.alpha"})
+	createDelegationAgent(t, s, "default", "agent-d", []string{"read"}, []string{"job.alpha"})
+
+	tokenAB, verifiedAB := issueDelegationTokenForTests(t, s, delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+	}, "agent-b")
+	tokenBC, _ := issueDelegationTokenForTests(t, s, delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-b",
+		TargetAgentID:     "agent-c",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       tokenAB,
+	}, "agent-c")
+	_, verifiedCD := issueDelegationTokenForTests(t, s, delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-c",
+		TargetAgentID:     "agent-d",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.alpha"},
+		ParentToken:       tokenBC,
+	}, "agent-d")
+
+	revokeReq := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/revoke-delegation", strings.NewReader(`{"jti":"`+verifiedAB.JTI+`","reason":"compromised"}`)))
+	revokeReq.Header.Set("Content-Type", "application/json")
+	revokeRec := httptest.NewRecorder()
+	s.handleRevokeDelegation(revokeRec, revokeReq)
+	if revokeRec.Code != http.StatusOK {
+		t.Fatalf("revoke status=%d body=%s", revokeRec.Code, revokeRec.Body.String())
+	}
+	var revokeResp revokeDelegationResponse
+	if err := json.NewDecoder(revokeRec.Body).Decode(&revokeResp); err != nil {
+		t.Fatalf("decode cascade revoke response: %v", err)
+	}
+	if revokeResp.CascadedCount != 2 {
+		t.Fatalf("unexpected cascade revoke response: %+v", revokeResp)
+	}
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	if _, err := service.VerifyDelegationToken(context.Background(), tokenBC, "agent-c"); err != delegation.ErrRevoked {
+		t.Fatalf("expected child token to be revoked, got %v", err)
+	}
+	if _, err := service.VerifyDelegationToken(context.Background(), verifiedCD.Token, "agent-d"); err != delegation.ErrRevoked {
+		t.Fatalf("expected grandchild token to be revoked, got %v", err)
+	}
+
+	if !hasDelegationAuditAction(sink.events, "delegation.revoked_cascade") {
+		t.Fatalf("expected cascade audit event, got %#v", sink.events)
+	}
+	if got := countDelegationAuditAction(sink.events, "delegation.revoked"); got != 2 {
+		t.Fatalf("expected 2 descendant revoked audit events, got %d", got)
+	}
+	if !hasDelegationAuditAction(sink.events, "delegation.revoke") {
+		t.Fatalf("expected root revoke audit event, got %#v", sink.events)
+	}
+}
+
+func TestHandleRevokeDelegationReturnsNotFoundForUnknownJTI(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+	})
+	setDelegationKeys(t)
+
+	req := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/revoke-delegation", strings.NewReader(`{"jti":"missing"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.handleRevokeDelegation(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown jti, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleDelegateAgentRejectsOverflowTTL guards the `ttl_seconds`
+// multiplication overflow path. Without the pre-multiplication bound,
+// `time.Duration(req.TTLSeconds) * time.Second` wraps int64 nanoseconds
+// into a negative duration that would sneak past the service-layer
+// maxTTL check (which tests `ttl > maxTTL`) and mint a token with
+// unbounded lifetime.
+func TestHandleDelegateAgentRejectsOverflowTTL(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.AgentIdentity = true
+	})
+	setDelegationKeys(t)
+
+	delegating := createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.alpha"})
+	target := createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.alpha"})
+
+	// math.MaxInt64 would overflow int64 nanoseconds when multiplied by
+	// time.Second; the handler must reject before the multiplication.
+	body := bytes.NewBufferString(`{"target_agent_id":"` + target.ID + `","allowed_actions":["read"],"allowed_topics":["job.alpha"],"ttl_seconds":9223372036854775000}`)
+	req := adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+delegating.ID+"/delegate", body))
+	req.SetPathValue("id", delegating.ID)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleDelegateAgent(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on overflow ttl_seconds, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "ttl_seconds") {
+		t.Fatalf("expected ttl_seconds error message, got: %s", rec.Body.String())
+	}
+
+	// One-year-plus-one-second is also rejected — 1 year is the documented
+	// pre-multiplication cap.
+	body = bytes.NewBufferString(`{"target_agent_id":"` + target.ID + `","allowed_actions":["read"],"allowed_topics":["job.alpha"],"ttl_seconds":31536001}`)
+	req = adminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+delegating.ID+"/delegate", body))
+	req.SetPathValue("id", delegating.ID)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+
+	s.handleDelegateAgent(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on >1yr ttl_seconds, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func issueDelegationTokenForTests(t *testing.T, s *server, req delegation.IssueRequest, expectedAudience string) (string, delegation.VerifiedToken) {
+	t.Helper()
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, claims, err := service.IssueDelegationToken(context.Background(), req)
+	if err != nil {
+		t.Fatalf("IssueDelegationToken(%s->%s) error = %v", req.DelegatingAgentID, req.TargetAgentID, err)
+	}
+	if err := s.delegationListStore().RecordIssuedToken(context.Background(), delegationIssuedView(req.Tenant, claims, req.TargetAgentID)); err != nil {
+		t.Fatalf("RecordIssuedToken(%s) error = %v", claims.ID, err)
+	}
+	verified, err := service.VerifyDelegationToken(context.Background(), token, expectedAudience)
+	if err != nil {
+		t.Fatalf("VerifyDelegationToken(%s) error = %v", claims.ID, err)
+	}
+	return token, verified
+}
+
+func hasDelegationAuditAction(events []audit.SIEMEvent, action string) bool {
+	return countDelegationAuditAction(events, action) > 0
+}
+
+func countDelegationAuditAction(events []audit.SIEMEvent, action string) int {
+	count := 0
+	for _, event := range events {
+		if event.Action == action {
+			count++
+		}
+	}
+	return count
+}

--- a/core/controlplane/gateway/handlers_jobs.go
+++ b/core/controlplane/gateway/handlers_jobs.go
@@ -1662,6 +1662,28 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 		meta.Labels["agent_id"] = authDerivedAgentID
 	}
 
+	// Gate delegation audience override. When the caller supplies an
+	// explicit delegation_audience_agent_id that differs from the
+	// auth-derived agent_id, they are asking the gateway to verify a
+	// token whose audience is a DIFFERENT agent — effectively
+	// impersonating that agent at delegation-verification time.
+	// Without a permission gate, any caller could widen their own
+	// identity by pointing the audience at a more-privileged agent.
+	// Require PermDelegationImpersonate (or admin) for this path and
+	// audit every denial.
+	audienceOverride := strings.TrimSpace(req.DelegationAudienceAgentID)
+	if audienceOverride != "" && audienceOverride != authDerivedAgentID {
+		if !s.requirePermissionOrRole(w, r, auth.PermDelegationImpersonate, "admin") {
+			actorID, role := "anonymous", "none"
+			if ac := auth.FromRequest(r); ac != nil {
+				actorID, role = ac.PrincipalID, ac.Role
+			}
+			s.appendAuditEntryNamed(r.Context(), "submit_delegation_impersonation_denied", "job", "", req.Topic, actorID, role,
+				"delegation audience override denied: caller agent_id "+authDerivedAgentID+" requested audience "+audienceOverride+" without "+auth.PermDelegationImpersonate)
+			return
+		}
+	}
+
 	if req.Labels, err = s.applySubmitDelegationWithAudience(r.Context(), orgID, req.Labels["agent_id"], req.DelegationToken, req.DelegationAudienceAgentID, req.Labels, meta); err != nil {
 		s.emitSubmitDelegationRejectedAudit(r, jobID, req.Topic, req.Labels["agent_id"], err)
 		status, message := submitDelegationErrorStatus(err)

--- a/core/controlplane/gateway/handlers_jobs.go
+++ b/core/controlplane/gateway/handlers_jobs.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
 	"github.com/cordum/cordum/core/controlplane/scheduler"
 	"github.com/cordum/cordum/core/controlplane/topicregistry"
 	"github.com/cordum/cordum/core/infra/artifacts"
@@ -55,27 +56,108 @@ func safeUnmarshal(data []byte, v any, field, jobID string) bool {
 	return true
 }
 
+func hasDelegationLineage(lineage model.DelegationLineage) bool {
+	return strings.TrimSpace(lineage.TokenJTI) != "" ||
+		strings.TrimSpace(lineage.Audience) != "" ||
+		strings.TrimSpace(lineage.RootIssuer) != "" ||
+		strings.TrimSpace(lineage.ParentIssuer) != "" ||
+		strings.TrimSpace(lineage.ExpiresAt) != "" ||
+		lineage.ChainDepth > 0 ||
+		len(lineage.IssuerChain) > 0 ||
+		len(lineage.Scope) > 0 ||
+		lineage.VerifiedAt > 0
+}
+
+func delegationLineageResponse(lineage model.DelegationLineage) map[string]any {
+	chain := make([]map[string]any, 0, len(lineage.IssuerChain))
+	for _, link := range lineage.IssuerChain {
+		item := map[string]any{}
+		if agentID := strings.TrimSpace(link.AgentID); agentID != "" {
+			item["agent_id"] = agentID
+		}
+		if issuedAt := strings.TrimSpace(link.IssuedAt); issuedAt != "" {
+			item["issued_at"] = issuedAt
+		}
+		if expiresAt := strings.TrimSpace(link.ExpiresAt); expiresAt != "" {
+			item["expires_at"] = expiresAt
+		}
+		if jti := strings.TrimSpace(link.JTI); jti != "" {
+			item["jti"] = jti
+		}
+		if parentJTI := strings.TrimSpace(link.ParentJTI); parentJTI != "" {
+			item["parent_jti"] = parentJTI
+		}
+		if len(item) > 0 {
+			chain = append(chain, item)
+		}
+	}
+
+	resp := map[string]any{
+		"chain_depth":            lineage.ChainDepth,
+		"chain":                  chain,
+		"scope":                  append([]string(nil), lineage.Scope...),
+		"verified_at":            lineage.VerifiedAt,
+		"reverified_at_dispatch": lineage.VerifiedAt > 0,
+	}
+	if jti := strings.TrimSpace(lineage.TokenJTI); jti != "" {
+		resp["jti"] = jti
+	}
+	if audience := strings.TrimSpace(lineage.Audience); audience != "" {
+		resp["audience"] = audience
+	}
+	if rootIssuer := strings.TrimSpace(lineage.RootIssuer); rootIssuer != "" {
+		resp["root_issuer"] = rootIssuer
+	}
+	if parentIssuer := strings.TrimSpace(lineage.ParentIssuer); parentIssuer != "" {
+		resp["parent_issuer"] = parentIssuer
+	}
+	if expiresAt := strings.TrimSpace(lineage.ExpiresAt); expiresAt != "" {
+		resp["expires_at"] = expiresAt
+	}
+	return resp
+}
+
 // --- Handlers ---
 
 func (s *server) handleGetWorkers(w http.ResponseWriter, r *http.Request) {
-	if err := s.requireRole(r, "admin"); err != nil {
-		writeForbidden(w, r, err)
+	if !s.requirePermissionOrRole(w, r, auth.PermWorkersRead, "admin") {
 		return
 	}
-	// Prefer Redis snapshot (consistent across all replicas).
-	workers, err := s.workersFromRedisSnapshot()
-	if err == nil && workers != nil {
+	// Prefer Redis snapshot (consistent across all replicas). The
+	// response shape layers session authority (online, session_valid,
+	// session_exp_ms, session_revoked, session_state) over the existing
+	// heartbeat telemetry fields. Legacy clients that read only the
+	// heartbeat-era fields (worker_id, pool, active_jobs, …) keep
+	// type-checking; new consumers get the demotion-era authority
+	// signal via "online".
+	snap, err := s.snapshotFromRedis()
+	if err == nil && snap != nil {
+		items := make([]map[string]any, 0, len(snap.Workers))
+		for _, ws := range snap.Workers {
+			items = append(items, s.workerStatusFromSummary(r.Context(), ws, snap.CapturedAt))
+		}
 		w.Header().Set("Content-Type", "application/json")
-		writeJSON(w, map[string]any{"items": workerSummariesToHeartbeats(workers)})
+		writeJSON(w, map[string]any{"items": items})
 		return
 	}
 	if err != nil {
 		slog.Warn("worker snapshot read failed, falling back to in-memory", "error", err)
 	}
 	// Fallback: in-memory heartbeat map (local replica only).
-	out := s.activeWorkersSnapshot(time.Now().UTC())
+	now := time.Now().UTC()
+	hbs := s.activeWorkersSnapshot(now)
+	items := make([]map[string]any, 0, len(hbs))
+	s.workerMu.RLock()
+	seenCopy := make(map[string]time.Time, len(s.workerSeen))
+	for id, t := range s.workerSeen {
+		seenCopy[id] = t
+	}
+	s.workerMu.RUnlock()
+	for _, hb := range hbs {
+		items = append(items, s.workerStatusResponse(r.Context(), hb, seenCopy[hb.GetWorkerId()]))
+	}
 	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, map[string]any{"items": out})
+	writeJSON(w, map[string]any{"items": items})
 }
 
 func (s *server) activeWorkersSnapshot(now time.Time) []*pb.Heartbeat {
@@ -110,6 +192,10 @@ func (s *server) activeWorkersSnapshot(now time.Time) []*pb.Heartbeat {
 }
 
 func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if !s.requireLicensePermission(w, r, licensing.BreakGlassPermissionSystemStatus) {
+		return
+	}
+
 	// Check cache first — avoids repeated Redis PING + snapshot reads on
 	// every dashboard poll (dashboard polls /api/v1/status every 5-10s).
 	if cached := s.statusCacheObj.Get(); cached != nil {
@@ -328,6 +414,9 @@ func (s *server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 		writeErrorJSON(w, http.StatusServiceUnavailable, "job store unavailable")
 		return
 	}
+	if !s.requirePermissionOrRole(w, r, auth.PermJobsRead) {
+		return
+	}
 	limit, _ := parsePagination(r, 50)
 	stateFilter := strings.ToUpper(r.URL.Query().Get("state"))
 	topicFilter := r.URL.Query().Get("topic")
@@ -413,6 +502,9 @@ func (s *server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleGetJob(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePermissionOrRole(w, r, auth.PermJobsRead) {
+		return
+	}
 	id, ok := requirePathParam(w, r, "id")
 	if !ok {
 		return
@@ -530,6 +622,7 @@ func (s *server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 	workflowID := ""
 	runID := ""
 	stepID := ""
+	var delegationLineage model.DelegationLineage
 	if s.jobStore != nil {
 		if req, err := s.jobStore.GetJobRequest(r.Context(), id); err == nil && req != nil {
 			if req.WorkflowId != "" {
@@ -545,6 +638,9 @@ func (s *server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 				runID = req.Labels["run_id"]
 				stepID = req.Labels["step_id"]
 			}
+		}
+		if lineage, err := s.jobStore.GetDelegationLineage(r.Context(), id); err == nil {
+			delegationLineage = lineage
 		}
 	}
 
@@ -660,12 +756,18 @@ func (s *server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 	if approvalRecord.Decision != "" {
 		resp["approval_decision"] = approvalRecord.Decision
 	}
+	if hasDelegationLineage(delegationLineage) {
+		resp["delegation"] = delegationLineageResponse(delegationLineage)
+	}
 	writeJSON(w, resp)
 }
 
 func (s *server) handleListJobDecisions(w http.ResponseWriter, r *http.Request) {
 	if s.jobStore == nil {
 		writeErrorJSON(w, http.StatusServiceUnavailable, "job store unavailable")
+		return
+	}
+	if !s.requirePermissionOrRole(w, r, auth.PermJobsRead) {
 		return
 	}
 	id, ok := requirePathParam(w, r, "id")
@@ -687,7 +789,7 @@ func (s *server) handleListJobDecisions(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
-	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.memStore) {
+	if !s.requireStoreAndPermissionOrRole(w, r, auth.PermMemoryRead, []string{"admin"}, s.memStore) {
 		return
 	}
 
@@ -728,7 +830,7 @@ func (s *server) handleGetMemory(w http.ResponseWriter, r *http.Request) {
 		ptr = store.PointerForKey(key)
 	}
 
-	if auth := authFromRequest(r); auth != nil {
+	if auth := auth.FromRequest(r); auth != nil {
 		slog.Info("memory read", "tenant", auth.Tenant, "principal", auth.PrincipalID, "key", key, "ptr", ptr)
 	} else {
 		slog.Info("memory read", "tenant", "", "principal", "", "key", key, "ptr", ptr)
@@ -984,14 +1086,14 @@ func (s *server) handlePutArtifact(w http.ResponseWriter, r *http.Request) {
 		Retention:   parseRetention(req.Retention),
 		Labels:      req.Labels,
 	}
-	auth := authFromRequest(r)
-	tenant := strings.TrimSpace(headerValue(r, "X-Tenant-ID"))
+	authCtx := auth.FromRequest(r)
+	tenant := strings.TrimSpace(auth.HeaderValue(r, "X-Tenant-ID"))
 	allowCrossTenant := false
-	if auth != nil {
-		if auth.Tenant != "" {
-			tenant = strings.TrimSpace(auth.Tenant)
+	if authCtx != nil {
+		if authCtx.Tenant != "" {
+			tenant = strings.TrimSpace(authCtx.Tenant)
 		}
-		allowCrossTenant = auth.AllowCrossTenant
+		allowCrossTenant = authCtx.AllowCrossTenant
 	}
 	if tenant != "" {
 		if meta.Labels == nil {
@@ -1053,14 +1155,14 @@ func (s *server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	auth := authFromRequest(r)
-	tenant := strings.TrimSpace(headerValue(r, "X-Tenant-ID"))
+	authCtx := auth.FromRequest(r)
+	tenant := strings.TrimSpace(auth.HeaderValue(r, "X-Tenant-ID"))
 	allowCrossTenant := false
-	if auth != nil {
-		if auth.Tenant != "" {
-			tenant = strings.TrimSpace(auth.Tenant)
+	if authCtx != nil {
+		if authCtx.Tenant != "" {
+			tenant = strings.TrimSpace(authCtx.Tenant)
 		}
-		allowCrossTenant = auth.AllowCrossTenant
+		allowCrossTenant = authCtx.AllowCrossTenant
 	}
 	if tenant != "" && !allowCrossTenant {
 		labelTenant := strings.TrimSpace(meta.Labels["tenant_id"])
@@ -1078,8 +1180,7 @@ func (s *server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleCancelJob(w http.ResponseWriter, r *http.Request) {
-	if err := s.requireRole(r, "admin"); err != nil {
-		writeForbidden(w, r, err)
+	if !s.requirePermissionOrRole(w, r, auth.PermJobsWrite, "admin") {
 		return
 	}
 	id, ok := requirePathParam(w, r, "id")
@@ -1169,8 +1270,7 @@ func (s *server) handleRemediateJob(w http.ResponseWriter, r *http.Request) {
 		writeErrorJSON(w, http.StatusServiceUnavailable, "job store or bus unavailable")
 		return
 	}
-	if err := s.requireRole(r, "admin"); err != nil {
-		writeForbidden(w, r, err)
+	if !s.requirePermissionOrRole(w, r, auth.PermJobsWrite, "admin") {
 		return
 	}
 	jobID, ok := requirePathParam(w, r, "id")
@@ -1328,16 +1428,14 @@ func (s *server) handleRemediateJob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
-	// RBAC: only admin and user roles may submit jobs.
-	// This matches the gRPC handler (SubmitJob) which also allows "admin"
-	// and "user" roles. Keep both in sync to avoid role asymmetry.
-	if err := s.requireRole(r, "admin", "user"); err != nil {
+	// RBAC: custom roles may submit when they hold jobs.write. When advanced
+	// RBAC is disabled, preserve the historical admin/user fallback.
+	if !s.requirePermissionOrRole(w, r, auth.PermJobsWrite, "admin", "user") {
 		actorID, role := "anonymous", "none"
-		if ac := authFromRequest(r); ac != nil {
+		if ac := auth.FromRequest(r); ac != nil {
 			actorID, role = ac.PrincipalID, ac.Role
 		}
-		s.appendAuditEntryNamed(r.Context(), "submit_denied", "job", "", "", actorID, role, "job submit denied: "+err.Error())
-		writeForbidden(w, r, err)
+		s.appendAuditEntryNamed(r.Context(), "submit_denied", "job", "", "", actorID, role, "job submit denied: permission or role check failed")
 		return
 	}
 
@@ -1545,6 +1643,14 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if req.Labels, err = s.applySubmitDelegationWithAudience(r.Context(), orgID, req.Labels["agent_id"], req.DelegationToken, req.DelegationAudienceAgentID, req.Labels, meta); err != nil {
+		s.emitSubmitDelegationRejectedAudit(r, jobID, req.Topic, req.Labels["agent_id"], err)
+		status, message := submitDelegationErrorStatus(err)
+		writeDelegationSubmitErrorJSON(w, status, message)
+		return
+	}
+	delegationExpectedAudience := submitDelegationExpectedAudience(req.Labels["agent_id"], req.DelegationAudienceAgentID)
+
 	// Inject job content into labels so the safety kernel's tag deriver can
 	// inspect the payload for server-side risk tag derivation.
 	req.Labels = injectContentLabels(req.Labels, req.Prompt, req.Context)
@@ -1584,7 +1690,7 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 		if policyResult.Reason != "" {
 			reason = policyResult.Reason
 		}
-		s.appendAuditEntryWithAgent(r.Context(), "submit_denied", "job", jobID, req.Topic, policyActorID(r), policyRole(r), "submit-time policy denied: "+reason, submitAgentID, submitAgentName, submitAgentRiskTier)
+		s.appendSubmitSafetyDecisionAudit(r.Context(), "submit_denied", jobID, req.Topic, policyActorID(r), policyRole(r), "submit-time policy denied: "+reason, policyResult, req.Labels, submitAgentID, submitAgentName, submitAgentRiskTier)
 		writeErrorJSON(w, http.StatusForbidden, reason)
 		return
 	}
@@ -1593,7 +1699,7 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 		if policyResult.Reason != "" {
 			reason = policyResult.Reason
 		}
-		s.appendAuditEntryWithAgent(r.Context(), "submit_throttled", "job", jobID, req.Topic, policyActorID(r), policyRole(r), "submit-time policy throttled: "+reason, submitAgentID, submitAgentName, submitAgentRiskTier)
+		s.appendSubmitSafetyDecisionAudit(r.Context(), "submit_throttled", jobID, req.Topic, policyActorID(r), policyRole(r), "submit-time policy throttled: "+reason, policyResult, req.Labels, submitAgentID, submitAgentName, submitAgentRiskTier)
 		w.Header().Set("Retry-After", "30")
 		writeErrorJSON(w, http.StatusTooManyRequests, reason)
 		return
@@ -1606,7 +1712,6 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 	if policyResult.ApprovalRequired {
 		slog.Info("submit-time policy requires approval",
 			"job_id", jobID, "topic", req.Topic, "reason", policyResult.Reason)
-		s.appendAuditEntryWithAgent(r.Context(), "submit_approval_required", "job", jobID, req.Topic, policyActorID(r), policyRole(r), "submit-time policy requires approval: "+policyResult.Reason, submitAgentID, submitAgentName, submitAgentRiskTier)
 
 		// Reserve idempotency key to prevent duplicate approval jobs.
 		if key != "" && s.jobStore != nil {
@@ -1701,6 +1806,12 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 			if err := s.jobStore.SetJobRequest(r.Context(), jobReq); err != nil {
 				slog.Error("failed to persist approval job request", "job_id", jobID, "error", err)
 			}
+			if err := s.persistSubmitDelegationToken(r.Context(), jobID, req.DelegationToken, delegationExpectedAudience); err != nil {
+				slog.Error("failed to persist approval delegation token", "job_id", jobID, "error", err)
+				_ = s.jobStore.SetState(r.Context(), jobID, model.JobStateFailed)
+				writeErrorJSON(w, http.StatusServiceUnavailable, "failed to persist delegation metadata")
+				return
+			}
 			if identity := submitterIdentity(r); identity != "" {
 				if err := s.jobStore.SetSubmittedBy(r.Context(), jobID, identity); err != nil {
 					slog.Error("failed to persist submitter identity for approval", "job_id", jobID, "error", err)
@@ -1727,6 +1838,7 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			s.syncApprovalQueueDepth(r.Context())
 		}
+		s.appendSubmitSafetyDecisionAudit(r.Context(), "submit_approval_required", jobID, req.Topic, policyActorID(r), policyRole(r), "submit-time policy requires approval: "+policyResult.Reason, policyResult, req.Labels, submitAgentID, submitAgentName, submitAgentRiskTier)
 
 		w.Header().Set("X-Trace-Id", traceID)
 		w.Header().Set("Content-Type", "application/json")
@@ -1861,6 +1973,12 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 			writeErrorJSON(w, http.StatusServiceUnavailable, "failed to persist job metadata")
 			return
 		}
+		if err := s.persistSubmitDelegationToken(r.Context(), jobID, req.DelegationToken, delegationExpectedAudience); err != nil {
+			slog.Error("failed to persist delegation token", "job_id", jobID, "error", err)
+			_ = s.jobStore.SetState(r.Context(), jobID, model.JobStateFailed)
+			writeErrorJSON(w, http.StatusServiceUnavailable, "failed to persist delegation metadata")
+			return
+		}
 		if identity := submitterIdentity(r); identity != "" {
 			if err := s.jobStore.SetSubmittedBy(r.Context(), jobID, identity); err != nil {
 				slog.Error("failed to persist submitter identity", "job_id", jobID, "error", err)
@@ -1893,7 +2011,7 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 		"topic", req.Topic,
 	)
 
-	s.appendAuditEntryNamed(r.Context(), "submit", "job", jobID, req.Topic, policyActorID(r), policyRole(r), "submit job "+jobID)
+	s.appendSubmitSafetyDecisionAudit(r.Context(), "submit", jobID, req.Topic, policyActorID(r), policyRole(r), "submit job "+jobID, policyResult, req.Labels, submitAgentID, submitAgentName, submitAgentRiskTier)
 	w.Header().Set("X-Trace-Id", traceID)
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]string{

--- a/core/controlplane/gateway/handlers_jobs.go
+++ b/core/controlplane/gateway/handlers_jobs.go
@@ -1629,18 +1629,37 @@ func (s *server) handleSubmitJobHTTP(w http.ResponseWriter, r *http.Request) {
 		meta.Labels = req.Labels
 	}
 
-	// Inject agent_id from linked worker credential if not already set.
-	if req.Labels["agent_id"] == "" && s.agentIdentityStore != nil {
+	// Bind agent_id to the authenticated principal. Never trust
+	// client-supplied labels.agent_id: a client that can reach this
+	// handler already has a worker credential, and that credential's
+	// agent identity is the only authoritative one. A mismatch between
+	// client-asserted and credential-derived agent_id is an
+	// impersonation attempt and rejects 403.
+	var authDerivedAgentID string
+	if s.agentIdentityStore != nil {
 		if agent, err := s.agentIdentityStore.GetByWorkerID(r.Context(), principalID); err == nil && agent != nil {
-			if req.Labels == nil {
-				req.Labels = map[string]string{}
-			}
-			req.Labels["agent_id"] = agent.ID
-			if meta.Labels == nil {
-				meta.Labels = map[string]string{}
-			}
-			meta.Labels["agent_id"] = agent.ID
+			authDerivedAgentID = agent.ID
 		}
+	}
+	if clientAgentID := req.Labels["agent_id"]; clientAgentID != "" {
+		if authDerivedAgentID == "" {
+			writeErrorJSON(w, http.StatusForbidden, "client-supplied agent_id requires an authenticated worker credential")
+			return
+		}
+		if clientAgentID != authDerivedAgentID {
+			writeErrorJSON(w, http.StatusForbidden, "client-supplied agent_id does not match authenticated principal")
+			return
+		}
+	}
+	if authDerivedAgentID != "" {
+		if req.Labels == nil {
+			req.Labels = map[string]string{}
+		}
+		req.Labels["agent_id"] = authDerivedAgentID
+		if meta.Labels == nil {
+			meta.Labels = map[string]string{}
+		}
+		meta.Labels["agent_id"] = authDerivedAgentID
 	}
 
 	if req.Labels, err = s.applySubmitDelegationWithAudience(r.Context(), orgID, req.Labels["agent_id"], req.DelegationToken, req.DelegationAudienceAgentID, req.Labels, meta); err != nil {

--- a/core/controlplane/gateway/integration_delegation_submit_test.go
+++ b/core/controlplane/gateway/integration_delegation_submit_test.go
@@ -1,0 +1,505 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/controlplane/scheduler"
+	infrabus "github.com/cordum/cordum/core/infra/bus"
+	"github.com/cordum/cordum/core/model"
+	capsdk "github.com/cordum/cordum/core/protocol/capsdk"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type integrationDelegationAuditSink struct {
+	mu     sync.Mutex
+	events []audit.SIEMEvent
+}
+
+type allowDelegationSafetyChecker struct{}
+
+func (allowDelegationSafetyChecker) Check(_ context.Context, req *pb.JobRequest) (scheduler.SafetyDecisionRecord, error) {
+	if req == nil || strings.TrimSpace(req.GetTopic()) == "" {
+		return scheduler.SafetyDecisionRecord{Decision: scheduler.SafetyDeny, Reason: "missing topic"}, nil
+	}
+	return scheduler.SafetyDecisionRecord{Decision: scheduler.SafetyAllow}, nil
+}
+
+func (s *integrationDelegationAuditSink) Send(event audit.SIEMEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+}
+
+func (s *integrationDelegationAuditSink) Emit(_ context.Context, event audit.SIEMEvent) {
+	s.Send(event)
+}
+
+func (s *integrationDelegationAuditSink) Close() error { return nil }
+
+func (s *integrationDelegationAuditSink) snapshot() []audit.SIEMEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]audit.SIEMEvent(nil), s.events...)
+}
+
+func (s *integrationDelegationAuditSink) countByType(eventType string) int {
+	count := 0
+	for _, event := range s.snapshot() {
+		if event.EventType == eventType {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *integrationDelegationAuditSink) firstByType(eventType string) (audit.SIEMEvent, bool) {
+	for _, event := range s.snapshot() {
+		if event.EventType == eventType {
+			return event, true
+		}
+	}
+	return audit.SIEMEvent{}, false
+}
+
+func newDelegationSubmitEngine(t *testing.T, bus *stubBus, jobStore storeBackedJobStore, sink *integrationDelegationAuditSink) *scheduler.Engine {
+	t.Helper()
+
+	registry := scheduler.NewMemoryRegistry()
+	t.Cleanup(registry.Close)
+	registry.UpdateHeartbeat(&pb.Heartbeat{
+		WorkerId:        "worker-target",
+		Pool:            "default",
+		ActiveJobs:      0,
+		MaxParallelJobs: 1,
+	})
+
+	engine := scheduler.NewEngine(
+		bus,
+		allowDelegationSafetyChecker{},
+		registry,
+		scheduler.NewLeastLoadedStrategy(scheduler.PoolRouting{
+			Topics: map[string][]string{
+				"job.test": {"default"},
+			},
+		}),
+		jobStore,
+		nil,
+	).WithDispatchAuditSink(sink)
+	t.Cleanup(engine.Stop)
+	return engine
+}
+
+type storeBackedJobStore interface {
+	scheduler.JobStore
+	GetDelegationLineage(ctx context.Context, jobID string) (model.DelegationLineage, error)
+	GetState(ctx context.Context, jobID string) (model.JobState, error)
+	GetFailureReason(ctx context.Context, jobID string) (string, error)
+	GetJobRequest(ctx context.Context, jobID string) (*pb.JobRequest, error)
+}
+
+func submitDelegatedJob(t *testing.T, s *server, principalID, token string) (string, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	body := `{"prompt":"hello","topic":"job.test","delegation_token":"` + token + `","labels":{"preferred_worker_id":"worker-target"}}`
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(body)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: principalID,
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "default")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+
+	jobID := ""
+	if rec.Code == http.StatusOK {
+		var resp struct {
+			JobID string `json:"job_id"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode submit response: %v", err)
+		}
+		jobID = resp.JobID
+		if strings.TrimSpace(jobID) == "" {
+			t.Fatalf("expected job_id in submit response, got %s", rec.Body.String())
+		}
+	}
+	return jobID, rec
+}
+
+func latestPublishedPacketForSubject(t *testing.T, bus *stubBus, subject string) *pb.BusPacket {
+	t.Helper()
+
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	for i := len(bus.published) - 1; i >= 0; i-- {
+		if bus.published[i].subject == subject {
+			return bus.published[i].packet
+		}
+	}
+	t.Fatalf("no published packet for subject %q; got %+v", subject, bus.published)
+	return nil
+}
+
+func issueThreeLinkSubmitToken(t *testing.T, s *server) (string, delegation.VerifiedToken) {
+	t.Helper()
+
+	tokenRootMiddle, _ := issueDelegationTokenForTests(t, s, delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "rootBot",
+		TargetAgentID:     "middleBot",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+	}, "middleBot")
+	tokenMiddleLeaf, _ := issueDelegationTokenForTests(t, s, delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "middleBot",
+		TargetAgentID:     "leafBot",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+		ParentToken:       tokenRootMiddle,
+	}, "leafBot")
+	return issueDelegationTokenForTests(t, s, delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "leafBot",
+		TargetAgentID:     "leafBot",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+		ParentToken:       tokenMiddleLeaf,
+	}, "leafBot")
+}
+
+func assertDelegationChain(t *testing.T, lineage model.DelegationLineage, want []string) {
+	t.Helper()
+
+	if lineage.ChainDepth != len(want) {
+		t.Fatalf("ChainDepth = %d, want %d", lineage.ChainDepth, len(want))
+	}
+	if len(lineage.IssuerChain) != len(want) {
+		t.Fatalf("IssuerChain length = %d, want %d", len(lineage.IssuerChain), len(want))
+	}
+	for i, wantAgentID := range want {
+		if got := lineage.IssuerChain[i].AgentID; got != wantAgentID {
+			t.Fatalf("IssuerChain[%d] = %q, want %q", i, got, wantAgentID)
+		}
+	}
+}
+
+func TestDelegationSubmitIntegration_ThreeLinkChainPersistsLineageAndAudits(t *testing.T) {
+	s, bus, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+	sink := &integrationDelegationAuditSink{}
+	s.auditExporter = sink
+
+	createDelegationAgent(t, s, "default", "rootBot", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "middleBot", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "leafBot", []string{"read"}, []string{"job.test"})
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "leafBot", "worker-leaf"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+
+	submitToken, verified := issueThreeLinkSubmitToken(t, s)
+	engine := newDelegationSubmitEngine(t, bus, s.jobStore, sink)
+
+	jobID, submitRec := submitDelegatedJob(t, s, "worker-leaf", submitToken)
+	if submitRec.Code != http.StatusOK {
+		t.Fatalf("submit status=%d body=%s", submitRec.Code, submitRec.Body.String())
+	}
+
+	if err := engine.HandlePacket(latestPublishedPacketForSubject(t, bus, capsdk.SubjectSubmit)); err != nil {
+		t.Fatalf("HandlePacket() error = %v", err)
+	}
+
+	ctx := context.Background()
+	state, err := s.jobStore.GetState(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetState() error = %v", err)
+	}
+	if state != model.JobStateRunning {
+		t.Fatalf("state = %q, want %q", state, model.JobStateRunning)
+	}
+
+	lineage, err := s.jobStore.GetDelegationLineage(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetDelegationLineage() error = %v", err)
+	}
+	assertDelegationChain(t, lineage, []string{"rootBot", "middleBot", "leafBot"})
+	if lineage.TokenJTI != verified.JTI {
+		t.Fatalf("TokenJTI = %q, want %q", lineage.TokenJTI, verified.JTI)
+	}
+	if lineage.Audience != "leafBot" {
+		t.Fatalf("Audience = %q, want leafBot", lineage.Audience)
+	}
+	if lineage.RootIssuer != "rootBot" {
+		t.Fatalf("RootIssuer = %q, want rootBot", lineage.RootIssuer)
+	}
+	if lineage.ParentIssuer != "leafBot" {
+		t.Fatalf("ParentIssuer = %q, want leafBot", lineage.ParentIssuer)
+	}
+
+	dispatchPacket := latestPublishedPacketForSubject(t, bus, infrabus.DirectSubject("worker-target"))
+	if dispatchPacket.GetJobRequest() == nil || dispatchPacket.GetJobRequest().GetJobId() != jobID {
+		t.Fatalf("expected direct dispatch for job %s, got %+v", jobID, dispatchPacket)
+	}
+
+	if sink.countByType(audit.EventSafetyDecision) != 1 || sink.countByType(audit.EventDelegationLineage) != 1 {
+		t.Fatalf("unexpected audit event counts: %#v", sink.snapshot())
+	}
+	decisionEvent, ok := sink.firstByType(audit.EventSafetyDecision)
+	if !ok {
+		t.Fatalf("missing %s event", audit.EventSafetyDecision)
+	}
+	if decisionEvent.Extra["delegation.depth"] != "3" {
+		t.Fatalf("delegation.depth = %q, want 3", decisionEvent.Extra["delegation.depth"])
+	}
+	if decisionEvent.Extra["delegation.root_issuer"] != "rootBot" {
+		t.Fatalf("delegation.root_issuer = %q, want rootBot", decisionEvent.Extra["delegation.root_issuer"])
+	}
+	if decisionEvent.Extra["delegation.parent_issuer"] != "leafBot" {
+		t.Fatalf("delegation.parent_issuer = %q, want leafBot", decisionEvent.Extra["delegation.parent_issuer"])
+	}
+	if decisionEvent.Extra["delegation.jti"] != verified.JTI {
+		t.Fatalf("delegation.jti = %q, want %q", decisionEvent.Extra["delegation.jti"], verified.JTI)
+	}
+
+	lineageEvent, ok := sink.firstByType(audit.EventDelegationLineage)
+	if !ok {
+		t.Fatalf("missing %s event", audit.EventDelegationLineage)
+	}
+	if lineageEvent.Extra["chain"] != "rootBot>middleBot>leafBot" {
+		t.Fatalf("chain = %q, want rootBot>middleBot>leafBot", lineageEvent.Extra["chain"])
+	}
+	if lineageEvent.Extra["chain_length"] != "3" {
+		t.Fatalf("chain_length = %q, want 3", lineageEvent.Extra["chain_length"])
+	}
+
+	getReq := withAuth(httptest.NewRequest(http.MethodGet, "/api/v1/jobs/"+jobID, nil), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-leaf",
+		Role:        "admin",
+	})
+	getReq.Header.Set("X-Tenant-ID", "default")
+	getReq.SetPathValue("id", jobID)
+	getRec := httptest.NewRecorder()
+	s.handleGetJob(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", getRec.Code, getRec.Body.String())
+	}
+
+	var getResp map[string]any
+	if err := json.Unmarshal(getRec.Body.Bytes(), &getResp); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	delegationResp, ok := getResp["delegation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected delegation object, got %#v", getResp["delegation"])
+	}
+	if delegationResp["chain_depth"] != float64(3) {
+		t.Fatalf("delegation.chain_depth = %#v, want 3", delegationResp["chain_depth"])
+	}
+	if delegationResp["root_issuer"] != "rootBot" || delegationResp["parent_issuer"] != "leafBot" {
+		t.Fatalf("unexpected delegation issuers in response: %#v", delegationResp)
+	}
+	chain, ok := delegationResp["chain"].([]any)
+	if !ok || len(chain) != 3 {
+		t.Fatalf("delegation.chain = %#v, want 3 entries", delegationResp["chain"])
+	}
+}
+
+func TestDelegationSubmitIntegration_ExpiredTokenRejectedBeforeEnqueue(t *testing.T) {
+	s, bus, _ := newTestGateway(t)
+	enableTestAuth(s)
+	signingKey := setDelegationKeys(t)
+	sink := &integrationDelegationAuditSink{}
+	s.auditExporter = sink
+
+	createDelegationAgent(t, s, "default", "rootBot", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "leafBot", []string{"read"}, []string{"job.test"})
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "leafBot", "worker-leaf"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+
+	now := time.Now().UTC().Add(-2 * time.Hour)
+	expiresAt := now.Add(-15 * time.Minute)
+	token := signDelegationToken(t, signingKey, delegation.DelegationClaims{
+		Tenant:         "default",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.test"},
+		DelegationChain: []delegation.ChainLink{{
+			AgentID:   "rootBot",
+			IssuedAt:  now.Format(time.RFC3339Nano),
+			ExpiresAt: expiresAt.Format(time.RFC3339Nano),
+			JTI:       "dlg-expired-root",
+			IssuedBy:  "cordum",
+		}},
+		ChainDepth: 1,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "cordum",
+			Subject:   "rootBot",
+			Audience:  jwt.ClaimStrings{"leafBot"},
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ID:        "dlg-expired-root",
+		},
+	})
+
+	_, rec := submitDelegatedJob(t, s, "worker-leaf", token)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error_code"] != "expired" {
+		t.Fatalf("error_code = %#v, want expired", resp["error_code"])
+	}
+	if sink.countByType(audit.EventDelegationLineage) != 0 {
+		t.Fatalf("unexpected delegation.lineage events: %#v", sink.snapshot())
+	}
+	if sink.countByType(audit.EventDelegationRejected) != 1 {
+		t.Fatalf("expected 1 delegation.rejected event, got %#v", sink.snapshot())
+	}
+
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	for _, published := range bus.published {
+		if published.subject == capsdk.SubjectSubmit {
+			t.Fatalf("expected no submit publish for expired token, got %+v", bus.published)
+		}
+	}
+}
+
+func TestDelegationSubmitIntegration_RevokedBeforeDispatchFailsJob(t *testing.T) {
+	s, bus, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+	sink := &integrationDelegationAuditSink{}
+	s.auditExporter = sink
+
+	createDelegationAgent(t, s, "default", "rootBot", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "middleBot", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "leafBot", []string{"read"}, []string{"job.test"})
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "leafBot", "worker-leaf"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+
+	submitToken, verified := issueThreeLinkSubmitToken(t, s)
+	engine := newDelegationSubmitEngine(t, bus, s.jobStore, sink)
+
+	jobID, submitRec := submitDelegatedJob(t, s, "worker-leaf", submitToken)
+	if submitRec.Code != http.StatusOK {
+		t.Fatalf("submit status=%d body=%s", submitRec.Code, submitRec.Body.String())
+	}
+
+	if err := delegation.NewRedisRevocationStoreFromClient(s.jobStore.Client()).Revoke(context.Background(), verified.JTI, verified.ExpiresAt); err != nil {
+		t.Fatalf("Revoke() error = %v", err)
+	}
+	if err := engine.HandlePacket(latestPublishedPacketForSubject(t, bus, capsdk.SubjectSubmit)); err != nil {
+		t.Fatalf("HandlePacket() error = %v", err)
+	}
+
+	ctx := context.Background()
+	state, err := s.jobStore.GetState(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetState() error = %v", err)
+	}
+	if state != model.JobStateFailed {
+		t.Fatalf("state = %q, want %q", state, model.JobStateFailed)
+	}
+	reason, err := s.jobStore.GetFailureReason(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetFailureReason() error = %v", err)
+	}
+	if reason != "delegation.revoked_before_dispatch" {
+		t.Fatalf("failure reason = %q, want delegation.revoked_before_dispatch", reason)
+	}
+	if sink.countByType(audit.EventDelegationLineage) != 0 {
+		t.Fatalf("unexpected delegation.lineage event after revocation: %#v", sink.snapshot())
+	}
+	event, ok := sink.firstByType(audit.EventDelegationRevokedBeforeDispatch)
+	if !ok {
+		t.Fatalf("missing %s event", audit.EventDelegationRevokedBeforeDispatch)
+	}
+	if event.Reason != "delegation.revoked_before_dispatch" {
+		t.Fatalf("audit reason = %q, want delegation.revoked_before_dispatch", event.Reason)
+	}
+}
+
+func TestDelegationSubmitIntegration_InvalidChainRejectedAtSubmit(t *testing.T) {
+	s, bus, _ := newTestGateway(t)
+	enableTestAuth(s)
+	signingKey := setDelegationKeys(t)
+	sink := &integrationDelegationAuditSink{}
+	s.auditExporter = sink
+
+	createDelegationAgent(t, s, "default", "rootBot", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "middleBot", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "leafBot", []string{"read"}, []string{"job.test"})
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "leafBot", "worker-leaf"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(30 * time.Minute)
+	token := signDelegationToken(t, signingKey, delegation.DelegationClaims{
+		Tenant:         "default",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.test"},
+		DelegationChain: []delegation.ChainLink{
+			{AgentID: "rootBot", IssuedAt: now.Format(time.RFC3339Nano), ExpiresAt: expiresAt.Format(time.RFC3339Nano), JTI: "dlg-root", IssuedBy: "cordum"},
+			{AgentID: "middleBot", IssuedAt: now.Format(time.RFC3339Nano), ExpiresAt: expiresAt.Format(time.RFC3339Nano), JTI: "dlg-middle", ParentJTI: "dlg-root", IssuedBy: "rootBot"},
+			{AgentID: "leafBot", IssuedAt: now.Format(time.RFC3339Nano), ExpiresAt: expiresAt.Format(time.RFC3339Nano), JTI: "dlg-leaf", ParentJTI: "dlg-middle", IssuedBy: "middleBot"},
+			{AgentID: "leafBot", IssuedAt: now.Format(time.RFC3339Nano), ExpiresAt: expiresAt.Format(time.RFC3339Nano), JTI: "dlg-too-deep", ParentJTI: "dlg-leaf", IssuedBy: "leafBot"},
+		},
+		ChainDepth: 4,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "cordum",
+			Subject:   "leafBot",
+			Audience:  jwt.ClaimStrings{"leafBot"},
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ID:        "dlg-too-deep",
+		},
+	})
+
+	_, rec := submitDelegatedJob(t, s, "worker-leaf", token)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error_code"] != "chain_too_deep" {
+		t.Fatalf("error_code = %#v, want chain_too_deep", resp["error_code"])
+	}
+	if sink.countByType(audit.EventDelegationLineage) != 0 {
+		t.Fatalf("unexpected delegation.lineage events: %#v", sink.snapshot())
+	}
+
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	for _, published := range bus.published {
+		if published.subject == capsdk.SubjectSubmit {
+			t.Fatalf("expected no submit publish for invalid chain token, got %+v", bus.published)
+		}
+	}
+}

--- a/core/controlplane/gateway/jobs_delegation_test.go
+++ b/core/controlplane/gateway/jobs_delegation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cordum/cordum/core/audit"
 	"github.com/cordum/cordum/core/auth/delegation"
 	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/licensing"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -463,6 +464,64 @@ func TestHandleSubmitJobHTTPRejectsExpiredDelegationToken(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "expired") {
 		t.Fatalf("expected expired body, got %s", rec.Body.String())
+	}
+}
+
+// TestHandleSubmitJobHTTPRejectsAudienceOverrideWithoutImpersonatePermission
+// verifies the delegation_audience_agent_id field cannot be used to widen
+// identity at token-verification time. A caller whose auth-derived agent
+// identity differs from the requested audience must hold
+// PermDelegationImpersonate (or the admin legacy role); otherwise the
+// submit is rejected 403 and an audit event is recorded.
+func TestHandleSubmitJobHTTPRejectsAudienceOverrideWithoutImpersonatePermission(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+	setTestEntitlements(t, s, licensing.PlanEnterprise, func(entitlements *licensing.Entitlements) {
+		entitlements.RBAC = true
+		entitlements.AgentIdentity = true
+	})
+
+	// Relay worker is bound to agent-b, but will try to submit with
+	// delegation_audience_agent_id=agent-c (impersonation attempt).
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-c", []string{"read"}, []string{"job.test"})
+
+	// Role holds jobs.write (so the outer gate passes) but NOT
+	// delegation.impersonate, so the audience override gate must fire.
+	putTestRole(t, s, "relay", auth.PermJobsWrite)
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-c",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	body := `{"prompt":"hello","topic":"job.test","delegation_token":"` + token + `","delegation_audience_agent_id":"agent-c"}`
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(body)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "relay",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s want 403", rec.Code, rec.Body.String())
 	}
 }
 

--- a/core/controlplane/gateway/jobs_delegation_test.go
+++ b/core/controlplane/gateway/jobs_delegation_test.go
@@ -1,0 +1,479 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/auth/delegation"
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestHandleSubmitJobHTTPInjectsDelegationContextIntoPolicyCheck(t *testing.T) {
+	s, _, safetyClient := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read", "write"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"`+token+`"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if safetyClient.lastReq == nil {
+		t.Fatal("expected policy check request to be captured")
+	}
+	if got := safetyClient.lastReq.GetLabels()["agent_id"]; got != "agent-b" {
+		t.Fatalf("agent_id label = %q, want agent-b", got)
+	}
+	if got := safetyClient.lastReq.GetLabels()["_delegation.depth"]; got != "1" {
+		t.Fatalf("delegation depth label = %q, want 1", got)
+	}
+	if got := safetyClient.lastReq.GetLabels()["_delegation.issuer"]; got != "agent-a" {
+		t.Fatalf("delegation issuer label = %q, want agent-a", got)
+	}
+	if got := safetyClient.lastReq.GetLabels()["_delegation.issuer_chain"]; got != "agent-a" {
+		t.Fatalf("delegation issuer_chain label = %q, want agent-a", got)
+	}
+	if got := safetyClient.lastReq.GetLabels()["_delegation.parent_issuer"]; got != "agent-a" {
+		t.Fatalf("delegation parent_issuer label = %q, want agent-a", got)
+	}
+	if got := safetyClient.lastReq.GetLabels()["_delegation.scope"]; got != "read" {
+		t.Fatalf("delegation scope label = %q, want read", got)
+	}
+	if got := safetyClient.lastReq.GetLabels()["_delegation.jti"]; got == "" {
+		t.Fatal("delegation jti label should be present")
+	}
+}
+
+func TestHandleSubmitJobHTTPPersistsDelegationDispatchToken(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read", "write"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"`+token+`"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	got, err := s.jobStore.GetDelegationDispatchToken(context.Background(), resp.JobID)
+	if err != nil {
+		t.Fatalf("GetDelegationDispatchToken() error = %v", err)
+	}
+	if got.Token != token {
+		t.Fatalf("stored delegation token mismatch")
+	}
+	if got.Audience != "agent-b" {
+		t.Fatalf("audience = %q, want agent-b", got.Audience)
+	}
+}
+
+func TestHandleSubmitJobHTTPEmitsDelegationExtrasOnSafetyDecisionAudit(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+	sink := &recordingAuditSender{}
+	s.auditExporter = sink
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read", "write"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, verifiedClaims, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+	verified, err := service.VerifyDelegationToken(context.Background(), token, "agent-b")
+	if err != nil {
+		t.Fatalf("VerifyDelegationToken() error = %v", err)
+	}
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"`+token+`"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var decisionEvent *audit.SIEMEvent
+	for i := range sink.events {
+		ev := &sink.events[i]
+		if ev.EventType == audit.EventSafetyDecision && ev.Action == "submit" {
+			decisionEvent = ev
+			break
+		}
+	}
+	if decisionEvent == nil {
+		t.Fatalf("expected safety.decision audit event, got %#v", sink.events)
+	}
+	if decisionEvent.Decision != "allow" {
+		t.Fatalf("decision = %q, want allow", decisionEvent.Decision)
+	}
+	if decisionEvent.Extra["topic"] != "job.test" {
+		t.Fatalf("topic extra = %q, want job.test", decisionEvent.Extra["topic"])
+	}
+	wantExtras := map[string]string{
+		"delegation.depth":         "1",
+		"delegation.root_issuer":   "agent-a",
+		"delegation.parent_issuer": "agent-a",
+		"delegation.audience":      "agent-b",
+		"delegation.expires_at":    verified.ExpiresAt.UTC().Format(time.RFC3339Nano),
+	}
+	for key, want := range wantExtras {
+		if got := decisionEvent.Extra[key]; got != want {
+			t.Fatalf("extra[%q] = %q, want %q", key, got, want)
+		}
+	}
+	if got := decisionEvent.Extra["delegation.jti"]; got == "" {
+		t.Fatal("delegation.jti should be present on safety decision audit event")
+	}
+	if got := decisionEvent.Extra["delegation.chain"]; got != "" {
+		t.Fatalf("delegation.chain = %q, want omitted from safety decision audit event", got)
+	}
+	if verifiedClaims.ExpiresAt == nil {
+		t.Fatal("expected issued claims to carry an expiration")
+	}
+}
+
+func TestHandleSubmitJobHTTPEmitsDelegationRejectedAuditOnVerifyFailure(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+	sink := &testAuditSender{}
+	s.auditExporter = sink
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"not-a-jwt"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if sink.Len() != 1 {
+		t.Fatalf("expected 1 audit event, got %d", sink.Len())
+	}
+	event := sink.Get(0)
+	if event.EventType != audit.EventDelegationRejected {
+		t.Fatalf("event_type = %q, want %q", event.EventType, audit.EventDelegationRejected)
+	}
+	if event.Action != "submit" {
+		t.Fatalf("action = %q, want submit", event.Action)
+	}
+	if event.Reason != "malformed" {
+		t.Fatalf("reason = %q, want malformed", event.Reason)
+	}
+	if event.Extra["topic"] != "job.test" {
+		t.Fatalf("topic extra = %q, want job.test", event.Extra["topic"])
+	}
+}
+
+func TestHandleSubmitJobHTTPRejectsDelegationAudienceMismatch(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-c", "worker-c"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-c", []string{"read"}, []string{"job.test"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, _, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"`+token+`"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-c",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "audience_mismatch") {
+		t.Fatalf("expected audience_mismatch body, got %s", rec.Body.String())
+	}
+}
+
+func TestHandleSubmitJobHTTPWithoutDelegationLeavesContextUnset(t *testing.T) {
+	s, _, safetyClient := newTestGateway(t)
+	enableTestAuth(s)
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if safetyClient.lastReq == nil {
+		t.Fatal("expected policy check request to be captured")
+	}
+	for _, key := range []string{
+		"_delegation.depth",
+		"_delegation.issuer",
+		"_delegation.issuer_chain",
+		"_delegation.parent_issuer",
+		"_delegation.scope",
+		"_delegation.jti",
+	} {
+		if got := safetyClient.lastReq.GetLabels()[key]; got != "" {
+			t.Fatalf("%s = %q, want empty for direct call", key, got)
+		}
+	}
+}
+
+func TestHandleSubmitJobHTTPRejectsMalformedDelegationToken(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"not-a-jwt"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "malformed") {
+		t.Fatalf("expected malformed body, got %s", rec.Body.String())
+	}
+}
+
+func TestHandleSubmitJobHTTPRejectsRevokedDelegationToken(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	setDelegationKeys(t)
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+
+	service, err := s.delegationTokenService()
+	if err != nil {
+		t.Fatalf("delegationTokenService() error = %v", err)
+	}
+	token, claims, err := service.IssueDelegationToken(context.Background(), delegation.IssueRequest{
+		Tenant:            "default",
+		DelegatingAgentID: "agent-a",
+		TargetAgentID:     "agent-b",
+		AllowedActions:    []string{"read"},
+		AllowedTopics:     []string{"job.test"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDelegationToken() error = %v", err)
+	}
+	if err := delegation.NewRedisRevocationStoreFromClient(s.jobStore.Client()).Revoke(context.Background(), claims.ID, time.Now().UTC().Add(time.Hour)); err != nil {
+		t.Fatalf("Revoke() error = %v", err)
+	}
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"`+token+`"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "revoked") {
+		t.Fatalf("expected revoked body, got %s", rec.Body.String())
+	}
+}
+
+func TestHandleSubmitJobHTTPRejectsExpiredDelegationToken(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableTestAuth(s)
+	signingKey := setDelegationKeys(t)
+
+	if err := s.agentIdentityStore.LinkWorker(context.Background(), "agent-b", "worker-b"); err != nil {
+		t.Fatalf("LinkWorker() error = %v", err)
+	}
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read"}, []string{"job.test"})
+	createDelegationAgent(t, s, "default", "agent-b", []string{"read"}, []string{"job.test"})
+
+	now := time.Now().UTC().Add(-2 * time.Hour)
+	expiresAt := now.Add(-15 * time.Minute)
+	token := signDelegationToken(t, signingKey, delegation.DelegationClaims{
+		Tenant:         "default",
+		AllowedActions: []string{"read"},
+		AllowedTopics:  []string{"job.test"},
+		DelegationChain: []delegation.ChainLink{{
+			AgentID:   "agent-a",
+			IssuedAt:  now.Format(time.RFC3339Nano),
+			ExpiresAt: expiresAt.Format(time.RFC3339Nano),
+			JTI:       "expired-link",
+			IssuedBy:  "cordum",
+		}},
+		ChainDepth: 1,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "cordum",
+			Subject:   "agent-a",
+			Audience:  jwt.ClaimStrings{"agent-b"},
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ID:        "expired-link",
+		},
+	})
+
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/jobs", strings.NewReader(`{"prompt":"hello","topic":"job.test","delegation_token":"`+token+`"}`)), &auth.AuthContext{
+		Tenant:      "default",
+		PrincipalID: "worker-b",
+		Role:        "admin",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.handleSubmitJobHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "expired") {
+		t.Fatalf("expected expired body, got %s", rec.Body.String())
+	}
+}
+
+func signDelegationToken(t *testing.T, signingKey delegation.SigningKey, claims delegation.DelegationClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	token.Header["kid"] = signingKey.KID
+	signed, err := token.SignedString(signingKey.PrivateKey)
+	if err != nil {
+		t.Fatalf("SignedString() error = %v", err)
+	}
+	return signed
+}

--- a/core/infra/config/delegation_policy.go
+++ b/core/infra/config/delegation_policy.go
@@ -34,24 +34,36 @@ type DelegationContext struct {
 }
 
 // DelegationMatch is the structured rule-match block under
-// PolicyRule.Match.Delegation. Every field is optional; the
-// rule-evaluator treats the zero value as "delegation-neutral" and
-// (per the DoD) allows non-delegated requests to pass delegation
-// rules by default. ForbidDelegated flips that to "direct-only".
+// PolicyRule.Match.Delegation. Every field is optional. An empty
+// DelegationMatch (no constraints) is delegation-neutral and matches
+// both direct and delegated requests.
+//
+// Policies that specify ANY delegation-specific constraint (MaxDepth,
+// Issuers, RequireIssuer, RequiredScope) are treated as delegation-
+// scoped rules: evaluateDelegationMatch fails closed when the request
+// carries no delegation chain, rather than silently passing direct
+// calls through constraints designed for delegated ones. This closes
+// the foot-gun where a deny rule written for "delegated calls with
+// depth>3" would also fire against direct calls.
+//
+// Use DelegationRequired=false to OPT OUT of fail-closed behaviour
+// (rule matches BOTH direct and delegated), true to require delegation,
+// or leave nil to accept the auto-inferred default from the presence
+// of constraints.
 type DelegationMatch struct {
-	// MaxDepth matches when delegation==nil OR delegation.Depth
+	// MaxDepth matches when delegation!=nil AND delegation.Depth
 	// <= *MaxDepth. A pointer (not int) so the zero value and
-	// "MaxDepth==0 means allow only direct calls" are
+	// "MaxDepth==0 means allow only direct chains" are
 	// distinguishable.
 	MaxDepth *int `yaml:"max_depth,omitempty"`
-	// Issuers matches when delegation==nil OR every id in the
+	// Issuers matches when delegation!=nil AND every id in the
 	// chain is in this allowlist. Strictest interpretation —
 	// relax via RequireIssuer (root-only) if operators want.
 	Issuers []string `yaml:"issuers,omitempty"`
-	// RequireIssuer matches when delegation==nil OR
+	// RequireIssuer matches when delegation!=nil AND
 	// delegation.RootIssuer == RequireIssuer.
 	RequireIssuer string `yaml:"require_issuer,omitempty"`
-	// RequiredScope matches when delegation==nil OR
+	// RequiredScope matches when delegation!=nil AND
 	// RequiredScope ⊆ delegation.Scope (set-subset).
 	RequiredScope []string `yaml:"required_scope,omitempty"`
 	// ForbidDelegated=true matches ONLY non-delegated requests
@@ -59,6 +71,41 @@ type DelegationMatch struct {
 	// only on direct calls" rules without inverting the match
 	// logic elsewhere.
 	ForbidDelegated bool `yaml:"forbid_delegated,omitempty"`
+	// DelegationRequired is an explicit tri-state override for the
+	// auto-inferred "this rule is delegation-scoped" behaviour:
+	//   nil   → infer from constraints (constraints present → true)
+	//   true  → rule applies ONLY to delegated requests
+	//   false → rule applies to BOTH direct and delegated (legacy
+	//           permissive behaviour; use only when the constraints
+	//           are intentionally non-gating for direct calls).
+	// Policy authors should almost never need false — it exists
+	// purely for the narrow case where an operator wants a
+	// delegation-neutral rule to also record delegation metadata.
+	DelegationRequired *bool `yaml:"delegation_required,omitempty"`
+}
+
+// hasDelegationScopedConstraint reports whether the match carries any
+// field whose semantics only make sense for a delegated request. Used
+// by evaluateDelegationMatch to default delegation-scoped rules to
+// fail-closed when the request is direct. DelegationRequired is an
+// explicit operator-facing override that wins over this inference.
+func (m *DelegationMatch) hasDelegationScopedConstraint() bool {
+	if m == nil {
+		return false
+	}
+	if m.MaxDepth != nil {
+		return true
+	}
+	if len(m.Issuers) > 0 {
+		return true
+	}
+	if strings.TrimSpace(m.RequireIssuer) != "" {
+		return true
+	}
+	if len(m.RequiredScope) > 0 {
+		return true
+	}
+	return false
 }
 
 // agentIDRegex is the validation pattern for issuer and
@@ -146,6 +193,7 @@ var DelegationMatchDenyFields = [...]string{
 	"issuers",
 	"require_issuer",
 	"required_scope",
+	"delegation_required",
 }
 
 func evaluateDelegationMatch(match *DelegationMatch, delegation *DelegationContext) bool {
@@ -160,9 +208,23 @@ func evaluateDelegationMatch(match *DelegationMatch, delegation *DelegationConte
 		reportDelegationDeny("forbid_delegated")
 		return false
 	}
-	// delegation==nil with non-Forbid fields set: the rule is
-	// neutral — per DoD, direct calls pass every delegation rule.
+	// When delegation is absent, decide whether this rule is
+	// delegation-scoped. The explicit DelegationRequired flag
+	// overrides auto-inference; otherwise a match with any
+	// delegation-specific constraint is treated as delegation-
+	// scoped and fails closed for direct calls.
 	if delegation == nil {
+		if match.DelegationRequired != nil {
+			if *match.DelegationRequired {
+				reportDelegationDeny("delegation_required")
+				return false
+			}
+			return true
+		}
+		if match.hasDelegationScopedConstraint() {
+			reportDelegationDeny("delegation_required")
+			return false
+		}
 		return true
 	}
 	// Structured checks — every failing sub-field short-circuits.

--- a/core/infra/config/delegation_policy.go
+++ b/core/infra/config/delegation_policy.go
@@ -1,0 +1,402 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	LabelDelegationDepth        = "_delegation.depth"
+	LabelDelegationIssuer       = "_delegation.issuer"
+	LabelDelegationIssuerChain  = "_delegation.issuer_chain"
+	LabelDelegationParentIssuer = "_delegation.parent_issuer"
+	LabelDelegationJTI          = "_delegation.jti"
+	LabelDelegationExpiresAt    = "_delegation.expires_at"
+	LabelDelegationAudience     = "_delegation.audience"
+	LabelDelegationScope        = "_delegation.scope"
+	LabelDelegationSubject      = "_delegation.subject"
+)
+
+// DelegationContext carries verified delegation metadata from the gateway into
+// policy evaluation. The gateway verifies the JWT and serializes only the
+// fields the kernel needs for policy rules.
+type DelegationContext struct {
+	Depth        int
+	IssuerChain  []string
+	Scope        []string
+	RootIssuer   string
+	ParentIssuer string
+	JTI          string
+	ExpiresAt    string
+	Audience     string
+}
+
+// DelegationMatch is the structured rule-match block under
+// PolicyRule.Match.Delegation. Every field is optional; the
+// rule-evaluator treats the zero value as "delegation-neutral" and
+// (per the DoD) allows non-delegated requests to pass delegation
+// rules by default. ForbidDelegated flips that to "direct-only".
+type DelegationMatch struct {
+	// MaxDepth matches when delegation==nil OR delegation.Depth
+	// <= *MaxDepth. A pointer (not int) so the zero value and
+	// "MaxDepth==0 means allow only direct calls" are
+	// distinguishable.
+	MaxDepth *int `yaml:"max_depth,omitempty"`
+	// Issuers matches when delegation==nil OR every id in the
+	// chain is in this allowlist. Strictest interpretation —
+	// relax via RequireIssuer (root-only) if operators want.
+	Issuers []string `yaml:"issuers,omitempty"`
+	// RequireIssuer matches when delegation==nil OR
+	// delegation.RootIssuer == RequireIssuer.
+	RequireIssuer string `yaml:"require_issuer,omitempty"`
+	// RequiredScope matches when delegation==nil OR
+	// RequiredScope ⊆ delegation.Scope (set-subset).
+	RequiredScope []string `yaml:"required_scope,omitempty"`
+	// ForbidDelegated=true matches ONLY non-delegated requests
+	// (delegation==nil). Lets operators write "this rule fires
+	// only on direct calls" rules without inverting the match
+	// logic elsewhere.
+	ForbidDelegated bool `yaml:"forbid_delegated,omitempty"`
+}
+
+// agentIDRegex is the validation pattern for issuer and
+// require-issuer values. Mirrors the existing agent-identity
+// naming convention used across the RBAC surface.
+var agentIDRegex = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_\-\.]{0,127}$`)
+
+// Validate checks the structural integrity of a DelegationMatch
+// block before it reaches evaluation. Returns a typed error so the
+// policy-parse path can reject malformed bundles at load time.
+func (m *DelegationMatch) Validate() error {
+	if m == nil {
+		return nil
+	}
+	if m.MaxDepth != nil && *m.MaxDepth < 0 {
+		return fmt.Errorf("delegation.max_depth must be >= 0, got %d", *m.MaxDepth)
+	}
+	seen := make(map[string]struct{}, len(m.Issuers))
+	for _, id := range m.Issuers {
+		trim := strings.TrimSpace(id)
+		if trim == "" {
+			return fmt.Errorf("delegation.issuers must not contain empty ids")
+		}
+		if !agentIDRegex.MatchString(trim) {
+			return fmt.Errorf("delegation.issuers: invalid agent id %q", trim)
+		}
+		if _, dup := seen[trim]; dup {
+			return fmt.Errorf("delegation.issuers: duplicate agent id %q", trim)
+		}
+		seen[trim] = struct{}{}
+	}
+	if trim := strings.TrimSpace(m.RequireIssuer); trim != "" && !agentIDRegex.MatchString(trim) {
+		return fmt.Errorf("delegation.require_issuer: invalid agent id %q", m.RequireIssuer)
+	}
+	if len(m.RequiredScope) > 0 {
+		for _, s := range m.RequiredScope {
+			if strings.TrimSpace(s) == "" {
+				return fmt.Errorf("delegation.required_scope must not contain empty values")
+			}
+		}
+	}
+	return nil
+}
+
+// evaluateDelegationMatch applies the six DoD match semantics:
+//
+//  1. ForbidDelegated=true matches ONLY when delegation==nil.
+//  2. delegation==nil with only non-Forbid fields set → neutral
+//     (matches) — "no-delegation = direct call = passes all
+//     delegation rules" per the DoD.
+//  3. MaxDepth: matches when *MaxDepth >= delegation.Depth.
+//  4. Issuers: matches when every id in delegation.IssuerChain
+//     ∈ allowlist.
+//  5. RequireIssuer: matches when delegation.RootIssuer == it.
+//  6. RequiredScope: matches when the required set ⊆
+//     delegation.Scope (both canonicalised before comparison so
+//     [read,write] and [write,read] evaluate equivalently).
+//
+// A match helper returns true when the rule should FIRE for the
+// given (match, delegation) pair — consistent with the existing
+// PolicyMatch semantics throughout this package.
+// delegationMatchDenyCallback, when set by an observer package, is invoked
+// exactly once per evaluateDelegationMatch call that rejects a rule. The
+// `field` argument names the sub-field that short-circuited the rule
+// (forbid_delegated|max_depth|issuers|require_issuer|required_scope). The
+// callback seam keeps this package metric-library-agnostic — safetykernel's
+// metrics.go wires it to the Prometheus counter.
+var delegationMatchDenyCallback func(field string)
+
+// SetDelegationMatchDenyCallback registers (or clears, when passed nil)
+// the observer invoked whenever evaluateDelegationMatch rejects a rule.
+// Exported so safetykernel's metrics bootstrap can inject its Prometheus
+// collector without importing from this package at evaluator-run time.
+func SetDelegationMatchDenyCallback(cb func(field string)) {
+	delegationMatchDenyCallback = cb
+}
+
+// DelegationMatchDenyFields enumerates the sub-field names that
+// evaluateDelegationMatch may report when a rule is rejected. Exposed so
+// observer packages can pre-register label values with their collector and
+// so tests can enumerate expected values without hard-coding strings.
+var DelegationMatchDenyFields = [...]string{
+	"forbid_delegated",
+	"max_depth",
+	"issuers",
+	"require_issuer",
+	"required_scope",
+}
+
+func evaluateDelegationMatch(match *DelegationMatch, delegation *DelegationContext) bool {
+	if match == nil {
+		return true
+	}
+	// ForbidDelegated flips the direct-vs-delegated decision.
+	if match.ForbidDelegated {
+		if delegation == nil {
+			return true
+		}
+		reportDelegationDeny("forbid_delegated")
+		return false
+	}
+	// delegation==nil with non-Forbid fields set: the rule is
+	// neutral — per DoD, direct calls pass every delegation rule.
+	if delegation == nil {
+		return true
+	}
+	// Structured checks — every failing sub-field short-circuits.
+	if match.MaxDepth != nil && delegation.Depth > *match.MaxDepth {
+		reportDelegationDeny("max_depth")
+		return false
+	}
+	if len(match.Issuers) > 0 {
+		allowed := make(map[string]struct{}, len(match.Issuers))
+		for _, id := range match.Issuers {
+			allowed[strings.TrimSpace(id)] = struct{}{}
+		}
+		for _, chainID := range delegation.IssuerChain {
+			if _, ok := allowed[strings.TrimSpace(chainID)]; !ok {
+				reportDelegationDeny("issuers")
+				return false
+			}
+		}
+	}
+	if req := strings.TrimSpace(match.RequireIssuer); req != "" {
+		if !strings.EqualFold(strings.TrimSpace(delegation.RootIssuer), req) {
+			reportDelegationDeny("require_issuer")
+			return false
+		}
+	}
+	if len(match.RequiredScope) > 0 {
+		have := make(map[string]struct{}, len(delegation.Scope))
+		for _, s := range delegation.Scope {
+			have[strings.ToLower(strings.TrimSpace(s))] = struct{}{}
+		}
+		for _, required := range match.RequiredScope {
+			key := strings.ToLower(strings.TrimSpace(required))
+			if _, ok := have[key]; !ok {
+				reportDelegationDeny("required_scope")
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func reportDelegationDeny(field string) {
+	if cb := delegationMatchDenyCallback; cb != nil {
+		cb(field)
+	}
+}
+
+// DelegationAuditExtras projects a verified DelegationContext into the
+// SIEMEvent.Extra map keys the audit trail should carry at safety-decision
+// emission time. Returns nil when the context is nil (direct call — no
+// delegation keys to emit). The companion delegation.lineage audit event
+// carries the full issuer chain, so the safety-decision event only includes
+// compact routing fields that stay under the syslog size rail.
+func DelegationAuditExtras(ctx *DelegationContext) map[string]string {
+	if ctx == nil {
+		return nil
+	}
+	out := map[string]string{
+		"delegation.depth": strconv.Itoa(ctx.Depth),
+	}
+	if root := strings.TrimSpace(ctx.RootIssuer); root != "" {
+		out["delegation.root_issuer"] = root
+	}
+	if parent := strings.TrimSpace(ctx.ParentIssuer); parent != "" {
+		out["delegation.parent_issuer"] = parent
+	}
+	if jti := strings.TrimSpace(ctx.JTI); jti != "" {
+		out["delegation.jti"] = jti
+	}
+	if expiresAt := strings.TrimSpace(ctx.ExpiresAt); expiresAt != "" {
+		out["delegation.expires_at"] = expiresAt
+	}
+	if audience := strings.TrimSpace(ctx.Audience); audience != "" {
+		out["delegation.audience"] = audience
+	}
+	return out
+}
+
+// DelegationContextFromLabels reconstructs a delegation context from reserved
+// internal labels injected by the gateway.
+func DelegationContextFromLabels(labels map[string]string) *DelegationContext {
+	if len(labels) == 0 {
+		return nil
+	}
+	depth, err := strconv.Atoi(strings.TrimSpace(labels[LabelDelegationDepth]))
+	if err != nil || depth <= 0 {
+		return nil
+	}
+	issuerChain := normalizeDelegationList(labels[LabelDelegationIssuerChain])
+	rootIssuer := strings.TrimSpace(labels[LabelDelegationIssuer])
+	if rootIssuer == "" && len(issuerChain) > 0 {
+		rootIssuer = issuerChain[0]
+	}
+	if len(issuerChain) == 0 && rootIssuer != "" {
+		issuerChain = []string{rootIssuer}
+	}
+	parentIssuer := strings.TrimSpace(labels[LabelDelegationParentIssuer])
+	if parentIssuer == "" && len(issuerChain) > 0 {
+		parentIssuer = issuerChain[len(issuerChain)-1]
+	}
+	return &DelegationContext{
+		Depth:        depth,
+		IssuerChain:  issuerChain,
+		Scope:        normalizeDelegationList(labels[LabelDelegationScope]),
+		RootIssuer:   rootIssuer,
+		ParentIssuer: parentIssuer,
+		JTI:          strings.TrimSpace(labels[LabelDelegationJTI]),
+		ExpiresAt:    strings.TrimSpace(labels[LabelDelegationExpiresAt]),
+		Audience:     strings.TrimSpace(labels[LabelDelegationAudience]),
+	}
+}
+
+type delegationPredicate struct {
+	kind  string
+	op    string
+	depth int
+	value string
+}
+
+func validateDelegationPredicate(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	_, err := parseDelegationPredicate(raw)
+	return err
+}
+
+func delegationPredicateMatch(raw string, delegation *DelegationContext) bool {
+	if strings.TrimSpace(raw) == "" {
+		return true
+	}
+	predicate, err := parseDelegationPredicate(raw)
+	if err != nil || delegation == nil {
+		return false
+	}
+	switch predicate.kind {
+	case "depth":
+		return compareDelegationDepth(delegation.Depth, predicate.op, predicate.depth)
+	case "issuer":
+		return strings.EqualFold(strings.TrimSpace(delegation.RootIssuer), predicate.value)
+	case "scope_contains":
+		return containsString(delegation.Scope, predicate.value)
+	default:
+		return false
+	}
+}
+
+func parseDelegationPredicate(raw string) (delegationPredicate, error) {
+	raw = strings.TrimSpace(raw)
+	switch {
+	case strings.HasPrefix(raw, "delegation.depth"):
+		tail := strings.TrimSpace(strings.TrimPrefix(raw, "delegation.depth"))
+		for _, op := range []string{">=", "<=", "==", ">", "<"} {
+			if strings.HasPrefix(tail, op) {
+				value, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(tail, op)))
+				if err != nil {
+					return delegationPredicate{}, fmt.Errorf("invalid delegation depth predicate %q", raw)
+				}
+				return delegationPredicate{kind: "depth", op: op, depth: value}, nil
+			}
+		}
+	case strings.HasPrefix(raw, "delegation.issuer"):
+		tail := strings.TrimSpace(strings.TrimPrefix(raw, "delegation.issuer"))
+		if !strings.HasPrefix(tail, "==") {
+			return delegationPredicate{}, fmt.Errorf("invalid delegation issuer predicate %q", raw)
+		}
+		value, err := parseDelegationPredicateValue(strings.TrimSpace(strings.TrimPrefix(tail, "==")))
+		if err != nil {
+			return delegationPredicate{}, err
+		}
+		return delegationPredicate{kind: "issuer", value: value}, nil
+	case strings.HasPrefix(raw, "delegation.scope.contains(") && strings.HasSuffix(raw, ")"):
+		inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(raw, "delegation.scope.contains("), ")"))
+		value, err := parseDelegationPredicateValue(inner)
+		if err != nil {
+			return delegationPredicate{}, err
+		}
+		return delegationPredicate{kind: "scope_contains", value: value}, nil
+	}
+	return delegationPredicate{}, fmt.Errorf("invalid delegation predicate %q", raw)
+}
+
+func parseDelegationPredicateValue(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("delegation predicate value required")
+	}
+	if len(raw) >= 2 {
+		if (raw[0] == '\'' && raw[len(raw)-1] == '\'') || (raw[0] == '"' && raw[len(raw)-1] == '"') {
+			raw = raw[1 : len(raw)-1]
+		}
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("delegation predicate value required")
+	}
+	return strings.ToLower(raw), nil
+}
+
+func compareDelegationDepth(actual int, op string, expected int) bool {
+	switch op {
+	case ">":
+		return actual > expected
+	case ">=":
+		return actual >= expected
+	case "<":
+		return actual < expected
+	case "<=":
+		return actual <= expected
+	case "==":
+		return actual == expected
+	default:
+		return false
+	}
+}
+
+func normalizeDelegationList(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key := strings.ToLower(part)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, part)
+	}
+	return out
+}

--- a/core/infra/config/policy_delegation_test.go
+++ b/core/infra/config/policy_delegation_test.go
@@ -129,9 +129,9 @@ func TestEvaluateDelegationMatch(t *testing.T) {
 			want: false,
 		},
 		{
-			name:  "direct call bypasses max depth",
+			name:  "direct call fails closed when max depth is set",
 			match: &DelegationMatch{MaxDepth: &zero},
-			want:  true,
+			want:  false,
 		},
 		{
 			name:  "max depth rejects deeper chain",
@@ -144,19 +144,29 @@ func TestEvaluateDelegationMatch(t *testing.T) {
 			want: false,
 		},
 		{
-			name:  "direct call bypasses issuer allowlist",
+			name:  "direct call fails closed when issuer allowlist is set",
 			match: &DelegationMatch{Issuers: []string{"agent-a"}},
-			want:  true,
+			want:  false,
 		},
 		{
-			name:  "direct call bypasses require issuer",
+			name:  "direct call fails closed when require issuer is set",
 			match: &DelegationMatch{RequireIssuer: "finance-bot"},
+			want:  false,
+		},
+		{
+			name:  "direct call fails closed when required scope is set",
+			match: &DelegationMatch{RequiredScope: []string{"read"}},
+			want:  false,
+		},
+		{
+			name:  "direct call admitted when delegation_required is explicitly false",
+			match: &DelegationMatch{RequiredScope: []string{"read"}, DelegationRequired: boolPtr(false)},
 			want:  true,
 		},
 		{
-			name:  "direct call bypasses required scope",
-			match: &DelegationMatch{RequiredScope: []string{"read"}},
-			want:  true,
+			name:  "direct call rejected when delegation_required is explicitly true",
+			match: &DelegationMatch{DelegationRequired: boolPtr(true)},
+			want:  false,
 		},
 		{
 			name:  "issuer allowlist accepts every chain member",
@@ -543,3 +553,8 @@ func TestDelegationAuditExtras_TrimsAudienceAndExpiry(t *testing.T) {
 		t.Fatalf("audience should be trimmed; got %q", got["delegation.audience"])
 	}
 }
+
+// boolPtr is a local convenience for taking the address of a bool
+// literal in test-case table entries. Keeps the Delegation matcher
+// table readable without scattering `func() *bool { ... }` boilerplate.
+func boolPtr(b bool) *bool { return &b }

--- a/core/infra/config/policy_delegation_test.go
+++ b/core/infra/config/policy_delegation_test.go
@@ -1,0 +1,545 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSafetyPolicyEvaluate_DelegationDepthPredicate(t *testing.T) {
+	policy := &SafetyPolicy{
+		DefaultDecision: "allow",
+		Rules: []PolicyRule{
+			{
+				ID:       "deny-deep-delegation",
+				Decision: "deny",
+				Reason:   "delegation too deep",
+				Match: PolicyMatch{
+					Predicate: "delegation.depth > 2",
+				},
+			},
+		},
+	}
+
+	decision := policy.Evaluate(PolicyInput{
+		Tenant: "default",
+		Topic:  "job.test",
+		Delegation: &DelegationContext{
+			Depth: 3,
+		},
+	})
+	if decision.Decision != "deny" {
+		t.Fatalf("decision = %q, want deny", decision.Decision)
+	}
+	if decision.RuleID != "deny-deep-delegation" {
+		t.Fatalf("rule = %q, want deny-deep-delegation", decision.RuleID)
+	}
+}
+
+func TestSafetyPolicyEvaluate_DelegationScopeContainsPredicate(t *testing.T) {
+	policy := &SafetyPolicy{
+		DefaultDecision: "deny",
+		Rules: []PolicyRule{
+			{
+				ID:       "allow-delegated-read",
+				Decision: "allow",
+				Reason:   "delegated read permitted",
+				Match: PolicyMatch{
+					Predicate: "delegation.scope.contains('read')",
+				},
+			},
+		},
+	}
+
+	decision := policy.Evaluate(PolicyInput{
+		Tenant: "default",
+		Topic:  "job.test",
+		Delegation: &DelegationContext{
+			Depth: 1,
+			Scope: []string{"read", "summarize"},
+		},
+	})
+	if decision.Decision != "allow" {
+		t.Fatalf("decision = %q, want allow", decision.Decision)
+	}
+}
+
+func TestSafetyPolicyEvaluate_NilDelegationDoesNotMatchPredicates(t *testing.T) {
+	tests := []struct {
+		name      string
+		predicate string
+	}{
+		{name: "equals_zero", predicate: "delegation.depth == 0"},
+		{name: "greater_than_zero", predicate: "delegation.depth > 0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := &SafetyPolicy{
+				DefaultDecision: "allow",
+				Rules: []PolicyRule{
+					{
+						ID:       tc.name,
+						Decision: "deny",
+						Reason:   "predicate matched",
+						Match: PolicyMatch{
+							Predicate: tc.predicate,
+						},
+					},
+				},
+			}
+
+			decision := policy.Evaluate(PolicyInput{
+				Tenant: "default",
+				Topic:  "job.test",
+			})
+			if decision.Decision != "allow" {
+				t.Fatalf("decision = %q, want allow when delegation is absent", decision.Decision)
+			}
+		})
+	}
+}
+
+func TestEvaluateDelegationMatch(t *testing.T) {
+	zero := 0
+	one := 1
+	tests := []struct {
+		name       string
+		match      *DelegationMatch
+		delegation *DelegationContext
+		want       bool
+	}{
+		{
+			name:  "nil match is neutral",
+			match: nil,
+			want:  true,
+		},
+		{
+			name:  "forbid delegated allows direct call",
+			match: &DelegationMatch{ForbidDelegated: true},
+			want:  true,
+		},
+		{
+			name:  "forbid delegated rejects delegated call",
+			match: &DelegationMatch{ForbidDelegated: true},
+			delegation: &DelegationContext{
+				Depth:       1,
+				IssuerChain: []string{"agent-a"},
+				RootIssuer:  "agent-a",
+			},
+			want: false,
+		},
+		{
+			name:  "direct call bypasses max depth",
+			match: &DelegationMatch{MaxDepth: &zero},
+			want:  true,
+		},
+		{
+			name:  "max depth rejects deeper chain",
+			match: &DelegationMatch{MaxDepth: &zero},
+			delegation: &DelegationContext{
+				Depth:       1,
+				IssuerChain: []string{"agent-a"},
+				RootIssuer:  "agent-a",
+			},
+			want: false,
+		},
+		{
+			name:  "direct call bypasses issuer allowlist",
+			match: &DelegationMatch{Issuers: []string{"agent-a"}},
+			want:  true,
+		},
+		{
+			name:  "direct call bypasses require issuer",
+			match: &DelegationMatch{RequireIssuer: "finance-bot"},
+			want:  true,
+		},
+		{
+			name:  "direct call bypasses required scope",
+			match: &DelegationMatch{RequiredScope: []string{"read"}},
+			want:  true,
+		},
+		{
+			name:  "issuer allowlist accepts every chain member",
+			match: &DelegationMatch{Issuers: []string{"agent-a", "agent-b"}},
+			delegation: &DelegationContext{
+				Depth:       2,
+				IssuerChain: []string{"agent-a", "agent-b"},
+				RootIssuer:  "agent-a",
+			},
+			want: true,
+		},
+		{
+			name:  "issuer allowlist rejects unknown chain member",
+			match: &DelegationMatch{Issuers: []string{"agent-a", "agent-b"}},
+			delegation: &DelegationContext{
+				Depth:       2,
+				IssuerChain: []string{"agent-a", "agent-x"},
+				RootIssuer:  "agent-a",
+			},
+			want: false,
+		},
+		{
+			name:  "require issuer matches root",
+			match: &DelegationMatch{RequireIssuer: "finance-bot"},
+			delegation: &DelegationContext{
+				Depth:       1,
+				IssuerChain: []string{"finance-bot"},
+				RootIssuer:  "finance-bot",
+			},
+			want: true,
+		},
+		{
+			name:  "require issuer rejects different root",
+			match: &DelegationMatch{RequireIssuer: "finance-bot"},
+			delegation: &DelegationContext{
+				Depth:       1,
+				IssuerChain: []string{"agent-a"},
+				RootIssuer:  "agent-a",
+			},
+			want: false,
+		},
+		{
+			name:  "required scope ignores order",
+			match: &DelegationMatch{RequiredScope: []string{"read", "write"}},
+			delegation: &DelegationContext{
+				Depth:       1,
+				IssuerChain: []string{"agent-a"},
+				Scope:       []string{"write", "read"},
+				RootIssuer:  "agent-a",
+			},
+			want: true,
+		},
+		{
+			name:  "required scope rejects missing action",
+			match: &DelegationMatch{RequiredScope: []string{"read", "write"}},
+			delegation: &DelegationContext{
+				Depth:       1,
+				IssuerChain: []string{"agent-a"},
+				Scope:       []string{"read"},
+				RootIssuer:  "agent-a",
+			},
+			want: false,
+		},
+		{
+			name: "multi field rule requires every condition",
+			match: &DelegationMatch{
+				MaxDepth:      &one,
+				Issuers:       []string{"agent-a", "agent-b"},
+				RequireIssuer: "agent-a",
+				RequiredScope: []string{"read"},
+			},
+			delegation: &DelegationContext{
+				Depth:       1,
+				IssuerChain: []string{"agent-a", "agent-b"},
+				Scope:       []string{"read", "write"},
+				RootIssuer:  "agent-a",
+			},
+			want: true,
+		},
+		{
+			name: "multi field rule fails if any condition fails",
+			match: &DelegationMatch{
+				MaxDepth:      &one,
+				Issuers:       []string{"agent-a", "agent-b"},
+				RequireIssuer: "agent-a",
+				RequiredScope: []string{"read"},
+			},
+			delegation: &DelegationContext{
+				Depth:       2,
+				IssuerChain: []string{"agent-a", "agent-b"},
+				Scope:       []string{"read"},
+				RootIssuer:  "agent-a",
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := evaluateDelegationMatch(tc.match, tc.delegation); got != tc.want {
+				t.Fatalf("evaluateDelegationMatch() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDelegationContextFromLabels(t *testing.T) {
+	if got := DelegationContextFromLabels(nil); got != nil {
+		t.Fatalf("DelegationContextFromLabels(nil) = %#v, want nil", got)
+	}
+	if got := DelegationContextFromLabels(map[string]string{}); got != nil {
+		t.Fatalf("DelegationContextFromLabels(empty) = %#v, want nil", got)
+	}
+	if got := DelegationContextFromLabels(map[string]string{LabelDelegationDepth: "0"}); got != nil {
+		t.Fatalf("DelegationContextFromLabels(depth=0) = %#v, want nil", got)
+	}
+
+	got := DelegationContextFromLabels(map[string]string{
+		LabelDelegationDepth:        "2",
+		LabelDelegationIssuerChain:  "agent-a,agent-b",
+		LabelDelegationIssuer:       "agent-a",
+		LabelDelegationParentIssuer: "agent-b",
+		LabelDelegationScope:        "read,write",
+		LabelDelegationJTI:          "dlg-123",
+		LabelDelegationExpiresAt:    "2026-04-21T13:14:15Z",
+		LabelDelegationAudience:     "agent-b",
+	})
+	if got == nil {
+		t.Fatal("expected delegation context")
+	}
+	if got.Depth != 2 || got.RootIssuer != "agent-a" || got.ParentIssuer != "agent-b" || got.JTI != "dlg-123" || got.ExpiresAt != "2026-04-21T13:14:15Z" || got.Audience != "agent-b" {
+		t.Fatalf("unexpected delegation context: %#v", got)
+	}
+}
+
+func TestParseSafetyPolicy_DelegationValidation(t *testing.T) {
+	validYAML := []byte(`
+default_decision: allow
+rules:
+  - id: delegation-allowlist
+    decision: deny
+    match:
+      delegation:
+        max_depth: 2
+        issuers: [agent-a, agent-b]
+        require_issuer: finance-bot
+        required_scope: [read, write]
+        forbid_delegated: false
+`)
+	policy, err := ParseSafetyPolicy(validYAML)
+	if err != nil {
+		t.Fatalf("ParseSafetyPolicy(valid) error = %v", err)
+	}
+	if policy == nil || policy.Rules[0].Match.Delegation == nil {
+		t.Fatalf("expected delegation match to parse, got %#v", policy)
+	}
+
+	invalidCases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "negative-max-depth",
+			yaml: `
+default_decision: allow
+rules:
+  - id: bad-depth
+    decision: deny
+    match:
+      delegation:
+        max_depth: -1
+`,
+			wantErr: "max_depth",
+		},
+		{
+			name: "duplicate-issuers",
+			yaml: `
+default_decision: allow
+rules:
+  - id: dup-issuers
+    decision: deny
+    match:
+      delegation:
+        issuers: [agent-a, agent-a]
+`,
+			wantErr: "duplicate",
+		},
+		{
+			name: "invalid-require-issuer",
+			yaml: `
+default_decision: allow
+rules:
+  - id: bad-root
+    decision: deny
+    match:
+      delegation:
+        require_issuer: "not valid"
+`,
+			wantErr: "require_issuer",
+		},
+		{
+			name: "empty-required-scope-entry",
+			yaml: `
+default_decision: allow
+rules:
+  - id: bad-scope
+    decision: deny
+    match:
+      delegation:
+        required_scope: [read, ""]
+`,
+			wantErr: "required_scope",
+		},
+	}
+
+	for _, tc := range invalidCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseSafetyPolicy([]byte(tc.yaml))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ParseSafetyPolicy() error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestDelegationMatchDenyCallback asserts the observer callback fires with
+// the expected `field` label for every sub-field that can short-circuit a
+// rule — this is the seam safetykernel's metrics use for per-field
+// Prometheus counters.
+func TestDelegationMatchDenyCallback(t *testing.T) {
+	zero := 0
+	maxOne := 1
+
+	type rejectedBy struct{ field string }
+	tests := []struct {
+		name       string
+		match      *DelegationMatch
+		delegation *DelegationContext
+		wantField  string
+	}{
+		{
+			name:       "forbid_delegated",
+			match:      &DelegationMatch{ForbidDelegated: true},
+			delegation: &DelegationContext{Depth: 1, IssuerChain: []string{"a"}},
+			wantField:  "forbid_delegated",
+		},
+		{
+			name:       "max_depth",
+			match:      &DelegationMatch{MaxDepth: &zero},
+			delegation: &DelegationContext{Depth: 1, IssuerChain: []string{"a"}},
+			wantField:  "max_depth",
+		},
+		{
+			name:       "issuers",
+			match:      &DelegationMatch{Issuers: []string{"a"}},
+			delegation: &DelegationContext{Depth: 1, IssuerChain: []string{"x"}},
+			wantField:  "issuers",
+		},
+		{
+			name:       "require_issuer",
+			match:      &DelegationMatch{RequireIssuer: "a"},
+			delegation: &DelegationContext{Depth: 1, RootIssuer: "b", IssuerChain: []string{"b"}},
+			wantField:  "require_issuer",
+		},
+		{
+			name:       "required_scope",
+			match:      &DelegationMatch{RequiredScope: []string{"write"}},
+			delegation: &DelegationContext{Depth: 1, Scope: []string{"read"}, IssuerChain: []string{"a"}, RootIssuer: "a"},
+			wantField:  "required_scope",
+		},
+		{
+			name:       "max_depth_multi_field_short_circuits_on_depth",
+			match:      &DelegationMatch{MaxDepth: &maxOne, Issuers: []string{"a"}},
+			delegation: &DelegationContext{Depth: 2, IssuerChain: []string{"a", "a"}},
+			wantField:  "max_depth",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []rejectedBy
+			SetDelegationMatchDenyCallback(func(field string) {
+				captured = append(captured, rejectedBy{field: field})
+			})
+			t.Cleanup(func() { SetDelegationMatchDenyCallback(nil) })
+
+			if evaluateDelegationMatch(tc.match, tc.delegation) {
+				t.Fatalf("evaluateDelegationMatch should have rejected")
+			}
+			if len(captured) != 1 {
+				t.Fatalf("callback called %d times, want 1", len(captured))
+			}
+			if captured[0].field != tc.wantField {
+				t.Fatalf("field = %q, want %q", captured[0].field, tc.wantField)
+			}
+		})
+	}
+}
+
+// TestDelegationMatchDenyCallbackNotCalledOnMatch asserts the callback does
+// NOT fire when a rule matches. Counting matches on the deny counter would
+// balloon dashboards with noise.
+func TestDelegationMatchDenyCallbackNotCalledOnMatch(t *testing.T) {
+	var called int
+	SetDelegationMatchDenyCallback(func(field string) { called++ })
+	t.Cleanup(func() { SetDelegationMatchDenyCallback(nil) })
+
+	// nil delegation passes every non-Forbid rule → no callback.
+	_ = evaluateDelegationMatch(&DelegationMatch{MaxDepth: func() *int { i := 0; return &i }()}, nil)
+	// nil match is neutral → no callback.
+	_ = evaluateDelegationMatch(nil, &DelegationContext{Depth: 1})
+	// Forbid + direct call is a match → no callback.
+	_ = evaluateDelegationMatch(&DelegationMatch{ForbidDelegated: true}, nil)
+
+	if called != 0 {
+		t.Fatalf("callback fired %d times on matches; should be 0", called)
+	}
+}
+
+// TestDelegationAuditExtras verifies the projection from DelegationContext
+// to the SIEMEvent.Extra map. The scope list is deliberately omitted so a
+// single safety-decision event stays under the 8 KiB syslog line limit.
+func TestDelegationAuditExtras(t *testing.T) {
+	if got := DelegationAuditExtras(nil); got != nil {
+		t.Fatalf("DelegationAuditExtras(nil) = %v, want nil", got)
+	}
+
+	ctx := &DelegationContext{
+		Depth:        2,
+		IssuerChain:  []string{"finance-bot", "agent-a"},
+		RootIssuer:   "finance-bot",
+		ParentIssuer: "agent-a",
+		Scope:        []string{"read", "write"}, // must NOT appear in Extras
+		JTI:          "jti-123",
+		ExpiresAt:    "2026-04-21T13:14:15Z",
+		Audience:     "agent-a",
+	}
+	got := DelegationAuditExtras(ctx)
+	wantPairs := map[string]string{
+		"delegation.depth":         "2",
+		"delegation.root_issuer":   "finance-bot",
+		"delegation.parent_issuer": "agent-a",
+		"delegation.jti":           "jti-123",
+		"delegation.expires_at":    "2026-04-21T13:14:15Z",
+		"delegation.audience":      "agent-a",
+	}
+	for k, v := range wantPairs {
+		if got[k] != v {
+			t.Errorf("Extras[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	if _, present := got["delegation.scope"]; present {
+		t.Fatalf("Extras must NOT include delegation.scope (syslog size rail)")
+	}
+	if got["delegation.depth"] == "" {
+		t.Fatal("depth must always be emitted, even zero-valued")
+	}
+	if _, present := got["delegation.chain"]; present {
+		t.Fatalf("Extras must NOT include delegation.chain; the companion lineage event carries the full chain")
+	}
+}
+
+func TestDelegationAuditExtras_OmitsBlankFields(t *testing.T) {
+	ctx := &DelegationContext{Depth: 0}
+	got := DelegationAuditExtras(ctx)
+	if got["delegation.depth"] != "0" {
+		t.Fatalf("depth=0 should be emitted verbatim; got %q", got["delegation.depth"])
+	}
+	for _, key := range []string{"delegation.root_issuer", "delegation.parent_issuer", "delegation.jti", "delegation.expires_at", "delegation.audience", "delegation.chain"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("key %q should be omitted when the source field is empty", key)
+		}
+	}
+}
+
+func TestDelegationAuditExtras_TrimsAudienceAndExpiry(t *testing.T) {
+	ctx := &DelegationContext{Depth: 3, ExpiresAt: " 2026-04-21T13:14:15Z ", Audience: " agent-b "}
+	got := DelegationAuditExtras(ctx)
+	if got["delegation.expires_at"] != "2026-04-21T13:14:15Z" {
+		t.Fatalf("expires_at should be trimmed; got %q", got["delegation.expires_at"])
+	}
+	if got["delegation.audience"] != "agent-b" {
+		t.Fatalf("audience should be trimmed; got %q", got["delegation.audience"])
+	}
+}

--- a/core/infra/config/safety_policy.go
+++ b/core/infra/config/safety_policy.go
@@ -222,6 +222,16 @@ type PolicyMatch struct {
 	LabelThreshold           map[string]float64  `yaml:"label_threshold,omitempty"` // deny when label value > threshold
 	SecretsPresent           *bool               `yaml:"secrets_present,omitempty"`
 	MCP                      MCPPolicy           `yaml:"mcp"`
+	// Predicate is an expression-based fallback used when structured
+	// match fields can't express the intent (for example, checking
+	// that a delegation scope contains a specific action). The DSL is
+	// evaluated by the safety kernel; the config package only parses
+	// and validates the string shape.
+	Predicate string `yaml:"predicate,omitempty"`
+	// Delegation captures rule-level matching against the request's
+	// delegation chain — depth, issuer allowlist, required scope,
+	// etc. Zero value is delegation-neutral.
+	Delegation *DelegationMatch `yaml:"delegation,omitempty"`
 }
 
 type PolicyConstraints struct {
@@ -298,6 +308,11 @@ type PolicyInput struct {
 	Meta           PolicyMeta
 	SecretsPresent bool
 	MCP            MCPRequest
+	// Delegation carries the verified delegation chain for the request,
+	// or nil for a direct (non-delegated) call. Populated upstream by
+	// the token verifier; evaluateDelegationMatch consults it when a
+	// rule specifies match.delegation constraints.
+	Delegation *DelegationContext
 }
 
 // PolicyMeta captures structured job metadata for policy checks.

--- a/core/infra/store/job_store.go
+++ b/core/infra/store/job_store.go
@@ -1745,6 +1745,24 @@ func (s *RedisJobStore) SetDelegationDispatchToken(ctx context.Context, jobID st
 	return nil
 }
 
+// ClearDelegationDispatchToken deletes the raw delegation bearer token from
+// the job metadata hash. Callers MUST invoke this as soon as dispatch-time
+// re-verification completes (successfully or with a fail-closed decision)
+// so the raw token does not sit in the 7-day job-metadata TTL where it
+// could be recovered via admin tooling, backups, or operator access. The
+// persisted DelegationLineage on the job record continues to carry the
+// non-sensitive chain metadata (JTI, issuer chain, scope) for audit and
+// read-side APIs after this wipe.
+func (s *RedisJobStore) ClearDelegationDispatchToken(ctx context.Context, jobID string) error {
+	if jobID == "" {
+		return fmt.Errorf("jobID required")
+	}
+	if _, err := s.client.HDel(ctx, jobMetaKey(jobID), metaFieldDelegationDispatch).Result(); err != nil {
+		return fmt.Errorf("job store clear delegation dispatch token %s: %w", jobID, err)
+	}
+	return nil
+}
+
 // GetDelegationDispatchToken loads the raw delegation token stored for
 // dispatch-time re-verification.
 func (s *RedisJobStore) GetDelegationDispatchToken(ctx context.Context, jobID string) (model.DelegationDispatchToken, error) {

--- a/core/infra/store/job_store.go
+++ b/core/infra/store/job_store.go
@@ -47,13 +47,15 @@ const (
 	metaFieldRiskTags              = "risk_tags"
 	metaFieldRequires              = "requires"
 	metaFieldPackID                = "pack_id"
-	metaFieldAttempts              = "attempts"
-	metaFieldDeadline              = "deadline_unix"
 	metaFieldAgentID               = "agent_id"
 	metaFieldAgentName             = "agent_name"
 	metaFieldAgentRiskTier         = "agent_risk_tier"
 	metaFieldSubmittedBy           = "submitted_by"
+	metaFieldAttempts              = "attempts"
+	metaFieldDeadline              = "deadline_unix"
 	metaFieldSafetyDecision        = "safety_decision"
+	metaFieldDelegationLineage     = "delegation_lineage"
+	metaFieldDelegationDispatch    = "delegation_dispatch_token"
 	metaFieldSafetyReason          = "safety_reason"
 	metaFieldSafetyRuleID          = "safety_rule_id"
 	metaFieldSafetySnapshot        = "safety_snapshot"
@@ -463,7 +465,11 @@ func (s *RedisJobStore) CancelJob(ctx context.Context, jobID string) (model.JobS
 			pipe.Expire(ctx, jobResultPtrKey(jobID), s.metaTTL)
 		}
 
-		pipe.RPush(ctx, jobEventsKey(jobID), fmt.Sprintf("%d|%s", now, model.JobStateCancelled))
+		cancelEvtStr, serErr := serializeJobEvent(model.JobStateCancelled, now, nil)
+		if serErr != nil {
+			return serErr
+		}
+		pipe.RPush(ctx, jobEventsKey(jobID), cancelEvtStr)
 
 		if _, err := pipe.Exec(ctx); err != nil {
 			return fmt.Errorf("job store cancel %s: %w", jobID, err)
@@ -582,88 +588,7 @@ func NewRedisJobStore(url string) (*RedisJobStore, error) {
 }
 
 func (s *RedisJobStore) SetState(ctx context.Context, jobID string, state model.JobState) error {
-	if jobID == "" || state == "" {
-		return fmt.Errorf("invalid jobID or state")
-	}
-
-	now := nowUnixMicros()
-	metaKey := jobMetaKey(jobID)
-
-	return s.client.Watch(ctx, func(tx *redis.Tx) error {
-		prev, err := tx.HGet(ctx, metaKey, "state").Result()
-		if err != nil && err != redis.Nil {
-			return fmt.Errorf("job store set state %s: %w", jobID, err)
-		}
-		prevState := model.JobState(prev)
-		if !isAllowedTransition(prevState, state) {
-			return fmt.Errorf("invalid transition %s -> %s", prevState, state)
-		}
-		attempts := 0
-		if raw, err := tx.HGet(ctx, metaKey, metaFieldAttempts).Result(); err == nil {
-			if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
-				attempts = parsed
-			}
-		}
-		// Count every scheduling attempt, including replays that remain in
-		// SCHEDULED due to downstream publish failures. This keeps retry budgets
-		// accurate under redelivery loops.
-		if state == model.JobStateScheduled {
-			attempts++
-		}
-		tenant, _ := tx.HGet(ctx, metaKey, metaFieldTenant).Result()
-
-		pipe := tx.TxPipeline()
-		pipe.HSet(ctx, metaKey, map[string]any{
-			"state":           string(state),
-			"updated_at":      now,
-			metaFieldAttempts: attempts,
-		})
-		// keep legacy key for compatibility
-		pipe.Set(ctx, jobStateKey(jobID), string(state), 0)
-
-		// maintain per-state index for reconciliation
-		prevIdx := stateIndexKey(prevState)
-		if prevIdx != "" {
-			pipe.ZRem(ctx, prevIdx, jobID)
-		}
-		idx := stateIndexKey(state)
-		if idx != "" {
-			pipe.ZAdd(ctx, idx, redis.Z{Score: float64(now), Member: jobID})
-		}
-
-		// Tenant active set: no TTL — self-manages via SAdd/SRem.
-		// A TTL would expire the key for long-running jobs, making them
-		// vanish from active counts while still running.
-		if tenant != "" {
-			activeKey := tenantActiveKey(tenant)
-			if isActiveState(state) {
-				pipe.SAdd(ctx, activeKey, jobID)
-			} else if terminalStates[state] {
-				pipe.SRem(ctx, activeKey, jobID)
-			}
-		}
-
-		// Maintain global recent jobs list (score = updated_at)
-		pipe.ZAdd(ctx, "job:recent", redis.Z{Score: float64(now), Member: jobID})
-		// Keep only last 1000
-		pipe.ZRemRangeByRank(ctx, "job:recent", 0, -1001)
-		if s.metaTTL > 0 {
-			pipe.Expire(ctx, metaKey, s.metaTTL)
-			pipe.Expire(ctx, jobStateKey(jobID), s.metaTTL)
-			pipe.Expire(ctx, jobResultPtrKey(jobID), s.metaTTL)
-		}
-
-		// append event
-		pipe.RPush(ctx, jobEventsKey(jobID), fmt.Sprintf("%d|%s", now, state))
-
-		if terminalStates[state] {
-			pipe.ZRem(ctx, deadlineIndexKey(), jobID)
-			pipe.HDel(ctx, metaKey, metaFieldDeadline)
-		}
-
-		_, execErr := pipe.Exec(ctx)
-		return execErr
-	}, metaKey, jobStateKey(jobID))
+	return s.SetStateWithContext(ctx, jobID, state, nil)
 }
 
 // ListRecentJobs returns the N most recently updated jobs.
@@ -1750,6 +1675,94 @@ func (s *RedisJobStore) SetSafetyDecision(ctx context.Context, jobID string, rec
 		return fmt.Errorf("job store set safety decision %s: %w", jobID, err)
 	}
 	return nil
+}
+
+// SetDelegationLineage stores the verified dispatch-time delegation lineage on
+// the job metadata hash as a JSON blob.
+func (s *RedisJobStore) SetDelegationLineage(ctx context.Context, jobID string, lineage model.DelegationLineage) error {
+	if jobID == "" {
+		return fmt.Errorf("jobID required")
+	}
+	encoded, err := json.Marshal(lineage)
+	if err != nil {
+		return fmt.Errorf("marshal delegation lineage: %w", err)
+	}
+	pipe := s.client.TxPipeline()
+	pipe.HSet(ctx, jobMetaKey(jobID), metaFieldDelegationLineage, string(encoded))
+	if s.metaTTL > 0 {
+		pipe.Expire(ctx, jobMetaKey(jobID), s.metaTTL)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("job store set delegation lineage %s: %w", jobID, err)
+	}
+	return nil
+}
+
+// GetDelegationLineage loads the verified dispatch-time delegation lineage from
+// the job metadata hash.
+func (s *RedisJobStore) GetDelegationLineage(ctx context.Context, jobID string) (model.DelegationLineage, error) {
+	if jobID == "" {
+		return model.DelegationLineage{}, fmt.Errorf("jobID required")
+	}
+	raw, err := s.client.HGet(ctx, jobMetaKey(jobID), metaFieldDelegationLineage).Result()
+	if err == redis.Nil || raw == "" {
+		return model.DelegationLineage{}, nil
+	}
+	if err != nil {
+		return model.DelegationLineage{}, fmt.Errorf("job store get delegation lineage %s: %w", jobID, err)
+	}
+	var lineage model.DelegationLineage
+	if err := json.Unmarshal([]byte(raw), &lineage); err != nil {
+		return model.DelegationLineage{}, fmt.Errorf("decode delegation lineage %s: %w", jobID, err)
+	}
+	return lineage, nil
+}
+
+// SetDelegationDispatchToken stores the raw delegation token required for
+// dispatch-time re-verification. It is intentionally persisted separately from
+// the public job request snapshot.
+func (s *RedisJobStore) SetDelegationDispatchToken(ctx context.Context, jobID string, token model.DelegationDispatchToken) error {
+	if jobID == "" {
+		return fmt.Errorf("jobID required")
+	}
+	if strings.TrimSpace(token.Token) == "" {
+		return nil
+	}
+	token.Token = strings.TrimSpace(token.Token)
+	token.Audience = strings.TrimSpace(token.Audience)
+	encoded, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("marshal delegation dispatch token: %w", err)
+	}
+	pipe := s.client.TxPipeline()
+	pipe.HSet(ctx, jobMetaKey(jobID), metaFieldDelegationDispatch, string(encoded))
+	if s.metaTTL > 0 {
+		pipe.Expire(ctx, jobMetaKey(jobID), s.metaTTL)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("job store set delegation dispatch token %s: %w", jobID, err)
+	}
+	return nil
+}
+
+// GetDelegationDispatchToken loads the raw delegation token stored for
+// dispatch-time re-verification.
+func (s *RedisJobStore) GetDelegationDispatchToken(ctx context.Context, jobID string) (model.DelegationDispatchToken, error) {
+	if jobID == "" {
+		return model.DelegationDispatchToken{}, fmt.Errorf("jobID required")
+	}
+	raw, err := s.client.HGet(ctx, jobMetaKey(jobID), metaFieldDelegationDispatch).Result()
+	if err == redis.Nil || raw == "" {
+		return model.DelegationDispatchToken{}, nil
+	}
+	if err != nil {
+		return model.DelegationDispatchToken{}, fmt.Errorf("job store get delegation dispatch token %s: %w", jobID, err)
+	}
+	var token model.DelegationDispatchToken
+	if err := json.Unmarshal([]byte(raw), &token); err != nil {
+		return model.DelegationDispatchToken{}, fmt.Errorf("decode delegation dispatch token %s: %w", jobID, err)
+	}
+	return token, nil
 }
 
 // SetOutputSafety stores output policy evaluation data on the job metadata hash.
@@ -2981,4 +2994,152 @@ func stringFromEntry(entry map[string]any, key string) string {
 		}
 	}
 	return ""
+}
+
+// parseJobEvent parses a raw event string from the job:events:{id} LIST.
+// It tries JSON first (new format), then falls back to "timestamp|state"
+// (old format). Returns (zero, false) for malformed entries.
+func parseJobEvent(raw string) (model.JobEvent, bool) {
+	var evt model.JobEvent
+	if err := json.Unmarshal([]byte(raw), &evt); err == nil && evt.State != "" {
+		return evt, true
+	}
+
+	// Fall back to old "timestamp|state" format.
+	parts := strings.SplitN(raw, "|", 2)
+	if len(parts) != 2 {
+		slog.Warn("malformed job event entry", "raw", raw)
+		return model.JobEvent{}, false
+	}
+	ts, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		slog.Warn("malformed job event timestamp", "raw", raw, "err", err)
+		return model.JobEvent{}, false
+	}
+	return model.JobEvent{Timestamp: ts, State: parts[1]}, true
+}
+
+// serializeJobEvent creates the JSON string for a job event entry.
+func serializeJobEvent(state model.JobState, nowMicros int64, evtCtx *model.StateEventContext) (string, error) {
+	evt := model.JobEvent{
+		Timestamp: nowMicros,
+		State:     string(state),
+		Context:   evtCtx,
+	}
+	b, err := json.Marshal(evt)
+	if err != nil {
+		return "", fmt.Errorf("marshal job event: %w", err)
+	}
+	return string(b), nil
+}
+
+// SetStateWithContext transitions a job to a new state and appends a rich
+// JSON event (with optional context) to the job:events:{id} LIST.
+// When evtCtx is nil, a minimal {"ts":...,"state":"..."} event is stored.
+func (s *RedisJobStore) SetStateWithContext(ctx context.Context, jobID string, state model.JobState, evtCtx *model.StateEventContext) error {
+	if jobID == "" || state == "" {
+		return fmt.Errorf("invalid jobID or state")
+	}
+
+	now := nowUnixMicros()
+	metaKey := jobMetaKey(jobID)
+
+	return s.client.Watch(ctx, func(tx *redis.Tx) error {
+		prev, err := tx.HGet(ctx, metaKey, "state").Result()
+		if err != nil && err != redis.Nil {
+			return fmt.Errorf("job store set state %s: %w", jobID, err)
+		}
+		prevState := model.JobState(prev)
+		if !isAllowedTransition(prevState, state) {
+			return fmt.Errorf("invalid transition %s -> %s", prevState, state)
+		}
+		attempts := 0
+		if raw, err := tx.HGet(ctx, metaKey, metaFieldAttempts).Result(); err == nil {
+			if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
+				attempts = parsed
+			}
+		}
+		if state == model.JobStateScheduled && prevState != model.JobStateScheduled {
+			attempts++
+		}
+		tenant, _ := tx.HGet(ctx, metaKey, metaFieldTenant).Result()
+
+		pipe := tx.TxPipeline()
+		pipe.HSet(ctx, metaKey, map[string]any{
+			"state":           string(state),
+			"updated_at":      now,
+			metaFieldAttempts: attempts,
+		})
+		// keep legacy key for compatibility
+		pipe.Set(ctx, jobStateKey(jobID), string(state), 0)
+
+		// maintain per-state index for reconciliation
+		prevIdx := stateIndexKey(prevState)
+		if prevIdx != "" {
+			pipe.ZRem(ctx, prevIdx, jobID)
+		}
+		idx := stateIndexKey(state)
+		if idx != "" {
+			pipe.ZAdd(ctx, idx, redis.Z{Score: float64(now), Member: jobID})
+		}
+
+		if tenant != "" {
+			activeKey := tenantActiveKey(tenant)
+			if isActiveState(state) {
+				pipe.SAdd(ctx, activeKey, jobID)
+			} else if terminalStates[state] {
+				pipe.SRem(ctx, activeKey, jobID)
+			}
+			if s.metaTTL > 0 {
+				pipe.Expire(ctx, activeKey, s.metaTTL)
+			}
+		}
+
+		// Maintain global recent jobs list (score = updated_at)
+		pipe.ZAdd(ctx, "job:recent", redis.Z{Score: float64(now), Member: jobID})
+		// Keep only last 1000
+		pipe.ZRemRangeByRank(ctx, "job:recent", 0, -1001)
+		if s.metaTTL > 0 {
+			pipe.Expire(ctx, metaKey, s.metaTTL)
+			pipe.Expire(ctx, jobStateKey(jobID), s.metaTTL)
+			pipe.Expire(ctx, jobResultPtrKey(jobID), s.metaTTL)
+		}
+
+		// append rich event
+		eventStr, err := serializeJobEvent(state, now, evtCtx)
+		if err != nil {
+			return err
+		}
+		pipe.RPush(ctx, jobEventsKey(jobID), eventStr)
+
+		if terminalStates[state] {
+			pipe.ZRem(ctx, deadlineIndexKey(), jobID)
+			pipe.HDel(ctx, metaKey, metaFieldDeadline)
+		}
+
+		_, execErr := pipe.Exec(ctx)
+		return execErr
+	}, metaKey, jobStateKey(jobID))
+}
+
+// GetJobEvents returns all state transition events for a job, parsed from
+// the job:events:{id} LIST. Handles both JSON (new) and "timestamp|state"
+// (old) formats. Malformed entries are skipped with a warning log.
+func (s *RedisJobStore) GetJobEvents(ctx context.Context, jobID string) ([]model.JobEvent, error) {
+	if jobID == "" {
+		return nil, fmt.Errorf("job store get events: empty jobID")
+	}
+	raw, err := s.client.LRange(ctx, jobEventsKey(jobID), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("job store get events %s: %w", jobID, err)
+	}
+	events := make([]model.JobEvent, 0, len(raw))
+	for _, entry := range raw {
+		evt, ok := parseJobEvent(entry)
+		if !ok {
+			continue
+		}
+		events = append(events, evt)
+	}
+	return events, nil
 }

--- a/core/infra/store/job_store_test.go
+++ b/core/infra/store/job_store_test.go
@@ -101,6 +101,59 @@ func TestRedisJobStoreResultPtrTTL(t *testing.T) {
 	}
 }
 
+func TestRedisJobStoreDelegationLineageRoundTrip(t *testing.T) {
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("failed to create job store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+	jobID := "job-delegation-lineage"
+	want := model.DelegationLineage{
+		TokenJTI:       "dlg-jti-1",
+		ParentTokenJTI: "dlg-parent-1",
+		Subject:        "agent-a",
+		Audience:       "agent-b",
+		Tenant:         "default",
+		RootIssuer:     "agent-a",
+		ParentIssuer:   "agent-a",
+		IssuerChain: []model.DelegationChainLink{{
+			AgentID:   "agent-a",
+			IssuedAt:  "2026-04-21T09:00:00Z",
+			ExpiresAt: "2026-04-21T10:00:00Z",
+			JTI:       "dlg-jti-1",
+			IssuedBy:  "agent-a",
+		}},
+		ChainDepth:    1,
+		ExpiresAt:     "2026-04-21T10:00:00Z",
+		Scope:         []string{"read"},
+		AllowedTopics: []string{"job.test"},
+		VerifiedAt:    1_713_680_000_000_000,
+	}
+
+	if err := store.SetDelegationLineage(ctx, jobID, want); err != nil {
+		t.Fatalf("SetDelegationLineage() error = %v", err)
+	}
+	got, err := store.GetDelegationLineage(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetDelegationLineage() error = %v", err)
+	}
+	if got.TokenJTI != want.TokenJTI || got.Audience != want.Audience || got.RootIssuer != want.RootIssuer || got.ChainDepth != want.ChainDepth {
+		t.Fatalf("delegation lineage mismatch: got %#v want %#v", got, want)
+	}
+	if len(got.IssuerChain) != 1 || got.IssuerChain[0].AgentID != "agent-a" {
+		t.Fatalf("issuer chain mismatch: %#v", got.IssuerChain)
+	}
+	if len(got.Scope) != 1 || got.Scope[0] != "read" {
+		t.Fatalf("scope mismatch: %#v", got.Scope)
+	}
+}
+
 func TestRedisJobStoreTransitionGuard(t *testing.T) {
 	srv, err := miniredis.Run()
 	if err != nil {
@@ -1934,180 +1987,277 @@ func TestNewRedisJobStore_InvalidTTLWarns(t *testing.T) {
 	}
 }
 
-// TestDeadlineSameSecondOrdering verifies that two jobs with deadlines in the
-// same second are ordered deterministically by their microsecond-precision scores.
-func TestDeadlineSameSecondOrdering(t *testing.T) {
-	srv, err := miniredis.Run()
-	if err != nil {
-		t.Skipf("miniredis unavailable: %v", err)
+func TestParseJobEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantOK  bool
+		wantTS  int64
+		wantSt  string
+		wantCtx bool
+	}{
+		{
+			name:   "valid JSON minimal",
+			raw:    `{"ts":1700000000,"state":"PENDING"}`,
+			wantOK: true, wantTS: 1700000000, wantSt: "PENDING",
+		},
+		{
+			name:    "valid JSON with context",
+			raw:     `{"ts":1700000001,"state":"SCHEDULED","ctx":{"rule":"r1","eval_ms":42}}`,
+			wantOK:  true, wantTS: 1700000001, wantSt: "SCHEDULED",
+			wantCtx: true,
+		},
+		{
+			name:   "old format timestamp|state",
+			raw:    "1700000002|RUNNING",
+			wantOK: true, wantTS: 1700000002, wantSt: "RUNNING",
+		},
+		{
+			name:   "malformed no separator",
+			raw:    "garbage",
+			wantOK: false,
+		},
+		{
+			name:   "malformed bad timestamp",
+			raw:    "notanumber|PENDING",
+			wantOK: false,
+		},
+		{
+			name:   "empty string",
+			raw:    "",
+			wantOK: false,
+		},
+		{
+			name:   "JSON with empty state is invalid",
+			raw:    `{"ts":123,"state":""}`,
+			wantOK: false,
+		},
 	}
-	store, err := NewRedisJobStore("redis://" + srv.Addr())
-	if err != nil {
-		t.Fatalf("create store: %v", err)
-	}
-	defer func() { _ = store.Close() }()
-	ctx := context.Background()
-
-	base := time.Now().Add(-5 * time.Minute)
-	// Two deadlines 500ms apart — same Unix second, different microseconds.
-	d1 := base
-	d2 := base.Add(500 * time.Millisecond)
-
-	if err := store.SetDeadline(ctx, "job-early", d1); err != nil {
-		t.Fatalf("set deadline 1: %v", err)
-	}
-	if err := store.SetDeadline(ctx, "job-late", d2); err != nil {
-		t.Fatalf("set deadline 2: %v", err)
-	}
-
-	expired, err := store.ListExpiredDeadlines(ctx, time.Now().Unix(), 10)
-	if err != nil {
-		t.Fatalf("list expired: %v", err)
-	}
-	if len(expired) != 2 {
-		t.Fatalf("expected 2 expired jobs, got %d", len(expired))
-	}
-	// First result should be the earlier deadline.
-	if expired[0].ID != "job-early" {
-		t.Fatalf("expected job-early first (earlier deadline), got %s", expired[0].ID)
-	}
-	if expired[1].ID != "job-late" {
-		t.Fatalf("expected job-late second, got %s", expired[1].ID)
-	}
-}
-
-// TestPaginationNoGaps creates 100 jobs and paginates with limit=10,
-// verifying no gaps or duplicates across all pages.
-func TestPaginationNoGaps(t *testing.T) {
-	srv, err := miniredis.Run()
-	if err != nil {
-		t.Skipf("miniredis unavailable: %v", err)
-	}
-	store, err := NewRedisJobStore("redis://" + srv.Addr())
-	if err != nil {
-		t.Fatalf("create store: %v", err)
-	}
-	defer func() { _ = store.Close() }()
-	ctx := context.Background()
-
-	const total = 100
-	for i := 0; i < total; i++ {
-		jobID := fmt.Sprintf("job-page-%03d", i)
-		if err := store.SetState(ctx, jobID, model.JobStatePending); err != nil {
-			t.Fatalf("set state %s: %v", jobID, err)
-		}
-		// Small delay to ensure distinct microsecond scores.
-		time.Sleep(time.Microsecond)
-	}
-
-	seen := make(map[string]bool)
-	var cursor int64
-	pages := 0
-	for {
-		jobs, err := store.ListRecentJobsByScore(ctx, cursor, 10)
-		if err != nil {
-			t.Fatalf("list page %d: %v", pages, err)
-		}
-		if len(jobs) == 0 {
-			break
-		}
-		for _, job := range jobs {
-			if seen[job.ID] {
-				t.Fatalf("duplicate job ID %s on page %d", job.ID, pages)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt, ok := parseJobEvent(tt.raw)
+			if ok != tt.wantOK {
+				t.Fatalf("parseJobEvent ok=%v, want %v", ok, tt.wantOK)
 			}
-			seen[job.ID] = true
+			if !ok {
+				return
+			}
+			if evt.Timestamp != tt.wantTS {
+				t.Errorf("timestamp=%d, want %d", evt.Timestamp, tt.wantTS)
+			}
+			if evt.State != tt.wantSt {
+				t.Errorf("state=%q, want %q", evt.State, tt.wantSt)
+			}
+			if tt.wantCtx && evt.Context == nil {
+				t.Error("expected non-nil context")
+			}
+			if !tt.wantCtx && evt.Context != nil {
+				t.Error("expected nil context")
+			}
+		})
+	}
+}
+
+func TestSetStateWithContext_RoundTrip(t *testing.T) {
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("failed to create job store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	jobID := "job-evt-1"
+
+	// Set initial state with rich context
+	evtCtx := &model.StateEventContext{
+		Rule:   "safety-rule-1",
+		Reason: "PII detected",
+		EvalMs: 42,
+		EvalPath: []string{"input_scan", "pii_check"},
+		Topic:  "job.default",
+		Extra:  map[string]string{"custom": "value"},
+	}
+	if err := store.SetStateWithContext(ctx, jobID, model.JobStatePending, evtCtx); err != nil {
+		t.Fatalf("SetStateWithContext: %v", err)
+	}
+
+	events, err := store.GetJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJobEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	evt := events[0]
+	if evt.State != string(model.JobStatePending) {
+		t.Errorf("state=%q, want %q", evt.State, model.JobStatePending)
+	}
+	if evt.Timestamp <= 0 {
+		t.Error("expected positive timestamp")
+	}
+	if evt.Context == nil {
+		t.Fatal("expected non-nil context")
+	}
+	if evt.Context.Rule != "safety-rule-1" {
+		t.Errorf("rule=%q, want %q", evt.Context.Rule, "safety-rule-1")
+	}
+	if evt.Context.Reason != "PII detected" {
+		t.Errorf("reason=%q, want %q", evt.Context.Reason, "PII detected")
+	}
+	if evt.Context.EvalMs != 42 {
+		t.Errorf("eval_ms=%d, want 42", evt.Context.EvalMs)
+	}
+	if len(evt.Context.EvalPath) != 2 || evt.Context.EvalPath[0] != "input_scan" {
+		t.Errorf("eval_path=%v, want [input_scan pii_check]", evt.Context.EvalPath)
+	}
+	if evt.Context.Extra["custom"] != "value" {
+		t.Errorf("extra[custom]=%q, want %q", evt.Context.Extra["custom"], "value")
+	}
+}
+
+func TestSetStateWithContext_NilCtx(t *testing.T) {
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("failed to create job store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	jobID := "job-evt-nil"
+
+	if err := store.SetStateWithContext(ctx, jobID, model.JobStatePending, nil); err != nil {
+		t.Fatalf("SetStateWithContext nil ctx: %v", err)
+	}
+
+	events, err := store.GetJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJobEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].State != string(model.JobStatePending) {
+		t.Errorf("state=%q, want %q", events[0].State, model.JobStatePending)
+	}
+	if events[0].Context != nil {
+		t.Error("expected nil context for nil evtCtx")
+	}
+}
+
+func TestSetState_StillWorks(t *testing.T) {
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("failed to create job store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	jobID := "job-evt-legacy"
+
+	if err := store.SetState(ctx, jobID, model.JobStatePending); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
+
+	// Verify state was set correctly
+	state, err := store.GetState(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if state != model.JobStatePending {
+		t.Errorf("state=%q, want %q", state, model.JobStatePending)
+	}
+
+	// Verify event is parseable via GetJobEvents
+	events, err := store.GetJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJobEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].State != string(model.JobStatePending) {
+		t.Errorf("event state=%q, want %q", events[0].State, model.JobStatePending)
+	}
+}
+
+func TestGetJobEvents_NonExistentJob(t *testing.T) {
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("failed to create job store: %v", err)
+	}
+	defer store.Close()
+
+	events, err := store.GetJobEvents(context.Background(), "job-does-not-exist")
+	if err != nil {
+		t.Fatalf("expected no error for non-existent job, got: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected empty slice, got %d events", len(events))
+	}
+}
+
+func TestGetJobEvents_ChronologicalOrder(t *testing.T) {
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("failed to create job store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	jobID := "job-evt-order"
+
+	states := []model.JobState{
+		model.JobStatePending,
+		model.JobStateScheduled,
+		model.JobStateDispatched,
+		model.JobStateRunning,
+		model.JobStateSucceeded,
+	}
+	for _, s := range states {
+		if err := store.SetState(ctx, jobID, s); err != nil {
+			t.Fatalf("SetState(%s): %v", s, err)
 		}
-		// Use the last job's UpdatedAt as cursor for next page.
-		cursor = jobs[len(jobs)-1].UpdatedAt - 1
-		pages++
-		if pages > 20 {
-			t.Fatal("too many pages, possible infinite loop")
+	}
+
+	events, err := store.GetJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJobEvents: %v", err)
+	}
+	if len(events) != len(states) {
+		t.Fatalf("expected %d events, got %d", len(states), len(events))
+	}
+	for i, evt := range events {
+		if evt.State != string(states[i]) {
+			t.Errorf("event[%d] state=%q, want %q", i, evt.State, states[i])
+		}
+		if i > 0 && evt.Timestamp < events[i-1].Timestamp {
+			t.Errorf("event[%d] timestamp %d < event[%d] timestamp %d (not chronological)",
+				i, evt.Timestamp, i-1, events[i-1].Timestamp)
 		}
 	}
-	if len(seen) != total {
-		t.Fatalf("expected %d unique jobs, got %d (pages=%d)", total, len(seen), pages)
-	}
 }
 
-// TestTenantActiveSetNoExpiry verifies that the tenant active set does not
-// expire, so long-running jobs remain in active counts.
-func TestTenantActiveSetNoExpiry(t *testing.T) {
-	srv, err := miniredis.Run()
-	if err != nil {
-		t.Skipf("miniredis unavailable: %v", err)
-	}
-	store, err := NewRedisJobStore("redis://" + srv.Addr())
-	if err != nil {
-		t.Fatalf("create store: %v", err)
-	}
-	defer func() { _ = store.Close() }()
-	ctx := context.Background()
-
-	if err := store.SetTenant(ctx, "job-long", "tenant-long"); err != nil {
-		t.Fatalf("set tenant: %v", err)
-	}
-	if err := store.SetState(ctx, "job-long", model.JobStateRunning); err != nil {
-		t.Fatalf("set state: %v", err)
-	}
-
-	count, err := store.CountActiveByTenant(ctx, "tenant-long")
-	if err != nil {
-		t.Fatalf("count active: %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("expected 1 active, got %d", count)
-	}
-
-	// Fast-forward past the default metaTTL (7 days + buffer).
-	srv.FastForward(8 * 24 * time.Hour)
-
-	count, err = store.CountActiveByTenant(ctx, "tenant-long")
-	if err != nil {
-		t.Fatalf("count active after 8 days: %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("expected 1 active after 8 days (no TTL expiry), got %d", count)
-	}
-}
-
-// TestBuildJobRecordsPipelineError verifies that a pipeline execution failure
-// in buildJobRecords surfaces as an error, not silently skipped.
-func TestBuildJobRecordsPipelineError(t *testing.T) {
-	srv, err := miniredis.Run()
-	if err != nil {
-		t.Skipf("miniredis unavailable: %v", err)
-	}
-	store, err := NewRedisJobStore("redis://" + srv.Addr())
-	if err != nil {
-		t.Fatalf("create store: %v", err)
-	}
-	defer func() { _ = store.Close() }()
-	ctx := context.Background()
-
-	// Create a job so there's something to list.
-	if err := store.SetState(ctx, "job-pipe", model.JobStatePending); err != nil {
-		t.Fatalf("set state: %v", err)
-	}
-
-	// Verify normal operation works.
-	jobs, err := store.ListRecentJobs(ctx, 10)
-	if err != nil {
-		t.Fatalf("list recent: %v", err)
-	}
-	if len(jobs) == 0 {
-		t.Fatal("expected at least 1 job")
-	}
-
-	// Close the miniredis server to simulate connection failure.
-	srv.Close()
-
-	_, err = store.ListRecentJobs(ctx, 10)
-	if err == nil {
-		t.Fatal("expected error when Redis is down, got nil")
-	}
-}
-
-func TestListRecentJobsByTimeRange(t *testing.T) {
+func TestGetJobEvents_MixedFormats(t *testing.T) {
 	srv, err := miniredis.Run()
 	if err != nil {
 		t.Skipf("miniredis unavailable: %v", err)
@@ -2116,188 +2266,45 @@ func TestListRecentJobsByTimeRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create job store: %v", err)
 	}
-	defer func() { _ = store.Close() }()
+	defer store.Close()
 
 	ctx := context.Background()
+	jobID := "job-evt-mixed"
+	eventsKey := jobEventsKey(jobID)
 
-	// Insert three jobs with known timestamps via SetState which adds to job:recent.
-	if err := store.SetState(ctx, "tr-job-1", model.JobStatePending); err != nil {
-		t.Fatalf("set state: %v", err)
-	}
-	time.Sleep(10 * time.Millisecond)
-	if err := store.SetState(ctx, "tr-job-2", model.JobStateDispatched); err != nil {
-		t.Fatalf("set state: %v", err)
-	}
-	time.Sleep(10 * time.Millisecond)
-	if err := store.SetState(ctx, "tr-job-3", model.JobStateRunning); err != nil {
-		t.Fatalf("set state: %v", err)
-	}
+	// Manually push old-format and new-format entries plus a malformed one
+	store.client.RPush(ctx, eventsKey, "1700000001|PENDING")
+	store.client.RPush(ctx, eventsKey, `{"ts":1700000002,"state":"SCHEDULED","ctx":{"rule":"r1"}}`)
+	store.client.RPush(ctx, eventsKey, "totally-broken")
+	store.client.RPush(ctx, eventsKey, "1700000003|RUNNING")
 
-	// Query the full time range — should get all 3 jobs.
-	from := time.Now().Add(-1 * time.Hour).UnixMicro()
-	to := time.Now().Add(1 * time.Hour).UnixMicro()
-	ids, err := store.ListRecentJobsByTimeRange(ctx, from, to, 0, 100)
+	events, err := store.GetJobEvents(ctx, jobID)
 	if err != nil {
-		t.Fatalf("ListRecentJobsByTimeRange: %v", err)
+		t.Fatalf("GetJobEvents: %v", err)
 	}
-	if len(ids) != 3 {
-		t.Fatalf("expected 3 jobs, got %d: %v", len(ids), ids)
-	}
-
-	// Query with limit=2 should return first 2 in score order.
-	ids, err = store.ListRecentJobsByTimeRange(ctx, from, to, 0, 2)
-	if err != nil {
-		t.Fatalf("ListRecentJobsByTimeRange with limit: %v", err)
-	}
-	if len(ids) != 2 {
-		t.Fatalf("expected 2 jobs, got %d", len(ids))
+	// Malformed entry should be skipped
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events (1 skipped), got %d", len(events))
 	}
 
-	// Query with cursor=2 should return the remaining 1.
-	ids, err = store.ListRecentJobsByTimeRange(ctx, from, to, 2, 100)
-	if err != nil {
-		t.Fatalf("ListRecentJobsByTimeRange with cursor: %v", err)
+	// First: old format
+	if events[0].State != "PENDING" || events[0].Timestamp != 1700000001 {
+		t.Errorf("event[0]=%+v, want PENDING@1700000001", events[0])
 	}
-	if len(ids) != 1 {
-		t.Fatalf("expected 1 job at cursor=2, got %d", len(ids))
-	}
-
-	// Query a future time range — should return 0 jobs.
-	futureFrom := time.Now().Add(1 * time.Hour).UnixMicro()
-	futureTo := time.Now().Add(2 * time.Hour).UnixMicro()
-	ids, err = store.ListRecentJobsByTimeRange(ctx, futureFrom, futureTo, 0, 100)
-	if err != nil {
-		t.Fatalf("ListRecentJobsByTimeRange future range: %v", err)
-	}
-	if len(ids) != 0 {
-		t.Fatalf("expected 0 jobs in future range, got %d", len(ids))
-	}
-}
-
-func TestGetJobRequests(t *testing.T) {
-	srv, err := miniredis.Run()
-	if err != nil {
-		t.Skipf("miniredis unavailable: %v", err)
-	}
-	store, err := NewRedisJobStore("redis://" + srv.Addr())
-	if err != nil {
-		t.Fatalf("failed to create job store: %v", err)
-	}
-	defer func() { _ = store.Close() }()
-
-	ctx := context.Background()
-
-	// Store two job requests.
-	req1 := &pb.JobRequest{JobId: "req-job-1", Topic: "job.test", TenantId: "tenant-a"}
-	req2 := &pb.JobRequest{JobId: "req-job-2", Topic: "job.other", TenantId: "tenant-b"}
-	if err := store.SetJobRequest(ctx, req1); err != nil {
-		t.Fatalf("set job request 1: %v", err)
-	}
-	if err := store.SetJobRequest(ctx, req2); err != nil {
-		t.Fatalf("set job request 2: %v", err)
+	if events[0].Context != nil {
+		t.Error("event[0] should have nil context (old format)")
 	}
 
-	// Batch fetch both plus a missing key.
-	result, err := store.GetJobRequests(ctx, []string{"req-job-1", "req-job-2", "req-job-missing"})
-	if err != nil {
-		t.Fatalf("GetJobRequests: %v", err)
+	// Second: new JSON format with context
+	if events[1].State != "SCHEDULED" || events[1].Timestamp != 1700000002 {
+		t.Errorf("event[1]=%+v, want SCHEDULED@1700000002", events[1])
 	}
-	if len(result) != 2 {
-		t.Fatalf("expected 2 results, got %d", len(result))
-	}
-	if _, ok := result["req-job-1"]; !ok {
-		t.Fatal("missing req-job-1 in results")
-	}
-	if _, ok := result["req-job-2"]; !ok {
-		t.Fatal("missing req-job-2 in results")
-	}
-	if _, ok := result["req-job-missing"]; ok {
-		t.Fatal("expected missing key to be absent")
+	if events[1].Context == nil || events[1].Context.Rule != "r1" {
+		t.Errorf("event[1] context=%+v, want rule=r1", events[1].Context)
 	}
 
-	// Empty input.
-	result, err = store.GetJobRequests(ctx, nil)
-	if err != nil {
-		t.Fatalf("GetJobRequests empty: %v", err)
-	}
-	if len(result) != 0 {
-		t.Fatalf("expected 0 results for empty input, got %d", len(result))
-	}
-}
-
-func TestGetJobMetas(t *testing.T) {
-	srv, err := miniredis.Run()
-	if err != nil {
-		t.Skipf("miniredis unavailable: %v", err)
-	}
-	store, err := NewRedisJobStore("redis://" + srv.Addr())
-	if err != nil {
-		t.Fatalf("failed to create job store: %v", err)
-	}
-	defer func() { _ = store.Close() }()
-
-	ctx := context.Background()
-
-	// Store two jobs' metadata via SetJobMeta.
-	req1 := &pb.JobRequest{
-		JobId:    "meta-job-1",
-		Topic:    "job.alpha",
-		TenantId: "t1",
-		Meta:     &pb.JobMetadata{TenantId: "t1", ActorId: "actor-1"},
-	}
-	req2 := &pb.JobRequest{
-		JobId:    "meta-job-2",
-		Topic:    "job.beta",
-		TenantId: "t2",
-		Meta:     &pb.JobMetadata{TenantId: "t2", Capability: "cap-a"},
-	}
-	if err := store.SetJobMeta(ctx, req1); err != nil {
-		t.Fatalf("set job meta 1: %v", err)
-	}
-	if err := store.SetJobMeta(ctx, req2); err != nil {
-		t.Fatalf("set job meta 2: %v", err)
-	}
-
-	// Batch fetch.
-	result, err := store.GetJobMetas(ctx, []string{"meta-job-1", "meta-job-2", "meta-job-missing"})
-	if err != nil {
-		t.Fatalf("GetJobMetas: %v", err)
-	}
-	if len(result) != 2 {
-		t.Fatalf("expected 2 results, got %d", len(result))
-	}
-	m1, ok := result["meta-job-1"]
-	if !ok {
-		t.Fatal("missing meta-job-1")
-	}
-	if m1["topic"] != "job.alpha" {
-		t.Fatalf("expected topic job.alpha, got %s", m1["topic"])
-	}
-	if m1["tenant"] != "t1" {
-		t.Fatalf("expected tenant t1, got %s", m1["tenant"])
-	}
-
-	m2, ok := result["meta-job-2"]
-	if !ok {
-		t.Fatal("missing meta-job-2")
-	}
-	if m2["topic"] != "job.beta" {
-		t.Fatalf("expected topic job.beta, got %s", m2["topic"])
-	}
-	if m2["capability"] != "cap-a" {
-		t.Fatalf("expected capability cap-a, got %s", m2["capability"])
-	}
-
-	if _, ok := result["meta-job-missing"]; ok {
-		t.Fatal("expected missing key to be absent")
-	}
-
-	// Empty input.
-	result, err = store.GetJobMetas(ctx, nil)
-	if err != nil {
-		t.Fatalf("GetJobMetas empty: %v", err)
-	}
-	if len(result) != 0 {
-		t.Fatalf("expected 0 results for empty input, got %d", len(result))
+	// Third: old format
+	if events[2].State != "RUNNING" || events[2].Timestamp != 1700000003 {
+		t.Errorf("event[2]=%+v, want RUNNING@1700000003", events[2])
 	}
 }

--- a/core/model/decision_log.go
+++ b/core/model/decision_log.go
@@ -1,0 +1,178 @@
+package model
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+const (
+	DefaultDecisionQueryLimit = 50
+	MaxDecisionQueryLimit     = 500
+	defaultDecisionQueryRange = 24 * time.Hour
+)
+
+const (
+	DecisionVerdictAllow           = "allow"
+	DecisionVerdictDeny            = "deny"
+	DecisionVerdictConstrain       = "constrain"
+	DecisionVerdictRequireApproval = "require_approval"
+	DecisionVerdictThrottle        = "throttle"
+)
+
+// DecisionLogRecord captures the governance fields required for the Policy
+// Decision Log and stays wire-compatible with audit.SIEMEvent projections.
+type DecisionLogRecord struct {
+	JobID            string                `json:"job_id,omitempty"`
+	Tenant           string                `json:"tenant,omitempty"`
+	AgentID          string                `json:"agent_id,omitempty"`
+	Topic            string                `json:"topic,omitempty"`
+	Verdict          SafetyDecision        `json:"verdict,omitempty"`
+	RuleID           string                `json:"rule_id,omitempty"`
+	PolicyVersion    string                `json:"policy_version,omitempty"`
+	Reason           string                `json:"reason,omitempty"`
+	Constraints      *pb.PolicyConstraints `json:"constraints,omitempty"`
+	ApprovalStatus   ApprovalStatus        `json:"approval_status,omitempty"`
+	ApprovalDecision ApprovalDecision      `json:"approval_decision,omitempty"`
+	Timestamp        int64                 `json:"timestamp,omitempty"`
+}
+
+// DecisionQuery scopes Policy Decision Log lookups for a single tenant.
+type DecisionQuery struct {
+	Tenant  string         `json:"tenant,omitempty"`
+	Since   int64          `json:"since,omitempty"`
+	Until   int64          `json:"until,omitempty"`
+	Topic   string         `json:"topic,omitempty"`
+	RuleID  string         `json:"rule_id,omitempty"`
+	Verdict SafetyDecision `json:"verdict,omitempty"`
+	AgentID string         `json:"agent_id,omitempty"`
+	Cursor  string         `json:"cursor,omitempty"`
+	Limit   int            `json:"limit,omitempty"`
+}
+
+// DecisionPage is one page of Policy Decision Log results.
+type DecisionPage struct {
+	Items      []DecisionLogRecord `json:"items"`
+	NextCursor string              `json:"next_cursor,omitempty"`
+}
+
+// Normalize applies defaults and validates the query.
+func (q DecisionQuery) Normalize(now time.Time) (DecisionQuery, error) {
+	normalized := q
+	normalized.Tenant = strings.TrimSpace(normalized.Tenant)
+	normalized.Topic = strings.TrimSpace(normalized.Topic)
+	normalized.RuleID = strings.TrimSpace(normalized.RuleID)
+	normalized.AgentID = strings.TrimSpace(normalized.AgentID)
+	normalized.Cursor = strings.TrimSpace(normalized.Cursor)
+
+	if normalized.Tenant == "" {
+		return DecisionQuery{}, fmt.Errorf("decision query tenant is required")
+	}
+
+	if normalized.Limit <= 0 {
+		normalized.Limit = DefaultDecisionQueryLimit
+	}
+	if normalized.Limit > MaxDecisionQueryLimit {
+		return DecisionQuery{}, fmt.Errorf("decision query limit must be <= %d", MaxDecisionQueryLimit)
+	}
+
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	switch {
+	case normalized.Since == 0 && normalized.Until == 0:
+		normalized.Until = now.UnixMilli()
+		normalized.Since = now.Add(-defaultDecisionQueryRange).UnixMilli()
+	case normalized.Since == 0:
+		normalized.Since = time.UnixMilli(normalized.Until).Add(-defaultDecisionQueryRange).UnixMilli()
+	case normalized.Until == 0:
+		normalized.Until = now.UnixMilli()
+	}
+
+	if normalized.Until < normalized.Since {
+		return DecisionQuery{}, fmt.Errorf("decision query until must be >= since")
+	}
+
+	if normalized.Verdict != "" {
+		if _, err := normalized.Verdict.DecisionLogWireValue(); err != nil {
+			return DecisionQuery{}, err
+		}
+	}
+
+	if normalized.Cursor != "" {
+		if _, _, err := DecodeDecisionCursor(normalized.Cursor); err != nil {
+			return DecisionQuery{}, err
+		}
+	}
+
+	return normalized, nil
+}
+
+// DecisionLogWireValue returns the lowercase wire value for API transport.
+func (d SafetyDecision) DecisionLogWireValue() (string, error) {
+	switch d {
+	case SafetyAllow:
+		return DecisionVerdictAllow, nil
+	case SafetyDeny:
+		return DecisionVerdictDeny, nil
+	case SafetyAllowWithConstraints:
+		return DecisionVerdictConstrain, nil
+	case SafetyRequireApproval:
+		return DecisionVerdictRequireApproval, nil
+	case SafetyThrottle:
+		return DecisionVerdictThrottle, nil
+	default:
+		return "", fmt.Errorf("unknown decision verdict %q", d)
+	}
+}
+
+// ParseDecisionLogVerdict converts the API wire enum to the canonical model enum.
+func ParseDecisionLogVerdict(raw string) (SafetyDecision, error) {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "":
+		return "", nil
+	case DecisionVerdictAllow:
+		return SafetyAllow, nil
+	case DecisionVerdictDeny:
+		return SafetyDeny, nil
+	case DecisionVerdictConstrain:
+		return SafetyAllowWithConstraints, nil
+	case DecisionVerdictRequireApproval:
+		return SafetyRequireApproval, nil
+	case DecisionVerdictThrottle:
+		return SafetyThrottle, nil
+	default:
+		return "", fmt.Errorf("unknown decision verdict %q", raw)
+	}
+}
+
+// EncodeDecisionCursor produces the opaque cursor format used by the API.
+func EncodeDecisionCursor(timestamp int64, id string) string {
+	payload := fmt.Sprintf("%d:%s", timestamp, id)
+	return base64.RawURLEncoding.EncodeToString([]byte(payload))
+}
+
+// DecodeDecisionCursor parses the opaque cursor format used by the API.
+func DecodeDecisionCursor(cursor string) (int64, string, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(cursor))
+	if err != nil {
+		return 0, "", fmt.Errorf("decode decision cursor: %w", err)
+	}
+	raw := string(decoded)
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return 0, "", fmt.Errorf("decode decision cursor: invalid cursor payload")
+	}
+	timestamp, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("decode decision cursor timestamp: %w", err)
+	}
+	return timestamp, parts[1], nil
+}

--- a/core/model/decision_log_test.go
+++ b/core/model/decision_log_test.go
@@ -1,0 +1,219 @@
+package model
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDecisionQueryNormalize(t *testing.T) {
+	now := time.Date(2026, time.April, 20, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		query   DecisionQuery
+		check   func(t *testing.T, got DecisionQuery)
+		wantErr string
+	}{
+		{
+			name:  "defaults last day and limit",
+			query: DecisionQuery{Tenant: "tenant-a"},
+			check: func(t *testing.T, got DecisionQuery) {
+				t.Helper()
+				if got.Limit != DefaultDecisionQueryLimit {
+					t.Fatalf("Limit=%d want %d", got.Limit, DefaultDecisionQueryLimit)
+				}
+				if got.Until != now.UnixMilli() {
+					t.Fatalf("Until=%d want %d", got.Until, now.UnixMilli())
+				}
+				if got.Since != now.Add(-24*time.Hour).UnixMilli() {
+					t.Fatalf("Since=%d want %d", got.Since, now.Add(-24*time.Hour).UnixMilli())
+				}
+			},
+		},
+		{
+			name: "fills missing until with now",
+			query: DecisionQuery{
+				Tenant: "tenant-a",
+				Since:  now.Add(-2 * time.Hour).UnixMilli(),
+				Limit:  25,
+			},
+			check: func(t *testing.T, got DecisionQuery) {
+				t.Helper()
+				if got.Until != now.UnixMilli() {
+					t.Fatalf("Until=%d want %d", got.Until, now.UnixMilli())
+				}
+				if got.Since != now.Add(-2*time.Hour).UnixMilli() {
+					t.Fatalf("Since=%d want %d", got.Since, now.Add(-2*time.Hour).UnixMilli())
+				}
+				if got.Limit != 25 {
+					t.Fatalf("Limit=%d want 25", got.Limit)
+				}
+			},
+		},
+		{
+			name: "fills missing since from until",
+			query: DecisionQuery{
+				Tenant: "tenant-a",
+				Until:  now.Add(-3 * time.Hour).UnixMilli(),
+			},
+			check: func(t *testing.T, got DecisionQuery) {
+				t.Helper()
+				wantSince := now.Add(-27 * time.Hour).UnixMilli()
+				if got.Since != wantSince {
+					t.Fatalf("Since=%d want %d", got.Since, wantSince)
+				}
+			},
+		},
+		{
+			name: "accepts supported verdict",
+			query: DecisionQuery{
+				Tenant:  "tenant-a",
+				Verdict: SafetyAllowWithConstraints,
+			},
+			check: func(t *testing.T, got DecisionQuery) {
+				t.Helper()
+				if got.Verdict != SafetyAllowWithConstraints {
+					t.Fatalf("Verdict=%q want %q", got.Verdict, SafetyAllowWithConstraints)
+				}
+			},
+		},
+		{
+			name: "accepts valid cursor",
+			query: DecisionQuery{
+				Tenant: "tenant-a",
+				Cursor: EncodeDecisionCursor(now.UnixMilli(), "job-1"),
+			},
+			check: func(t *testing.T, got DecisionQuery) {
+				t.Helper()
+				if got.Cursor == "" {
+					t.Fatal("Cursor unexpectedly empty")
+				}
+			},
+		},
+		{
+			name:    "requires tenant",
+			query:   DecisionQuery{},
+			wantErr: "tenant is required",
+		},
+		{
+			name: "rejects until before since",
+			query: DecisionQuery{
+				Tenant: "tenant-a",
+				Since:  now.UnixMilli(),
+				Until:  now.Add(-time.Minute).UnixMilli(),
+			},
+			wantErr: "until must be >= since",
+		},
+		{
+			name: "rejects limit above max",
+			query: DecisionQuery{
+				Tenant: "tenant-a",
+				Limit:  MaxDecisionQueryLimit + 1,
+			},
+			wantErr: "limit must be <=",
+		},
+		{
+			name: "rejects unknown verdict",
+			query: DecisionQuery{
+				Tenant:  "tenant-a",
+				Verdict: SafetyDecision("maybe"),
+			},
+			wantErr: "unknown decision verdict",
+		},
+		{
+			name: "rejects bad cursor",
+			query: DecisionQuery{
+				Tenant: "tenant-a",
+				Cursor: "not-base64",
+			},
+			wantErr: "decode decision cursor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.Normalize(now)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErr)
+				}
+				if !contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error=%q want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize() error = %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+func TestParseDecisionLogVerdict(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    SafetyDecision
+		wantErr string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "allow", input: "allow", want: SafetyAllow},
+		{name: "deny uppercase", input: "DENY", want: SafetyDeny},
+		{name: "constrain", input: "constrain", want: SafetyAllowWithConstraints},
+		{name: "require approval", input: "require_approval", want: SafetyRequireApproval},
+		{name: "throttle", input: "throttle", want: SafetyThrottle},
+		{name: "reject unknown", input: "shadowban", wantErr: "unknown decision verdict"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDecisionLogVerdict(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErr)
+				}
+				if !contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error=%q want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDecisionLogVerdict() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseDecisionLogVerdict()=%q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecisionCursorRoundTrip(t *testing.T) {
+	timestamp := int64(1713614400000)
+	cursor := EncodeDecisionCursor(timestamp, "decision-1")
+	gotTS, gotID, err := DecodeDecisionCursor(cursor)
+	if err != nil {
+		t.Fatalf("DecodeDecisionCursor() error = %v", err)
+	}
+	if gotTS != timestamp {
+		t.Fatalf("timestamp=%d want %d", gotTS, timestamp)
+	}
+	if gotID != "decision-1" {
+		t.Fatalf("id=%q want decision-1", gotID)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(substr) == 0 || (len(s) >= len(substr) && stringContains(s, substr))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/core/model/delegation.go
+++ b/core/model/delegation.go
@@ -1,0 +1,50 @@
+package model
+
+import "context"
+
+// DelegationChainLink captures one hop in a verified delegation chain.
+// The shape mirrors the token claims but lives in model so stores, APIs,
+// and scheduler code can share a stable representation without depending
+// directly on the token package.
+type DelegationChainLink struct {
+	AgentID   string `json:"agent_id,omitempty"`
+	IssuedAt  string `json:"issued_at,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+	JTI       string `json:"jti,omitempty"`
+	ParentJTI string `json:"parent_jti,omitempty"`
+	IssuedBy  string `json:"issued_by,omitempty"`
+}
+
+// DelegationLineage is the persisted scheduler-time snapshot of the
+// delegation token that authorized a job submission.
+type DelegationLineage struct {
+	TokenJTI       string                `json:"token_jti,omitempty"`
+	ParentTokenJTI string                `json:"parent_token_jti,omitempty"`
+	Subject        string                `json:"subject,omitempty"`
+	Audience       string                `json:"audience,omitempty"`
+	Tenant         string                `json:"tenant,omitempty"`
+	RootIssuer     string                `json:"root_issuer,omitempty"`
+	ParentIssuer   string                `json:"parent_issuer,omitempty"`
+	IssuerChain    []DelegationChainLink `json:"issuer_chain,omitempty"`
+	ChainDepth     int                   `json:"chain_depth,omitempty"`
+	ExpiresAt      string                `json:"expires_at,omitempty"`
+	Scope          []string              `json:"scope,omitempty"`
+	AllowedTopics  []string              `json:"allowed_topics,omitempty"`
+	VerifiedAt     int64                 `json:"verified_at,omitempty"`
+}
+
+// DelegationDispatchToken is a scheduler-only secret used to re-verify
+// delegation at dispatch time. It is intentionally stored outside the public
+// job request payload so operators and workers do not receive the raw token.
+type DelegationDispatchToken struct {
+	Token    string `json:"token,omitempty"`
+	Audience string `json:"audience,omitempty"`
+}
+
+// DelegationDispatchTokenStore is an optional extension implemented by stores
+// that can persist the raw delegation token required for dispatch-time
+// re-verification.
+type DelegationDispatchTokenStore interface {
+	SetDelegationDispatchToken(ctx context.Context, jobID string, token DelegationDispatchToken) error
+	GetDelegationDispatchToken(ctx context.Context, jobID string) (DelegationDispatchToken, error)
+}

--- a/core/model/delegation.go
+++ b/core/model/delegation.go
@@ -44,7 +44,15 @@ type DelegationDispatchToken struct {
 // DelegationDispatchTokenStore is an optional extension implemented by stores
 // that can persist the raw delegation token required for dispatch-time
 // re-verification.
+//
+// Callers MUST invoke ClearDelegationDispatchToken as soon as dispatch-time
+// verification completes (whether it admits or rejects the job) so the raw
+// bearer token does not sit in the job-metadata TTL where it could be
+// recovered via admin tooling, backups, or operator access. The persisted
+// DelegationLineage continues to carry the non-sensitive chain metadata
+// (JTI, issuer chain, scope) for audit and read-side APIs after the wipe.
 type DelegationDispatchTokenStore interface {
 	SetDelegationDispatchToken(ctx context.Context, jobID string, token DelegationDispatchToken) error
 	GetDelegationDispatchToken(ctx context.Context, jobID string) (DelegationDispatchToken, error)
+	ClearDelegationDispatchToken(ctx context.Context, jobID string) error
 }

--- a/core/model/eval_dataset.go
+++ b/core/model/eval_dataset.go
@@ -1,0 +1,382 @@
+package model
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Eval dataset hard limits. The caps here are enforced by the model-level
+// Validate() and are the canonical contract used by the store and handler
+// layers alike. They exist to keep a single Redis hash payload bounded and
+// the gateway's in-memory copy predictable under pathological input.
+const (
+	// MaxEvalDatasetEntries is the hard cap on entries in a single dataset.
+	// Datasets that outgrow this cap must be split along a meaningful axis
+	// (tenant, topic, risk tier) rather than raised — the rail is that
+	// datasets are curated test fixtures, not bulk event dumps.
+	MaxEvalDatasetEntries = 10_000
+
+	// MaxEvalDatasetBytes is the hard cap on the canonical-JSON serialization
+	// size of a dataset. 16 MiB gives ~1.6 KiB per entry at full capacity,
+	// which covers realistic job-request snapshots with headroom.
+	MaxEvalDatasetBytes = 16 * 1024 * 1024
+
+	// MaxEvalEntryNotesBytes bounds the operator-provided notes field per
+	// entry so a single annotator can't blow past the payload cap alone.
+	MaxEvalEntryNotesBytes = 4 * 1024
+
+	// MaxEvalEntryMetadataKeys bounds the metadata map width per entry.
+	MaxEvalEntryMetadataKeys = 32
+)
+
+// Eval entry origin values. These are stable wire constants — the
+// governance replay pipeline (phase 2) treats each origin differently when
+// attributing regressions, so renaming one is a breaking wire change.
+const (
+	EvalEntrySourceManual        = "manual"
+	EvalEntrySourceAuditImport   = "audit-import"
+	EvalEntrySourceReplayImport  = "replay-import"
+)
+
+var validEvalEntrySources = map[string]struct{}{
+	EvalEntrySourceManual:       {},
+	EvalEntrySourceAuditImport:  {},
+	EvalEntrySourceReplayImport: {},
+}
+
+// evalDatasetNamePattern pins the dataset name format. The first character
+// must be a lowercase alphanumeric so names sort predictably and stay safe
+// as Redis key components; the tail allows `_` and `-` for human-friendly
+// labels. Length is 3..64 so names fit in indexes without ballooning.
+var evalDatasetNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_\-]{2,63}$`)
+
+// EvalDataset is a curated, versioned collection of policy-regression test
+// cases. Datasets are immutable once created: mutating an existing (name,
+// version) pair is forbidden by the store, and any change of content must
+// flow through a new version. See docs/evals/datasets.md for the rail.
+type EvalDataset struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Version     int         `json:"version"`
+	Tenant      string      `json:"tenant"`
+	Description string      `json:"description,omitempty"`
+	Entries     []EvalEntry `json:"entries"`
+	// CreatedAt is the RFC3339Nano UTC timestamp at which the dataset was
+	// first durably stored. The store also indexes the corresponding
+	// unix-milli score for cursor pagination; the string form here is the
+	// wire contract.
+	CreatedAt string `json:"created_at"`
+	// UpdatedAt exists solely to satisfy the generic resource envelope used
+	// by existing gateway responses; by rail it is always equal to
+	// CreatedAt on a freshly-created (and therefore immutable) dataset.
+	UpdatedAt   string `json:"updated_at"`
+	CreatedBy   string `json:"created_by,omitempty"`
+	EntryCount  int    `json:"entry_count"`
+	// ContentHash is the sha256 (hex) of the canonical-JSON Entries slice,
+	// computed at create time. It is a tamper-evidence aid for operators
+	// auditing long-lived datasets, not a security primitive — the store
+	// does not re-verify it on read.
+	ContentHash string `json:"content_hash"`
+}
+
+// EvalEntry is a single policy-regression test case. Input captures a
+// snapshot of the originating job-request shape (tenant, topic, caps,
+// risk tags, metadata, agent id) as raw JSON so callers retain full
+// fidelity without the model having to track every gateway field.
+type EvalEntry struct {
+	ID               string            `json:"id"`
+	Input            json.RawMessage   `json:"input"`
+	ExpectedDecision SafetyDecision    `json:"expected_decision"`
+	RuleID           string            `json:"rule_id,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	Source           string            `json:"source,omitempty"`
+	SourceRef        string            `json:"source_ref,omitempty"`
+	Notes            string            `json:"notes,omitempty"`
+}
+
+// EvalDatasetFilter narrows a list query. Tenant is always implicit in the
+// store (the store is tenant-scoped at the call site); NamePrefix matches
+// the start of the name; CreatedAfter/Before bound the creation window in
+// unix-milli.
+type EvalDatasetFilter struct {
+	Tenant         string
+	NamePrefix     string
+	CreatedAfterMS int64
+	CreatedBeforeMS int64
+}
+
+// EvalDatasetPage is a single page of list results.
+type EvalDatasetPage struct {
+	Items      []EvalDataset `json:"items"`
+	NextCursor string        `json:"next_cursor,omitempty"`
+}
+
+// Normalize trims and lowercases the fields a caller is expected to
+// provide without care. It does not generate missing values — the store
+// owns ID/timestamp assignment.
+func (d *EvalDataset) Normalize() {
+	if d == nil {
+		return
+	}
+	d.ID = strings.TrimSpace(d.ID)
+	d.Name = strings.ToLower(strings.TrimSpace(d.Name))
+	d.Tenant = strings.TrimSpace(d.Tenant)
+	d.Description = strings.TrimSpace(d.Description)
+	d.CreatedBy = strings.TrimSpace(d.CreatedBy)
+	d.ContentHash = strings.ToLower(strings.TrimSpace(d.ContentHash))
+	for i := range d.Entries {
+		d.Entries[i].normalize()
+	}
+}
+
+func (e *EvalEntry) normalize() {
+	e.ID = strings.TrimSpace(e.ID)
+	e.RuleID = strings.TrimSpace(e.RuleID)
+	e.Source = strings.ToLower(strings.TrimSpace(e.Source))
+	e.SourceRef = strings.TrimSpace(e.SourceRef)
+	e.Notes = strings.TrimSpace(e.Notes)
+}
+
+// Validate enforces the shape of a dataset. It does not compute or verify
+// ContentHash — that is an invariant the store layer is responsible for
+// because only it knows the final canonical-JSON form of the record.
+func (d *EvalDataset) Validate() error {
+	if d == nil {
+		return fmt.Errorf("eval dataset is nil")
+	}
+
+	if !evalDatasetNamePattern.MatchString(d.Name) {
+		return fmt.Errorf("eval dataset name must match %s", evalDatasetNamePattern.String())
+	}
+	if d.Version < 1 {
+		return fmt.Errorf("eval dataset version must be >= 1")
+	}
+	if d.Tenant == "" {
+		return fmt.Errorf("eval dataset tenant is required")
+	}
+	if len(d.Entries) == 0 {
+		return fmt.Errorf("eval dataset must contain at least one entry")
+	}
+	if len(d.Entries) > MaxEvalDatasetEntries {
+		return fmt.Errorf("eval dataset has %d entries (cap %d)", len(d.Entries), MaxEvalDatasetEntries)
+	}
+
+	seenEntryIDs := make(map[string]struct{}, len(d.Entries))
+	for i := range d.Entries {
+		entry := &d.Entries[i]
+		if err := entry.Validate(); err != nil {
+			return fmt.Errorf("eval dataset entry %d: %w", i, err)
+		}
+		if _, dup := seenEntryIDs[entry.ID]; dup {
+			return fmt.Errorf("eval dataset duplicate entry id %q", entry.ID)
+		}
+		seenEntryIDs[entry.ID] = struct{}{}
+	}
+
+	size, err := canonicalJSONSize(d)
+	if err != nil {
+		return fmt.Errorf("eval dataset serialize probe: %w", err)
+	}
+	if size > MaxEvalDatasetBytes {
+		return fmt.Errorf("eval dataset serialized size %d exceeds cap %d bytes", size, MaxEvalDatasetBytes)
+	}
+
+	return nil
+}
+
+// Validate enforces the shape of a single entry.
+func (e *EvalEntry) Validate() error {
+	if e == nil {
+		return fmt.Errorf("entry is nil")
+	}
+	if e.ID == "" {
+		return fmt.Errorf("entry id is required")
+	}
+	if len(e.Input) == 0 {
+		return fmt.Errorf("entry input is required")
+	}
+	if !json.Valid(e.Input) {
+		return fmt.Errorf("entry input must be valid JSON")
+	}
+	if !validExpectedDecision(e.ExpectedDecision) {
+		return fmt.Errorf("entry expected_decision %q is not a recognized SafetyDecision", e.ExpectedDecision)
+	}
+	if e.Source != "" {
+		if _, ok := validEvalEntrySources[e.Source]; !ok {
+			return fmt.Errorf("entry source %q must be one of manual|audit-import|replay-import", e.Source)
+		}
+	}
+	if len(e.Notes) > MaxEvalEntryNotesBytes {
+		return fmt.Errorf("entry notes exceeds %d bytes", MaxEvalEntryNotesBytes)
+	}
+	if len(e.Metadata) > MaxEvalEntryMetadataKeys {
+		return fmt.Errorf("entry metadata has %d keys (cap %d)", len(e.Metadata), MaxEvalEntryMetadataKeys)
+	}
+	return nil
+}
+
+// ComputeContentHash returns the hex-encoded sha256 of the canonical-JSON
+// form of the Entries slice. The canonical form sorts object keys and
+// strips insignificant whitespace so the same logical content always
+// hashes identically, independent of how it was constructed.
+//
+// The hash is captured at create time on EvalDataset.ContentHash and is
+// advisory: downstream consumers can compare it against a re-computed hash
+// to spot accidental mutation by operators or by recovery tooling. The
+// store does not re-verify it on read because doing so would couple every
+// read to an O(N) hash pass over the entries.
+func (d *EvalDataset) ComputeContentHash() (string, error) {
+	if d == nil {
+		return "", fmt.Errorf("eval dataset is nil")
+	}
+	canonical, err := canonicalJSONEntries(d.Entries)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// CreatedAtMilli parses CreatedAt and returns its unix-milli form, used by
+// the store for sorted-set scoring. An empty or malformed timestamp yields
+// 0 and an error.
+func (d *EvalDataset) CreatedAtMilli() (int64, error) {
+	if d == nil || strings.TrimSpace(d.CreatedAt) == "" {
+		return 0, fmt.Errorf("eval dataset created_at is empty")
+	}
+	if t, err := time.Parse(time.RFC3339Nano, d.CreatedAt); err == nil {
+		return t.UTC().UnixMilli(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, d.CreatedAt); err == nil {
+		return t.UTC().UnixMilli(), nil
+	}
+	return 0, fmt.Errorf("eval dataset created_at must be RFC3339")
+}
+
+func validExpectedDecision(d SafetyDecision) bool {
+	switch d {
+	case SafetyAllow,
+		SafetyDeny,
+		SafetyRequireApproval,
+		SafetyThrottle,
+		SafetyAllowWithConstraints:
+		return true
+	}
+	return false
+}
+
+// canonicalJSONEntries marshals the Entries slice with sorted object keys
+// so that logically equivalent content always produces the same bytes.
+// encoding/json does not guarantee deterministic map ordering; we therefore
+// do a JSON round-trip through canonicalJSON below.
+func canonicalJSONEntries(entries []EvalEntry) ([]byte, error) {
+	raw, err := json.Marshal(entries)
+	if err != nil {
+		return nil, fmt.Errorf("marshal entries: %w", err)
+	}
+	return canonicalJSON(raw)
+}
+
+// canonicalJSONSize computes the canonical-JSON byte length of a dataset
+// without retaining the full buffer — we only need the size for the cap
+// check. Using canonical form here keeps the check independent of random
+// map ordering so a dataset with flappy map iteration won't intermittently
+// bust the cap.
+func canonicalJSONSize(d *EvalDataset) (int, error) {
+	raw, err := json.Marshal(d)
+	if err != nil {
+		return 0, err
+	}
+	canonical, err := canonicalJSON(raw)
+	if err != nil {
+		return 0, err
+	}
+	return len(canonical), nil
+}
+
+// canonicalJSON deterministically re-encodes a JSON payload: maps become
+// JSON objects with keys sorted ascending, arrays keep order, and
+// whitespace is removed. The implementation is intentionally minimal — we
+// parse into interface{} and re-encode with a sorted writer.
+func canonicalJSON(raw []byte) ([]byte, error) {
+	var v any
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&v); err != nil {
+		return nil, fmt.Errorf("decode for canonicalization: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := writeCanonical(&buf, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeCanonical(buf *bytes.Buffer, v any) error {
+	switch val := v.(type) {
+	case nil:
+		buf.WriteString("null")
+	case bool:
+		if val {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case json.Number:
+		buf.WriteString(val.String())
+	case string:
+		encoded, err := json.Marshal(val)
+		if err != nil {
+			return err
+		}
+		buf.Write(encoded)
+	case []any:
+		buf.WriteByte('[')
+		for i, item := range val {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := writeCanonical(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			encoded, err := json.Marshal(k)
+			if err != nil {
+				return err
+			}
+			buf.Write(encoded)
+			buf.WriteByte(':')
+			if err := writeCanonical(buf, val[k]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	default:
+		// Fall back to encoding/json for types we did not introduce above.
+		encoded, err := json.Marshal(val)
+		if err != nil {
+			return err
+		}
+		buf.Write(encoded)
+	}
+	return nil
+}

--- a/core/model/eval_dataset.go
+++ b/core/model/eval_dataset.go
@@ -184,8 +184,14 @@ func (d *EvalDataset) Validate() error {
 	if err != nil {
 		return fmt.Errorf("eval dataset serialize probe: %w", err)
 	}
-	if size > MaxEvalDatasetBytes {
-		return fmt.Errorf("eval dataset serialized size %d exceeds cap %d bytes", size, MaxEvalDatasetBytes)
+	// Reserve headroom for store-assigned fields the caller hasn't populated
+	// yet: ID (ULID-ish, ~26B), CreatedAt / UpdatedAt (RFC3339, ~30B each),
+	// EntryCount (int, ~20B), ContentHash (hex, ~64B), plus the JSON
+	// envelope (quotes, commas, keys). 256 bytes gives comfortable slack
+	// without materially tightening the usable size for payloads.
+	const storeAssignedHeadroomBytes = 256
+	if size+storeAssignedHeadroomBytes > MaxEvalDatasetBytes {
+		return fmt.Errorf("eval dataset serialized size %d (plus %d bytes store headroom) exceeds cap %d bytes", size, storeAssignedHeadroomBytes, MaxEvalDatasetBytes)
 	}
 
 	return nil

--- a/core/model/eval_dataset_test.go
+++ b/core/model/eval_dataset_test.go
@@ -1,0 +1,333 @@
+package model
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func baseEntry() EvalEntry {
+	return EvalEntry{
+		ID:               "entry-1",
+		Input:            json.RawMessage(`{"tenant":"acme","topic":"support","agent_id":"agent-a","capabilities":["read"],"risk_tags":["pii"],"metadata":{"origin":"ticket-42"}}`),
+		ExpectedDecision: SafetyDeny,
+		RuleID:           "rule-pii-leak-01",
+		Metadata:         map[string]string{"scenario": "denied-in-prod"},
+		Source:           EvalEntrySourceAuditImport,
+		SourceRef:        "audit-xyz",
+		Notes:            "Reproduces the leak detected on 2026-03-12",
+	}
+}
+
+func baseDataset() EvalDataset {
+	return EvalDataset{
+		Name:        "pii-leaks-q1",
+		Version:     1,
+		Tenant:      "acme",
+		Description: "Q1 regression cases for PII leak rule",
+		CreatedAt:   "2026-04-20T09:17:00Z",
+		UpdatedAt:   "2026-04-20T09:17:00Z",
+		CreatedBy:   "alice@example.com",
+		Entries:     []EvalEntry{baseEntry()},
+	}
+}
+
+func TestEvalDatasetValidateHappyPath(t *testing.T) {
+	d := baseDataset()
+	d.Normalize()
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate: unexpected error: %v", err)
+	}
+}
+
+func TestEvalDatasetNameValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"simple", "basic", false},
+		{"hyphen", "pii-leaks-q1", false},
+		{"underscore", "audit_import_v1", false},
+		{"alphanum", "abc123", false},
+		{"minlen_3", "abc", false},
+		{"too-short_2", "ab", true},
+		{"too-long_65", "a" + strings.Repeat("b", 64), true},
+		{"leading-dash", "-bad", true},
+		{"leading-underscore", "_bad", true},
+		{"uppercase", "BadCase", true},
+		{"space", "bad name", true},
+		{"dot", "bad.name", true},
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := baseDataset()
+			d.Name = tt.in
+			d.Normalize()
+			if tt.name == "uppercase" {
+				// Normalize lowercases names; to actually test the uppercase
+				// failure mode we re-assert post-normalize.
+				d.Name = tt.in
+			}
+			err := d.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected validation error for %q", tt.in)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected validation error for %q: %v", tt.in, err)
+			}
+		})
+	}
+}
+
+func TestEvalDatasetVersionMustBePositive(t *testing.T) {
+	for _, v := range []int{-1, 0} {
+		d := baseDataset()
+		d.Version = v
+		d.Normalize()
+		err := d.Validate()
+		if err == nil {
+			t.Fatalf("expected error for version %d", v)
+		}
+		if !strings.Contains(err.Error(), "version must be >= 1") {
+			t.Fatalf("unexpected error for version %d: %v", v, err)
+		}
+	}
+}
+
+func TestEvalDatasetRequiresTenant(t *testing.T) {
+	d := baseDataset()
+	d.Tenant = "   "
+	d.Normalize()
+	if err := d.Validate(); err == nil || !strings.Contains(err.Error(), "tenant is required") {
+		t.Fatalf("expected tenant required error, got %v", err)
+	}
+}
+
+func TestEvalDatasetRequiresEntries(t *testing.T) {
+	d := baseDataset()
+	d.Entries = nil
+	d.Normalize()
+	if err := d.Validate(); err == nil || !strings.Contains(err.Error(), "at least one entry") {
+		t.Fatalf("expected missing-entries error, got %v", err)
+	}
+}
+
+func TestEvalDatasetEntryCap(t *testing.T) {
+	d := baseDataset()
+	base := baseEntry()
+	d.Entries = make([]EvalEntry, MaxEvalDatasetEntries+1)
+	for i := range d.Entries {
+		d.Entries[i] = EvalEntry{
+			ID:               strings.Repeat("a", 1) + itoa(i),
+			Input:            base.Input,
+			ExpectedDecision: SafetyAllow,
+		}
+	}
+	d.Normalize()
+	if err := d.Validate(); err == nil || !strings.Contains(err.Error(), "cap") {
+		t.Fatalf("expected entries cap error, got %v", err)
+	}
+}
+
+func TestEvalDatasetRejectsDuplicateEntryIDs(t *testing.T) {
+	d := baseDataset()
+	dup := baseEntry()
+	dup.Notes = "second"
+	d.Entries = append(d.Entries, dup)
+	d.Normalize()
+	err := d.Validate()
+	if err == nil || !strings.Contains(err.Error(), "duplicate entry id") {
+		t.Fatalf("expected duplicate-entry-id error, got %v", err)
+	}
+}
+
+func TestEvalDatasetEntryValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*EvalEntry)
+		errSub string
+	}{
+		{
+			name:   "missing id",
+			mutate: func(e *EvalEntry) { e.ID = "" },
+			errSub: "entry id is required",
+		},
+		{
+			name:   "missing input",
+			mutate: func(e *EvalEntry) { e.Input = nil },
+			errSub: "entry input is required",
+		},
+		{
+			name:   "invalid json input",
+			mutate: func(e *EvalEntry) { e.Input = json.RawMessage(`{broken`) },
+			errSub: "must be valid JSON",
+		},
+		{
+			name:   "unknown expected decision",
+			mutate: func(e *EvalEntry) { e.ExpectedDecision = SafetyDecision("MAYBE") },
+			errSub: "not a recognized SafetyDecision",
+		},
+		{
+			name:   "unavailable rejected",
+			mutate: func(e *EvalEntry) { e.ExpectedDecision = SafetyUnavailable },
+			errSub: "not a recognized SafetyDecision",
+		},
+		{
+			name:   "unknown source",
+			mutate: func(e *EvalEntry) { e.Source = "guess" },
+			errSub: "entry source",
+		},
+		{
+			name:   "notes too long",
+			mutate: func(e *EvalEntry) { e.Notes = strings.Repeat("x", MaxEvalEntryNotesBytes+1) },
+			errSub: "entry notes exceeds",
+		},
+		{
+			name: "metadata too many keys",
+			mutate: func(e *EvalEntry) {
+				e.Metadata = make(map[string]string, MaxEvalEntryMetadataKeys+1)
+				for i := 0; i <= MaxEvalEntryMetadataKeys; i++ {
+					e.Metadata["k"+itoa(i)] = "v"
+				}
+			},
+			errSub: "entry metadata has",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := baseDataset()
+			d.Entries[0] = baseEntry()
+			tt.mutate(&d.Entries[0])
+			d.Normalize()
+			err := d.Validate()
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.errSub)
+			}
+			if !strings.Contains(err.Error(), tt.errSub) {
+				t.Fatalf("expected error containing %q, got %v", tt.errSub, err)
+			}
+		})
+	}
+}
+
+func TestEvalDatasetAcceptsAllExpectedDecisions(t *testing.T) {
+	decisions := []SafetyDecision{
+		SafetyAllow,
+		SafetyDeny,
+		SafetyRequireApproval,
+		SafetyThrottle,
+		SafetyAllowWithConstraints,
+	}
+	for _, decision := range decisions {
+		t.Run(string(decision), func(t *testing.T) {
+			d := baseDataset()
+			d.Entries[0].ExpectedDecision = decision
+			d.Normalize()
+			if err := d.Validate(); err != nil {
+				t.Fatalf("unexpected error for %s: %v", decision, err)
+			}
+		})
+	}
+}
+
+func TestEvalDatasetContentHashIsDeterministic(t *testing.T) {
+	d1 := baseDataset()
+	d2 := baseDataset()
+	// Re-order metadata by supplying a map with multiple keys; Go's map
+	// iteration is randomized so without canonicalization this would be
+	// flaky.
+	d1.Entries[0].Metadata = map[string]string{"a": "1", "b": "2", "c": "3"}
+	d2.Entries[0].Metadata = map[string]string{"c": "3", "b": "2", "a": "1"}
+
+	h1, err := d1.ComputeContentHash()
+	if err != nil {
+		t.Fatalf("ComputeContentHash d1: %v", err)
+	}
+	h2, err := d2.ComputeContentHash()
+	if err != nil {
+		t.Fatalf("ComputeContentHash d2: %v", err)
+	}
+	if h1 != h2 {
+		t.Fatalf("content hash not canonical: %s vs %s", h1, h2)
+	}
+	if len(h1) != 64 {
+		t.Fatalf("expected 64-hex sha256, got %d chars: %s", len(h1), h1)
+	}
+}
+
+func TestEvalDatasetContentHashChangesWithContent(t *testing.T) {
+	d := baseDataset()
+	h1, err := d.ComputeContentHash()
+	if err != nil {
+		t.Fatalf("hash 1: %v", err)
+	}
+
+	modified := baseDataset()
+	modified.Entries[0].Notes = "different"
+	h2, err := modified.ComputeContentHash()
+	if err != nil {
+		t.Fatalf("hash 2: %v", err)
+	}
+
+	if h1 == h2 {
+		t.Fatal("expected content hash to change when an entry's notes change")
+	}
+}
+
+func TestEvalDatasetCreatedAtMilli(t *testing.T) {
+	d := baseDataset()
+	d.CreatedAt = "2026-04-20T09:17:00.000Z"
+	ms, err := d.CreatedAtMilli()
+	if err != nil {
+		t.Fatalf("CreatedAtMilli: %v", err)
+	}
+	// 2026-04-20T09:17:00Z UTC
+	want := int64(1776676620000)
+	if ms != want {
+		t.Fatalf("expected %d, got %d", want, ms)
+	}
+
+	d.CreatedAt = "not-a-date"
+	if _, err := d.CreatedAtMilli(); err == nil {
+		t.Fatal("expected error for malformed timestamp")
+	}
+}
+
+func TestEvalDatasetNormalizeLowercasesName(t *testing.T) {
+	d := baseDataset()
+	d.Name = "PII-Leaks-Q1"
+	d.Normalize()
+	if d.Name != "pii-leaks-q1" {
+		t.Fatalf("expected lowercased name, got %q", d.Name)
+	}
+}
+
+// itoa is a tiny allocation-free int-to-string for table driven tests.
+// It keeps the test file dependency-free (no strconv import just for
+// this).
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/core/model/events.go
+++ b/core/model/events.go
@@ -1,0 +1,39 @@
+package model
+
+// StateEventContext captures rich context for a job state transition.
+// Each field is optional — callers populate only what's relevant for
+// the specific transition (e.g. safety eval populates Rule/EvalMs,
+// dispatch populates WorkerID/Pool, completion populates DurationMs).
+type StateEventContext struct {
+	Rule         string            `json:"rule,omitempty"`
+	Reason       string            `json:"reason,omitempty"`
+	EvalMs       int64             `json:"eval_ms,omitempty"`
+	EvalPath     []string          `json:"eval_path,omitempty"`
+	WorkerID     string            `json:"worker_id,omitempty"`
+	Pool         string            `json:"pool,omitempty"`
+	Strategy     string            `json:"strategy,omitempty"`
+	ApprovedBy   string            `json:"approved_by,omitempty"`
+	ApprovalRole string            `json:"approval_role,omitempty"`
+	ApprovalNote string            `json:"approval_note,omitempty"`
+	WaitMs       int64             `json:"wait_ms,omitempty"`
+	ErrorCode    string            `json:"error_code,omitempty"`
+	ErrorMsg     string            `json:"error_msg,omitempty"`
+	ResultPtr    string            `json:"result_ptr,omitempty"`
+	DurationMs   int64             `json:"duration_ms,omitempty"`
+	Findings     int               `json:"findings,omitempty"`
+	Scanner      string            `json:"scanner,omitempty"`
+	Topic        string            `json:"topic,omitempty"`
+	Capabilities []string          `json:"capabilities,omitempty"`
+	RiskTags     []string          `json:"risk_tags,omitempty"`
+	ActorID      string            `json:"actor_id,omitempty"`
+	Extra        map[string]string `json:"extra,omitempty"`
+}
+
+// JobEvent represents a single state transition event stored in the
+// job:events:{id} Redis LIST. Supports both the new JSON format and
+// backward-compatible parsing of old "timestamp|state" entries.
+type JobEvent struct {
+	Timestamp int64              `json:"ts"`
+	State     string             `json:"state"`
+	Context   *StateEventContext `json:"ctx,omitempty"`
+}

--- a/core/model/store.go
+++ b/core/model/store.go
@@ -7,9 +7,35 @@ import (
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 )
 
+// ApprovalOwnerKind identifies which subsystem owns the approval. New
+// values must be enumerated here; ApprovalRecord.OwnerKind is consumed
+// by audit code, dashboard rendering, and the cordumctl `mcp` subcommand.
+type ApprovalOwnerKind string
+
+const (
+	// ApprovalOwnerJob is the legacy default — approvals attached to jobs.
+	// Records with OwnerKind == "" are interpreted as ApprovalOwnerJob for
+	// backward compatibility with pre-MCP records already in Redis.
+	ApprovalOwnerJob ApprovalOwnerKind = "job"
+
+	// ApprovalOwnerMCPCall is the per-tool approval gate added for MCP.
+	// OwnerID holds the MCP-call approval ID; the job-scoped fields
+	// (JobHash, Decision tied to a JobRequest, etc.) are not populated.
+	ApprovalOwnerMCPCall ApprovalOwnerKind = "mcp_call"
+)
+
 // ApprovalRecord captures approval audit metadata plus explicit lifecycle state.
+//
+// Owner discrimination:
+//   - When OwnerKind is empty or "job", the approval is keyed by JobID
+//     (the existing job-meta storage). All legacy fields apply.
+//   - When OwnerKind == "mcp_call", OwnerID is the approval ID and
+//     MCPCallID identifies the originating tools/call invocation. JobID
+//     is NOT populated; consume the new fields instead.
+//
+// The owner discriminator is additive (omitempty) so existing serialised
+// records decode unchanged.
 type ApprovalRecord struct {
-	SubmittedBy    string                `json:"submitted_by,omitempty"`
 	ApprovedBy     string                `json:"approved_by,omitempty"`
 	ApprovedRole   string                `json:"approved_role,omitempty"`
 	ApprovedAt     int64                 `json:"approved_at,omitempty"`
@@ -24,6 +50,31 @@ type ApprovalRecord struct {
 	PublishStatus  ApprovalPublishStatus `json:"publish_status,omitempty"`
 	PublishTarget  ApprovalPublishTarget `json:"publish_target,omitempty"`
 	PublishedAt    int64                 `json:"published_at,omitempty"`
+
+	// OwnerKind identifies which subsystem the approval belongs to.
+	// Empty means legacy job-scoped behaviour (treated as "job").
+	OwnerKind ApprovalOwnerKind `json:"owner_kind,omitempty"`
+
+	// OwnerID is the canonical ID of the approval target. For job
+	// approvals this mirrors the existing JobID-based access path so
+	// callers can move to a uniform key without changing semantics.
+	OwnerID string `json:"owner_id,omitempty"`
+
+	// MCPCallID is the MCP-call invocation ID that produced this approval
+	// (set only when OwnerKind == "mcp_call"). Together with the args
+	// hash on the request it lets the server short-circuit a re-issued
+	// tools/call against an already-granted approval.
+	MCPCallID string `json:"mcp_call_id,omitempty"`
+}
+
+// EffectiveOwnerKind returns the owner kind, defaulting to job for legacy
+// records. Use this rather than reading OwnerKind directly so the
+// "" → "job" backward-compat translation lives in exactly one place.
+func (r ApprovalRecord) EffectiveOwnerKind() ApprovalOwnerKind {
+	if r.OwnerKind == "" {
+		return ApprovalOwnerJob
+	}
+	return r.OwnerKind
 }
 
 // HasPendingPublish reports whether the approval still has durable side effects
@@ -35,6 +86,8 @@ func (r ApprovalRecord) HasPendingPublish() bool {
 // JobStore tracks job state and result pointers.
 type JobStore interface {
 	SetState(ctx context.Context, jobID string, state JobState) error
+	SetStateWithContext(ctx context.Context, jobID string, state JobState, evtCtx *StateEventContext) error
+	GetJobEvents(ctx context.Context, jobID string) ([]JobEvent, error)
 	GetState(ctx context.Context, jobID string) (JobState, error)
 	SetResultPtr(ctx context.Context, jobID, resultPtr string) error
 	GetResultPtr(ctx context.Context, jobID string) (string, error)
@@ -54,6 +107,8 @@ type JobStore interface {
 	GetTeam(ctx context.Context, jobID string) (string, error)
 	SetSafetyDecision(ctx context.Context, jobID string, record SafetyDecisionRecord) error
 	GetSafetyDecision(ctx context.Context, jobID string) (SafetyDecisionRecord, error)
+	SetDelegationLineage(ctx context.Context, jobID string, lineage DelegationLineage) error
+	GetDelegationLineage(ctx context.Context, jobID string) (DelegationLineage, error)
 	GetAttempts(ctx context.Context, jobID string) (int, error)
 	CountActiveByTenant(ctx context.Context, tenant string) (int, error)
 	TryAcquireLock(ctx context.Context, key string, ttl time.Duration) (string, error)
@@ -66,4 +121,49 @@ type JobStore interface {
 	GetOutputDecision(ctx context.Context, jobID string) (OutputSafetyRecord, error)
 	// Worker tracking
 	SetWorkerID(ctx context.Context, jobID, workerID string) error
+}
+
+// DecisionLogStore indexes governance decisions for the Policy Decision Log.
+type DecisionLogStore interface {
+	AppendDecision(ctx context.Context, record DecisionLogRecord) error
+	QueryDecisions(ctx context.Context, query DecisionQuery) (DecisionPage, error)
+}
+
+// EvalDatasetStore persists curated policy-regression evaluation datasets.
+//
+// Datasets are immutable once created: the store does not expose an update
+// method, and Create enforces uniqueness on the (tenant, name, version)
+// triple. To evolve a dataset, callers Create a new version with the same
+// (tenant, name) and an incremented Version. Destruction is an admin-only
+// escape hatch and is modeled as a hard delete so auditors do not discover
+// silently-hidden datasets.
+type EvalDatasetStore interface {
+	// CreateEvalDataset persists a new dataset. The ID, CreatedAt,
+	// UpdatedAt, EntryCount, and ContentHash fields are assigned by the
+	// store and will overwrite whatever the caller set. Returns
+	// ErrEvalDatasetVersionExists when (tenant, name, version) already
+	// exists.
+	CreateEvalDataset(ctx context.Context, dataset EvalDataset) (EvalDataset, error)
+
+	// GetEvalDataset returns the dataset by id within the tenant scope, or
+	// (EvalDataset{}, ErrEvalDatasetNotFound) when absent.
+	GetEvalDataset(ctx context.Context, tenant, id string) (EvalDataset, error)
+
+	// ListEvalDatasets returns a page of datasets ordered by CreatedAt
+	// descending, filtered by the supplied filter.
+	ListEvalDatasets(ctx context.Context, tenant string, filter EvalDatasetFilter, cursor string, limit int) (EvalDatasetPage, error)
+
+	// DeleteEvalDataset removes a dataset and every index entry pointing
+	// at it. Because the store has no soft-delete it is the caller's job
+	// (typically the gateway handler) to gate this on the explicit force
+	// query flag plus admin RBAC.
+	DeleteEvalDataset(ctx context.Context, tenant, id string) error
+
+	// GetEvalDatasetByNameVersion returns the dataset uniquely identified
+	// by (tenant, name, version), or ErrEvalDatasetNotFound when absent.
+	GetEvalDatasetByNameVersion(ctx context.Context, tenant, name string, version int) (EvalDataset, error)
+
+	// ListEvalDatasetVersions returns every version of a dataset name in
+	// the tenant, newest-version-first.
+	ListEvalDatasetVersions(ctx context.Context, tenant, name string) ([]EvalDataset, error)
 }


### PR DESCRIPTION
Delegation-security slice (re-opened after #203 auto-closed when base branch split/infra was deleted).

Contains all 5 commits from #203: initial feature + 3 rounds of blocker + CodeRabbit fixes.

All review threads on #203 already resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added agent-to-agent delegation token support with issuance, verification, and revocation capabilities.
  * Introduced delegation token management endpoints for listing, verifying, and revoking delegated access.
  * Added cascade revocation to revoke a delegation token and all its dependent tokens in a single operation.
  * Enabled job submission using delegation tokens with delegation chain tracking.
  * Implemented policy-based constraints on delegation (depth limits, issuer allowlists, scope requirements).
  * Added decision logging for policy evaluation outcomes with querying capabilities.
  * Introduced evaluation datasets for safety policy testing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->