### PR TITLE
fix(approval): stale-snapshot recovery + TOCTOU fix + scheduler reconciler provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,9 @@ jobs:
     - name: Generate API key
       run: echo "CORDUM_API_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
+    - name: Generate Redis password
+      run: echo "REDIS_PASSWORD=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
     - name: Generate TLS certificates
       run: |
         go run ./cmd/cordumctl generate-certs --dir ./certs
@@ -238,12 +241,14 @@ jobs:
         done
       env:
         CORDUM_API_KEY: ${{ env.CORDUM_API_KEY }}
+        REDIS_PASSWORD: ${{ env.REDIS_PASSWORD }}
 
     - name: Run Go integration tests
       run: go test -v -tags=integration -timeout 5m ./...
       env:
         CORDUM_API_KEY: ${{ env.CORDUM_API_KEY }}
-        REDIS_URL: rediss://:cordum-dev@localhost:6379
+        REDIS_PASSWORD: ${{ env.REDIS_PASSWORD }}
+        REDIS_URL: rediss://:${{ env.REDIS_PASSWORD }}@localhost:6379
         REDIS_TLS_CA: ${{ github.workspace }}/certs/ca/ca.crt
         REDIS_TLS_INSECURE: "false"
         NATS_URL: tls://localhost:4222
@@ -267,12 +272,13 @@ jobs:
         fi
       env:
         CORDUM_API_KEY: ${{ env.CORDUM_API_KEY }}
+        REDIS_PASSWORD: ${{ env.REDIS_PASSWORD }}
         NATS_URL: tls://localhost:4222
         NATS_TOKEN: cordum-dev-token
         NATS_TLS_CA: ${{ github.workspace }}/certs/ca/ca.crt
         NATS_TLS_CERT: ${{ github.workspace }}/certs/client/tls.crt
         NATS_TLS_KEY: ${{ github.workspace }}/certs/client/tls.key
-        REDIS_URL: rediss://:cordum-dev@localhost:6379
+        REDIS_URL: rediss://:${{ env.REDIS_PASSWORD }}@localhost:6379
         REDIS_TLS_CA: ${{ github.workspace }}/certs/ca/ca.crt
         REDIS_TLS_CERT: ${{ github.workspace }}/certs/client/tls.crt
         REDIS_TLS_KEY: ${{ github.workspace }}/certs/client/tls.key

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Generate API key
       run: echo "CORDUM_API_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
+    - name: Generate Redis password
+      run: echo "REDIS_PASSWORD=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
     - name: Generate TLS certificates
       # Relax permissions so non-root containers in docker-compose can
       # read the generated cert + key files mounted from the workspace.
@@ -67,6 +70,7 @@ jobs:
         done
       env:
         CORDUM_API_KEY: ${{ env.CORDUM_API_KEY }}
+        REDIS_PASSWORD: ${{ env.REDIS_PASSWORD }}
 
     - name: Run all production gates (1-17)
       run: bash tools/scripts/production_gate.sh --skip-rebuild
@@ -123,6 +127,9 @@ jobs:
     - name: Generate API key
       run: echo "CORDUM_API_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
+    - name: Generate Redis password
+      run: echo "REDIS_PASSWORD=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
     - name: Generate TLS certificates
       # Relax permissions so non-root containers in docker-compose can
       # read the generated cert + key files mounted from the workspace.
@@ -151,6 +158,7 @@ jobs:
         done
       env:
         CORDUM_API_KEY: ${{ env.CORDUM_API_KEY }}
+        REDIS_PASSWORD: ${{ env.REDIS_PASSWORD }}
 
     - name: Run strict production gate
       run: bash tools/scripts/production_gate.sh --skip-rebuild --strict
@@ -205,6 +213,9 @@ jobs:
     - name: Generate API key
       run: echo "CORDUM_API_KEY=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
+    - name: Generate Redis password
+      run: echo "REDIS_PASSWORD=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
     - name: Generate TLS certificates
       # Relax permissions so non-root containers in docker-compose can
       # read the generated cert + key files mounted from the workspace.
@@ -233,11 +244,13 @@ jobs:
         done
       env:
         CORDUM_API_KEY: ${{ env.CORDUM_API_KEY }}
+        REDIS_PASSWORD: ${{ env.REDIS_PASSWORD }}
 
     - name: Run soak test
       run: bash tools/scripts/soak_test.sh
       env:
         CORDUM_API_KEY: ${{ env.CORDUM_API_KEY }}
+        REDIS_PASSWORD: ${{ env.REDIS_PASSWORD }}
         SOAK_DURATION_MINUTES: ${{ inputs.soak_duration || '60' }}
 
     - name: Upload soak results

--- a/cmd/cordum-scheduler/main.go
+++ b/cmd/cordum-scheduler/main.go
@@ -503,7 +503,8 @@ func main() {
 
 	dispatchTimeout, runningTimeout, scanInterval := reconcilerTimeouts(snapshot.Timeouts)
 	reconciler := scheduler.NewReconciler(jobStore, dispatchTimeout, runningTimeout, scanInterval).
-		WithApprovalMetrics(approvalMetrics)
+		WithApprovalMetrics(approvalMetrics).
+		WithSnapshotProvider(safetyClient)
 	go reconciler.Start(ctx)
 	pendingReplayer := scheduler.NewPendingReplayer(engine, jobStore, dispatchTimeout, scanInterval)
 	go pendingReplayer.Start(ctx)

--- a/cmd/cordum-scheduler/main.go
+++ b/cmd/cordum-scheduler/main.go
@@ -384,8 +384,7 @@ func main() {
 		WithSchemaRegistry(schemaRegistry).
 		WithEntitlements(entitlementResolver).
 		WithContextClient(jobStore.Client()).
-		WithSaga(sagaManager).
-		WithAgentResolver(scheduler.NewAgentResolver(workerCredentialCache, store.NewAgentIdentityStoreFromClient(sagaRedis)))
+		WithSaga(sagaManager)
 	if dlqStore != nil {
 		engine.WithDLQSink(&redisDLQSink{
 			store:    dlqStore,
@@ -504,8 +503,7 @@ func main() {
 
 	dispatchTimeout, runningTimeout, scanInterval := reconcilerTimeouts(snapshot.Timeouts)
 	reconciler := scheduler.NewReconciler(jobStore, dispatchTimeout, runningTimeout, scanInterval).
-		WithApprovalMetrics(approvalMetrics).
-		WithSnapshotProvider(safetyClient)
+		WithApprovalMetrics(approvalMetrics)
 	go reconciler.Start(ctx)
 	pendingReplayer := scheduler.NewPendingReplayer(engine, jobStore, dispatchTimeout, scanInterval)
 	go pendingReplayer.Start(ctx)

--- a/cmd/cordumctl-governance-helper/governance.go
+++ b/cmd/cordumctl-governance-helper/governance.go
@@ -383,7 +383,7 @@ func (s natsGovernanceSubscriber) Subscribe(handler func([]byte) error) error {
 	if err != nil {
 		return err
 	}
-	s.conn.Flush()
+	_ = s.conn.Flush()
 	return s.conn.LastError()
 }
 

--- a/cmd/cordumctl/audit.go
+++ b/cmd/cordumctl/audit.go
@@ -79,20 +79,20 @@ func renderAuditVerifyTable(out io.Writer, r *sdk.AuditVerifyResult, tenant stri
 	if tenant == "" {
 		tenant = "(default)"
 	}
-	fmt.Fprintf(out, "Audit chain verification — tenant %s\n", tenant)
-	fmt.Fprintf(out, "  status:                 %s\n", r.Status)
-	fmt.Fprintf(out, "  events checked:         %d\n", r.TotalEvents)
-	fmt.Fprintf(out, "  events verified:        %d\n", r.VerifiedEvents)
+	_, _ = fmt.Fprintf(out, "Audit chain verification — tenant %s\n", tenant)
+	_, _ = fmt.Fprintf(out, "  status:                 %s\n", r.Status)
+	_, _ = fmt.Fprintf(out, "  events checked:         %d\n", r.TotalEvents)
+	_, _ = fmt.Fprintf(out, "  events verified:        %d\n", r.VerifiedEvents)
 	if r.FirstSeq > 0 || r.LastSeq > 0 {
-		fmt.Fprintf(out, "  seq range observed:     %d..%d\n", r.FirstSeq, r.LastSeq)
+		_, _ = fmt.Fprintf(out, "  seq range observed:     %d..%d\n", r.FirstSeq, r.LastSeq)
 	}
-	fmt.Fprintf(out, "  retention boundary:     seq %d\n", r.RetentionBoundarySeq)
+	_, _ = fmt.Fprintf(out, "  retention boundary:     seq %d\n", r.RetentionBoundarySeq)
 	if r.RetentionWindowHours > 0 {
-		fmt.Fprintf(out, "  retention window:       %.1f hours\n", r.RetentionWindowHours)
+		_, _ = fmt.Fprintf(out, "  retention window:       %.1f hours\n", r.RetentionWindowHours)
 	}
 
 	if len(r.Gaps) == 0 {
-		fmt.Fprintln(out, "  gaps:                   none")
+		_, _ = fmt.Fprintln(out, "  gaps:                   none")
 		return
 	}
 
@@ -113,18 +113,18 @@ func renderAuditVerifyTable(out io.Writer, r *sdk.AuditVerifyResult, tenant stri
 			missing = append(missing, g)
 		}
 	}
-	fmt.Fprintf(out, "  gaps:                   %d total\n", len(r.Gaps))
+	_, _ = fmt.Fprintf(out, "  gaps:                   %d total\n", len(r.Gaps))
 	if len(trimmed) > 0 {
-		fmt.Fprintf(out, "    retention_trimmed:    %d  %s\n", len(trimmed), formatGapSeqs(trimmed))
+		_, _ = fmt.Fprintf(out, "    retention_trimmed:    %d  %s\n", len(trimmed), formatGapSeqs(trimmed))
 	}
 	if len(missing) > 0 {
-		fmt.Fprintf(out, "    missing (tampering):  %d  %s\n", len(missing), formatGapSeqs(missing))
+		_, _ = fmt.Fprintf(out, "    missing (tampering):  %d  %s\n", len(missing), formatGapSeqs(missing))
 	}
 	if len(mismatched) > 0 {
-		fmt.Fprintf(out, "    hash_mismatch:        %d  %s\n", len(mismatched), formatGapSeqs(mismatched))
+		_, _ = fmt.Fprintf(out, "    hash_mismatch:        %d  %s\n", len(mismatched), formatGapSeqs(mismatched))
 	}
 	if len(outOfOrder) > 0 {
-		fmt.Fprintf(out, "    out_of_order:         %d  %s\n", len(outOfOrder), formatGapSeqs(outOfOrder))
+		_, _ = fmt.Fprintf(out, "    out_of_order:         %d  %s\n", len(outOfOrder), formatGapSeqs(outOfOrder))
 	}
 }
 

--- a/cmd/cordumctl/demo.go
+++ b/cmd/cordumctl/demo.go
@@ -226,28 +226,28 @@ func renderVerdictTable(out io.Writer, rows []demoVerdict) {
 		})
 	}
 
-	fmt.Fprintln(out)
-	fmt.Fprintln(out, "  Demo verdicts")
-	fmt.Fprintln(out, hr)
-	fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "  Demo verdicts")
+	_, _ = fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
 		stepW, "Step", topicW, "Topic", verdictW, "Verdict", reasonW, "Reason")
-	fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintln(out, hr)
 	for _, row := range rendered {
 		verdict := row.Verdict
 		if verdict == "" {
 			verdict = "PENDING"
 		}
-		fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
+		_, _ = fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
 			stepW, demoTruncate(row.StepID, stepW),
 			topicW, demoTruncate(row.Topic, topicW),
 			verdictW, demoTruncate(verdict, verdictW),
 			reasonW, demoTruncate(row.Reason, reasonW))
 	}
-	fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintln(out, hr)
 
 	for _, row := range rendered {
 		if row.Verdict == "REQUIRE_APPROVAL" && row.JobID != "" {
-			fmt.Fprintf(out, "\n  To approve %s: cordumctl approval job %s --approve\n",
+			_, _ = fmt.Fprintf(out, "\n  To approve %s: cordumctl approval job %s --approve\n",
 				row.StepID, row.JobID)
 		}
 	}

--- a/cmd/cordumctl/demo_test.go
+++ b/cmd/cordumctl/demo_test.go
@@ -25,7 +25,7 @@ func TestRenderVerdictTableOrdersByExpectedSteps(t *testing.T) {
 	if posGreet == -1 || posDelete == -1 || posAdmin == -1 {
 		t.Fatalf("missing rows in output:\n%s", out)
 	}
-	if !(posGreet < posDelete && posDelete < posAdmin) {
+	if posGreet >= posDelete || posDelete >= posAdmin {
 		t.Errorf("rows not in canonical order — greet=%d delete=%d admin=%d\n%s",
 			posGreet, posDelete, posAdmin, out)
 	}

--- a/cmd/cordumctl/doctor.go
+++ b/cmd/cordumctl/doctor.go
@@ -77,12 +77,10 @@ type doctorEnv struct {
 	apiKey      string
 	tenant      string
 	caCert      string
-	insecure    bool
 	skipWorkers bool
 	serviceURL  map[string]string
 	httpClient  *http.Client
 	status      *gatewayStatusResponse // lazily populated by the gateway_auth check
-	statusErr   error
 }
 
 const (
@@ -166,7 +164,6 @@ func buildDoctorEnv(fs *flagSet, skipWorkers bool, serviceURLRaw string) (*docto
 		apiKey:      strings.TrimSpace(*fs.apiKey),
 		tenant:      strings.TrimSpace(*fs.tenant),
 		caCert:      strings.TrimSpace(*fs.cacert),
-		insecure:    fs.insecure != nil && *fs.insecure,
 		skipWorkers: skipWorkers,
 		serviceURL:  parseServiceURLOverrides(serviceURLRaw),
 		httpClient:  hc,
@@ -287,7 +284,7 @@ func probeServiceReadyz(ctx context.Context, env *doctorEnv, p serviceProbe, url
 			Fix:    p.fix,
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return checkResult{State: stateOK, Detail: fmt.Sprintf("GET %s %d", url, resp.StatusCode)}
 	}
@@ -339,7 +336,7 @@ func checkGatewayReachable(ctx context.Context, env *doctorEnv) checkResult {
 			Fix:    "docker compose up -d api-gateway  (or check gateway_addr + TLS trust)",
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return checkResult{
 			State:  stateFail,
@@ -370,7 +367,7 @@ func checkGatewayAuth(ctx context.Context, env *doctorEnv) checkResult {
 	if err != nil {
 		return checkResult{State: stateFail, Detail: err.Error(), Fix: "docker compose logs api-gateway"}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusUnauthorized {
 		return checkResult{
 			State:  stateFail,
@@ -668,7 +665,7 @@ func doctorGetJSON(ctx context.Context, env *doctorEnv, path string, out any) (i
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 && out != nil {
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 			return resp.StatusCode, fmt.Errorf("decode body: %w", err)
@@ -912,40 +909,40 @@ func runInteractiveFixes(
 		if r.State != stateFail || strings.TrimSpace(r.Fix) == "" {
 			continue
 		}
-		fmt.Fprintf(stdout, "\n[FIX] %s (%s)\n", r.Label, r.ID)
-		fmt.Fprintf(stdout, "      detail: %s\n", r.Detail)
-		fmt.Fprintf(stdout, "      suggested: %s\n", r.Fix)
+		_, _ = fmt.Fprintf(stdout, "\n[FIX] %s (%s)\n", r.Label, r.ID)
+		_, _ = fmt.Fprintf(stdout, "      detail: %s\n", r.Detail)
+		_, _ = fmt.Fprintf(stdout, "      suggested: %s\n", r.Fix)
 		if isDestructiveFix(r.Fix) {
-			fmt.Fprintf(stdout, "      WARNING: suggested fix contains a potentially destructive flag.\n")
+			_, _ = fmt.Fprintf(stdout, "      WARNING: suggested fix contains a potentially destructive flag.\n")
 		}
-		fmt.Fprint(stdout, "      run now? [y/N/a] ")
+		_, _ = fmt.Fprint(stdout, "      run now? [y/N/a] ")
 		resp, readErr := readPromptLine(reader)
 		if readErr != nil {
-			fmt.Fprintln(stdout, "      (no input — skipping)")
+			_, _ = fmt.Fprintln(stdout, "      (no input — skipping)")
 			continue
 		}
 		choice := strings.ToLower(strings.TrimSpace(resp))
 		switch choice {
 		case "a":
-			fmt.Fprintln(stdout, "      aborting remaining fixes.")
+			_, _ = fmt.Fprintln(stdout, "      aborting remaining fixes.")
 			abort = true
 			continue
 		case "y", "yes":
 			if isDestructiveFix(r.Fix) {
-				fmt.Fprint(stdout, "      destructive — confirm with 'yes' to proceed: ")
+				_, _ = fmt.Fprint(stdout, "      destructive — confirm with 'yes' to proceed: ")
 				confirm, cerr := readPromptLine(reader)
 				if cerr != nil || strings.ToLower(strings.TrimSpace(confirm)) != "yes" {
-					fmt.Fprintln(stdout, "      confirmation declined — skipping.")
+					_, _ = fmt.Fprintln(stdout, "      confirmation declined — skipping.")
 					continue
 				}
 			}
-			fmt.Fprintf(stdout, "      running: %s\n", r.Fix)
+			_, _ = fmt.Fprintf(stdout, "      running: %s\n", r.Fix)
 			out, runErr := run(ctx, r.Fix)
 			if trimmed := strings.TrimSpace(out); trimmed != "" {
-				fmt.Fprintln(stdout, indentLines(trimmed, "        "))
+				_, _ = fmt.Fprintln(stdout, indentLines(trimmed, "        "))
 			}
 			if runErr != nil {
-				fmt.Fprintf(stdout, "      fix failed: %v\n", runErr)
+				_, _ = fmt.Fprintf(stdout, "      fix failed: %v\n", runErr)
 				continue
 			}
 			if c, ok := byID[r.ID]; ok {
@@ -958,7 +955,7 @@ func runInteractiveFixes(
 				if updated[i].Label == "" {
 					updated[i].Label = c.label
 				}
-				fmt.Fprintf(stdout, "      re-run: %s\n", updated[i].State)
+				_, _ = fmt.Fprintf(stdout, "      re-run: %s\n", updated[i].State)
 			}
 		default:
 			// "", "n", "no" → default skip, leave result as-is.
@@ -1051,7 +1048,7 @@ func emitHuman(w *os.File, results []checkResult, verbose bool) {
 // tests can render against a bytes.Buffer without isatty detection.
 func emitHumanTo(w io.Writer, useColor bool, results []checkResult, verbose bool) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "CHECK\tSTATE\tDETAIL\tFIX")
+	_, _ = fmt.Fprintln(tw, "CHECK\tSTATE\tDETAIL\tFIX")
 	// Stable order so human output is diff-friendly across runs.
 	ordered := append([]checkResult(nil), results...)
 	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
@@ -1064,10 +1061,10 @@ func emitHumanTo(w io.Writer, useColor bool, results []checkResult, verbose bool
 		if !verbose && len(detail) > 80 {
 			detail = detail[:77] + "..."
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", r.ID, state, detail, r.Fix)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", r.ID, state, detail, r.Fix)
 	}
 	_ = tw.Flush()
-	fmt.Fprintf(w, "\n%d checks: %d ok, %d warn, %d fail, %d skip\n",
+	_, _ = fmt.Fprintf(w, "\n%d checks: %d ok, %d warn, %d fail, %d skip\n",
 		len(results),
 		countByState(results, stateOK),
 		countByState(results, stateWarn),

--- a/cmd/cordumctl/doctor_test.go
+++ b/cmd/cordumctl/doctor_test.go
@@ -303,9 +303,13 @@ func TestSummaryAndExitCode(t *testing.T) {
 
 func TestRunDoctorChecks_RespectsOverallDeadline(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-	defer cancel()
-	time.Sleep(5 * time.Millisecond)
+	// Use a pre-cancelled context instead of a tiny timeout + sleep: on CI
+	// under -race the 1ms timer + 5ms sleep racy window occasionally lets
+	// the check execute before ctx.Err() fires. Cancelling explicitly is
+	// deterministic and equivalent for the invariant under test (any
+	// terminal ctx state short-circuits the check loop to stateSkip).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 	env := &doctorEnv{}
 	results := runDoctorChecks(ctx, env, []doctorCheck{
 		{id: "x", label: "X", run: func(_ context.Context, _ *doctorEnv) checkResult {

--- a/cmd/cordumctl/doctor_test.go
+++ b/cmd/cordumctl/doctor_test.go
@@ -932,9 +932,6 @@ func TestRunInteractiveFixes_EOFIsSkip(t *testing.T) {
 	if updated[0].State != stateFail {
 		t.Fatalf("EOF must preserve fail state, got %+v", updated[0])
 	}
-	if !errors.Is(nil, errors.New("")) {
-		// silence import linter: ensure `errors` import is used.
-	}
 	_ = errors.New
 }
 

--- a/cmd/cordumctl/main.go
+++ b/cmd/cordumctl/main.go
@@ -420,6 +420,10 @@ Usage:
   cordumctl audit verify [tenant] [--since ms] [--until ms] [--limit N] [--json]
   cordumctl evals extract --name <dataset> [--dry-run]
   cordumctl evals run --dataset <id> [--use-current] [--wait]
+  cordumctl auth <subcommand> [...]
+  cordumctl doctor [--json] [--verbose] [--strict] [--timeout SEC] [--skip-workers] [--fix]
+  cordumctl delegation <subcommand> [...]
+  cordumctl governance <subcommand> [...]
 
 Global flags:
   --gateway    Gateway base URL (default from CORDUM_GATEWAY)

--- a/cmd/cordumctl/main.go
+++ b/cmd/cordumctl/main.go
@@ -65,6 +65,14 @@ func main() {
 		runAuditCmd(args)
 	case "evals":
 		runEvalsCmd(args)
+	case "auth":
+		runAuthCmd(args)
+	case "doctor":
+		runDoctorCmd(args)
+	case "delegation":
+		runDelegationCmd(args)
+	case "governance":
+		runGovernanceCmd(args)
 	default:
 		usage()
 		os.Exit(1)

--- a/cmd/cordumctl/mcp.go
+++ b/cmd/cordumctl/mcp.go
@@ -97,18 +97,18 @@ func filterMCPToolList(list *sdk.MCPToolList, needle string) *sdk.MCPToolList {
 func renderMCPToolList(out io.Writer, list *sdk.MCPToolList) {
 	if list == nil || len(list.Tools) == 0 {
 		if list != nil && list.Note != "" {
-			fmt.Fprintln(out, "note:", list.Note)
+			_, _ = fmt.Fprintln(out, "note:", list.Note)
 		}
-		fmt.Fprintln(out, "No MCP tools visible.")
+		_, _ = fmt.Fprintln(out, "No MCP tools visible.")
 		return
 	}
 	header := "  Full registry"
 	if list.Filtered {
 		header = fmt.Sprintf("  Filtered for agent %s", list.AgentID)
 	}
-	fmt.Fprintln(out, header)
+	_, _ = fmt.Fprintln(out, header)
 	if list.Note != "" {
-		fmt.Fprintln(out, "  note:", list.Note)
+		_, _ = fmt.Fprintln(out, "  note:", list.Note)
 	}
 
 	const (
@@ -122,10 +122,10 @@ func renderMCPToolList(out io.Writer, list *sdk.MCPToolList) {
 		strings.Repeat("-", tierW+2) + "+" +
 		strings.Repeat("-", clsW+2) + "+" +
 		strings.Repeat("-", apvW+2) + "+"
-	fmt.Fprintln(out, hr)
-	fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
+	_, _ = fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
 		nameW, "Name", tierW, "Tier", clsW, "Classifications", apvW, "Approval")
-	fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintln(out, hr)
 	for _, t := range list.Tools {
 		tier := t.RiskTier
 		if tier == "" {
@@ -135,14 +135,14 @@ func renderMCPToolList(out io.Writer, list *sdk.MCPToolList) {
 		if t.RequiresApproval {
 			apv = "required"
 		}
-		fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
+		_, _ = fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s |\n",
 			nameW, truncateASCII(t.Name, nameW),
 			tierW, truncateASCII(tier, tierW),
 			clsW, truncateASCII(strings.Join(t.DataClassifications, ","), clsW),
 			apvW, truncateASCII(apv, apvW))
 	}
-	fmt.Fprintln(out, hr)
-	fmt.Fprintf(out, "  %d tool(s)\n", len(list.Tools))
+	_, _ = fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintf(out, "  %d tool(s)\n", len(list.Tools))
 }
 
 func runMCPPending(args []string) {
@@ -295,7 +295,7 @@ func runMCPResolve(args []string, verb string) {
 // only so MSYS/Windows consoles render correctly.
 func renderMCPApprovalList(out io.Writer, items []sdk.MCPApproval) {
 	if len(items) == 0 {
-		fmt.Fprintln(out, "No MCP approvals match the current filter.")
+		_, _ = fmt.Fprintln(out, "No MCP approvals match the current filter.")
 		return
 	}
 	// Approval IDs are 32 hex chars. Widen the column so operators can
@@ -314,19 +314,19 @@ func renderMCPApprovalList(out io.Writer, items []sdk.MCPApproval) {
 		strings.Repeat("-", agentW+2) + "+" +
 		strings.Repeat("-", statusW+2) + "+" +
 		strings.Repeat("-", hashW+2) + "+"
-	fmt.Fprintln(out, hr)
-	fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s | %-*s |\n",
+	_, _ = fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s | %-*s |\n",
 		idW, "Approval ID", toolW, "Tool", agentW, "Agent", statusW, "Status", hashW, "Args hash")
-	fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintln(out, hr)
 	for _, it := range items {
-		fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s | %-*s |\n",
+		_, _ = fmt.Fprintf(out, "  | %-*s | %-*s | %-*s | %-*s | %-*s |\n",
 			idW, truncateASCII(it.ID, idW),
 			toolW, truncateASCII(it.ToolName, toolW),
 			agentW, truncateASCII(it.AgentID, agentW),
 			statusW, truncateASCII(it.Status, statusW),
 			hashW, truncateASCII(shortHex(it.ArgsHash, 8), hashW))
 	}
-	fmt.Fprintln(out, hr)
+	_, _ = fmt.Fprintln(out, hr)
 }
 
 func truncateASCII(s string, n int) string {

--- a/cmd/cordumctl/mcp_keygen_test.go
+++ b/cmd/cordumctl/mcp_keygen_test.go
@@ -80,7 +80,7 @@ func TestMCPKeygen_WritesPrivatePEMAndPrintsBase64Public(t *testing.T) {
 	if keyID != "default" {
 		t.Errorf("keyID = %q, want default", keyID)
 	}
-	if loaded.PublicKey.X.Cmp(pub.X) != 0 || loaded.PublicKey.Y.Cmp(pub.Y) != 0 {
+	if loaded.X.Cmp(pub.X) != 0 || loaded.Y.Cmp(pub.Y) != 0 {
 		t.Error("loaded private key's public half does NOT match printed base64 SPKI — keygen round-trip is broken")
 	}
 

--- a/cmd/cordumctl/pack_install_verify.go
+++ b/cmd/cordumctl/pack_install_verify.go
@@ -112,7 +112,7 @@ func VerifyInstallBundle(bundleDir, packID string, opts PackVerificationOptions)
 		if opts.Strict && !opts.Force {
 			return nil, ErrNoVerifyRequiresForce
 		}
-		fmt.Fprintf(opts.Stderr, "WARNING: --no-verify set; pack %q signature will NOT be checked. This is unsafe for production.\n", packID)
+		_, _ = fmt.Fprintf(opts.Stderr, "WARNING: --no-verify set; pack %q signature will NOT be checked. This is unsafe for production.\n", packID)
 		return &PackVerificationResult{
 			Signed:             false,
 			SignatureAlgorithm: signing.AlgorithmEd25519,
@@ -127,7 +127,7 @@ func VerifyInstallBundle(bundleDir, packID string, opts PackVerificationOptions)
 		if opts.Strict {
 			return nil, fmt.Errorf("%w: pack %q (set CORDUM_PACK_STRICT=false, --strict=false, or sign the pack with `cordumctl pack sign`)", ErrUnsignedPackInStrict, packID)
 		}
-		fmt.Fprintf(opts.Stderr, "WARNING: pack %q is unsigned. Install proceeding in non-strict mode.\n", packID)
+		_, _ = fmt.Fprintf(opts.Stderr, "WARNING: pack %q is unsigned. Install proceeding in non-strict mode.\n", packID)
 		// When --require-cordum-sig is set on an unsigned pack the
 		// operator's intent is explicit: they want Cordum-counter-sig
 		// proof. Unsigned packs can't carry it, so fail even outside

--- a/cmd/cordumctl/pack_trust.go
+++ b/cmd/cordumctl/pack_trust.go
@@ -349,7 +349,7 @@ func decodePackPublicKeyBytes(raw []byte) (string, ed25519.PublicKey, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	if _, err := tmp.Write(raw); err != nil {
 		_ = tmp.Close()
 		return "", nil, err

--- a/core/audit/chain_reopen_test.go
+++ b/core/audit/chain_reopen_test.go
@@ -23,7 +23,7 @@ func TestChainer_HeadPoisonExhaustsCAS(t *testing.T) {
 	}
 	defer srv.Close()
 	client := redis.NewClient(&redis.Options{Addr: srv.Addr()})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	chainer := NewChainer(client, "")
 
 	ctx := context.Background()
@@ -90,7 +90,7 @@ func TestChainer_AppendLeavesEventCleanOnRetryFailure(t *testing.T) {
 	}
 	defer srv.Close()
 	client := redis.NewClient(&redis.Options{Addr: srv.Addr()})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	chainer := NewChainer(client, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -130,7 +130,7 @@ func TestVerifyChain_CrossWindowLinkageDetectsMutation(t *testing.T) {
 	}
 	defer srv.Close()
 	client := redis.NewClient(&redis.Options{Addr: srv.Addr()})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	chainer := NewChainer(client, "")
 
 	ctx := context.Background()

--- a/core/audit/exporter.go
+++ b/core/audit/exporter.go
@@ -84,6 +84,12 @@ const (
 	// A/B impact analysis. Extra carries shadow_bundle_id, bundle_id,
 	// active_verdict, shadow_verdict, diff, and latency_ms.
 	EventShadowEval = "shadow_eval"
+	// EventApprovalRevisionMismatch is emitted when the scheduler's
+	// approval fast-path rejects a job because the approval_snapshot
+	// label carried on the resubmitted JobRequest does not match the
+	// PolicySnapshot currently stored on the SafetyDecisionRecord.
+	// Extra carries stored_snapshot, asserted_snapshot, and topic.
+	EventApprovalRevisionMismatch = "approval.revision_mismatch"
 )
 
 // Severity levels for SIEM events.

--- a/core/audit/exporter.go
+++ b/core/audit/exporter.go
@@ -84,12 +84,6 @@ const (
 	// A/B impact analysis. Extra carries shadow_bundle_id, bundle_id,
 	// active_verdict, shadow_verdict, diff, and latency_ms.
 	EventShadowEval = "shadow_eval"
-	// EventApprovalRevisionMismatch is emitted when the scheduler's
-	// approval fast-path rejects a job because the approval_snapshot
-	// label carried on the resubmitted JobRequest does not match the
-	// PolicySnapshot currently stored on the SafetyDecisionRecord.
-	// Extra carries stored_snapshot, asserted_snapshot, and topic.
-	EventApprovalRevisionMismatch = "approval.revision_mismatch"
 )
 
 // Severity levels for SIEM events.

--- a/core/auth/delegation/token.go
+++ b/core/auth/delegation/token.go
@@ -401,7 +401,7 @@ func numericDateTime(value *jwt.NumericDate) time.Time {
 	if value == nil {
 		return time.Time{}
 	}
-	return value.Time.UTC()
+	return value.UTC()
 }
 
 func normalizeStringSet(values []string) []string {

--- a/core/controlplane/gateway/approvals_test.go
+++ b/core/controlplane/gateway/approvals_test.go
@@ -370,9 +370,10 @@ func TestApproveJobRefreshesStaleSnapshot(t *testing.T) {
 
 	jobID := "job-mismatch"
 	req := &pb.JobRequest{
-		JobId:    jobID,
-		Topic:    "job.test",
-		TenantId: "default",
+		JobId:       jobID,
+		Topic:       "job.test",
+		TenantId:    "default",
+		PrincipalId: "agent-submitter",
 	}
 	if err := s.jobStore.SetJobMeta(context.Background(), req); err != nil {
 		t.Fatalf("set job meta: %v", err)

--- a/core/controlplane/gateway/delegation_submit.go
+++ b/core/controlplane/gateway/delegation_submit.go
@@ -16,10 +16,6 @@ import (
 
 var errDelegationAgentRequired = errors.New("delegation token requires an authenticated agent identity")
 
-func (s *server) applySubmitDelegation(ctx context.Context, tenant, agentID, token string, labels map[string]string, meta *pb.JobMetadata) (map[string]string, error) {
-	return s.applySubmitDelegationWithAudience(ctx, tenant, agentID, token, "", labels, meta)
-}
-
 func submitDelegationExpectedAudience(agentID, audienceOverride string) string {
 	expectedAudience := strings.TrimSpace(audienceOverride)
 	if expectedAudience == "" {

--- a/core/controlplane/gateway/gateway.go
+++ b/core/controlplane/gateway/gateway.go
@@ -228,28 +228,6 @@ func (s *server) workersFromRedisSnapshot() ([]registry.WorkerSummary, error) {
 	return snap.Workers, nil
 }
 
-// workerSummariesToHeartbeats converts snapshot summaries to the Heartbeat
-// protobuf format used by the workers API, preserving the API contract.
-func workerSummariesToHeartbeats(workers []registry.WorkerSummary) []*pb.Heartbeat {
-	out := make([]*pb.Heartbeat, len(workers))
-	for i, w := range workers {
-		out[i] = &pb.Heartbeat{
-			WorkerId:        w.WorkerID,
-			Pool:            w.Pool,
-			ActiveJobs:      w.ActiveJobs,
-			MaxParallelJobs: w.MaxParallelJobs,
-			Capabilities:    w.Capabilities,
-			CpuLoad:         w.CpuLoad,
-			GpuUtilization:  w.GpuUtilization,
-			MemoryLoad:      w.MemoryLoad,
-			Region:          w.Region,
-			Type:            w.Type,
-			Labels:          w.Labels,
-		}
-	}
-	return out
-}
-
 // Close releases resources owned by the server, notably the user store
 // connection. It is safe to call with a nil userStore.
 func (s *server) Close() {
@@ -1091,6 +1069,10 @@ func startHTTPServer(s *server, httpAddr, metricsAddr string, grpcServer *grpc.S
 	mux.HandleFunc("POST /api/v1/mcp/verify-signature", s.instrumented("/api/v1/mcp/verify-signature", s.handleMCPVerifySignature))
 	mux.HandleFunc("GET /api/v1/mcp/outbound", s.instrumented("/api/v1/mcp/outbound", s.handleMCPOutbound))
 	mux.HandleFunc("GET /api/v1/mcp/usage", s.instrumented("/api/v1/mcp/usage", s.handleMCPUsage))
+	// MCP tool visibility (dashboard consumes these via src/hooks/useAgentTools.ts):
+	mux.HandleFunc("GET /api/v1/mcp/tools", s.instrumented("/api/v1/mcp/tools", s.handleListMCPTools))
+	mux.HandleFunc("GET /api/v1/agents/{id}/tools", s.instrumented("/api/v1/agents/{id}/tools", s.handleAgentToolVisibility))
+	mux.HandleFunc("GET /api/v1/agents/{id}/denied-events", s.instrumented("/api/v1/agents/{id}/denied-events", s.handleAgentDeniedEvents))
 
 	// 12. Policy endpoints
 	mux.HandleFunc("POST /api/v1/policy/evaluate", s.instrumented("/api/v1/policy/evaluate", s.handlePolicyEvaluate))

--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -1097,13 +1097,85 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 				return nil
 			}
 			if snapshotBase(currentSnapshot) != snapshotBase(policySnapshot) {
-				// Policy changed since the approval was created. The human is
-				// explicitly choosing to approve after reviewing the request —
-				// refresh the snapshot and proceed. Audit trail records the
-				// discrepancy for compliance.
-				s.appendAuditEntryNamed(ctx, "approve_snapshot_refreshed", "job", jobID, "", policyActorID(r), policyRole(r),
-					fmt.Sprintf("policy snapshot refreshed during approval (was=%s now=%s)", snapshotBase(policySnapshot), snapshotBase(currentSnapshot)))
-				policySnapshot = currentSnapshot
+				// Policy changed since the approval was created. Re-evaluate
+				// the CURRENT policy against the stored request before
+				// admitting the human approval — without this check, a job
+				// that the pre-drift policy merely gate-required can be
+				// dispatched under the post-drift policy even when that
+				// policy now denies it outright (TOCTOU). We only admit the
+				// approval if the fresh decision is still approval-gated or
+				// plain allow; DENY / THROTTLE / anything else fails closed
+				// and the request must be resubmitted.
+				defaultTenant := strings.TrimSpace(s.tenant)
+				if defaultTenant == "" {
+					defaultTenant = "default"
+				}
+				freshMeta := &policyMetaRequest{}
+				if req.Meta != nil {
+					freshMeta.TenantId = req.Meta.TenantId
+					freshMeta.ActorId = req.Meta.ActorId
+					freshMeta.ActorType = req.Meta.ActorType.String()
+					freshMeta.IdempotencyKey = req.Meta.IdempotencyKey
+					freshMeta.Capability = req.Meta.Capability
+					freshMeta.RiskTags = append([]string{}, req.Meta.RiskTags...)
+					freshMeta.Requires = append([]string{}, req.Meta.Requires...)
+					freshMeta.PackId = req.Meta.PackId
+					freshMeta.Labels = req.Meta.Labels
+				}
+				freshCheck, freshErr := buildPolicyCheckRequest(ctx, &policyCheckRequest{
+					JobId:       jobID,
+					Topic:       req.GetTopic(),
+					Tenant:      strings.TrimSpace(req.TenantId),
+					WorkflowId:  strings.TrimSpace(req.WorkflowId),
+					Priority:    req.Priority.String(),
+					PrincipalId: strings.TrimSpace(policyActorID(r)),
+					Labels:      req.Labels,
+					Budget:      req.Budget,
+					MemoryId:    strings.TrimSpace(req.MemoryId),
+					Meta:        freshMeta,
+				}, s.configSvc, defaultTenant)
+				if freshErr != nil {
+					s.appendAuditEntryNamed(ctx, "approve_failed", "job", jobID, "", policyActorID(r), policyRole(r),
+						fmt.Sprintf("approval drift re-evaluation build failed: %v", freshErr))
+					result = handlerResult{http.StatusInternalServerError, "approval drift re-evaluation failed"}
+					return nil
+				}
+				freshResp, freshEvalErr := s.safetyClient.Check(ctx, freshCheck)
+				if freshEvalErr != nil || freshResp == nil {
+					s.appendAuditEntryNamed(ctx, "approve_failed", "job", jobID, "", policyActorID(r), policyRole(r),
+						fmt.Sprintf("approval drift re-evaluation call failed: %v", freshEvalErr))
+					result = handlerResult{http.StatusBadGateway, "approval drift re-evaluation failed"}
+					return nil
+				}
+				freshDecision := freshResp.GetDecision()
+				switch freshDecision {
+				case pb.DecisionType_DECISION_TYPE_ALLOW,
+					pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS,
+					pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN:
+					// Fresh policy still admits this request (possibly with
+					// approval). Rotate the snapshot + rewrite the safety
+					// record so the scheduler fast-path binds to the new
+					// decision, not the pre-drift one.
+					s.appendAuditEntryNamed(ctx, "approve_snapshot_refreshed", "job", jobID, "", policyActorID(r), policyRole(r),
+						fmt.Sprintf("policy snapshot refreshed during approval (was=%s now=%s decision=%s)",
+							snapshotBase(policySnapshot), snapshotBase(currentSnapshot), freshDecision.String()))
+					policySnapshot = currentSnapshot
+					safetyRecord.PolicySnapshot = currentSnapshot
+					safetyRecord.ApprovalRequired = freshDecision == pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN
+					if err := s.jobStore.SetSafetyDecision(ctx, jobID, safetyRecord); err != nil {
+						slog.Warn("approve: failed to persist re-evaluated safety decision", "job_id", jobID, "error", err)
+					}
+				default:
+					// DENY / THROTTLE / UNSPECIFIED — the drifted policy no
+					// longer permits this request at all. Fail closed and
+					// surface a stale-snapshot conflict so the caller
+					// resubmits under current policy.
+					reason := fmt.Sprintf("policy drift denies this request under current snapshot (was=%s now=%s decision=%s)",
+						snapshotBase(policySnapshot), snapshotBase(currentSnapshot), freshDecision.String())
+					s.appendAuditEntryNamed(ctx, "approve_failed", "job", jobID, "", policyActorID(r), policyRole(r), reason)
+					result = handlerResult{http.StatusConflict, approvalConflictPayload(http.StatusConflict, model.ApprovalConflictStaleSnapshot, reason)}
+					return nil
+				}
 			}
 		}
 		reason := strings.TrimSpace(body.Reason)

--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -1201,9 +1201,17 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// approval_snapshot binds the resubmitted JobRequest to the exact
+		// PolicySnapshot this approval was admitted against (including any
+		// drift-refresh above). The scheduler's approval fast-path requires
+		// this label to match the stored SafetyDecisionRecord.PolicySnapshot
+		// before short-circuiting to SafetyAllow — blocking the TOCTOU where
+		// an approval granted under policy v1 would dispatch against policy v2
+		// without re-evaluation.
 		labelUpdates := map[string]string{
-			"approval_granted": "true",
-			bus.LabelBusMsgID:  "approval:" + jobID,
+			"approval_granted":  "true",
+			"approval_snapshot": policySnapshot,
+			bus.LabelBusMsgID:   "approval:" + jobID,
 		}
 		if reason != "" {
 			labelUpdates["approval_reason"] = reason

--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/controlplane/scheduler"
 	"github.com/cordum/cordum/core/infra/bus"
 	"github.com/cordum/cordum/core/infra/store"
 	"github.com/cordum/cordum/core/model"
@@ -310,7 +312,7 @@ func (s *server) syncApprovalQueueDepth(ctx context.Context) {
 }
 
 func (s *server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
-	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.workflowEng) {
+	if !s.requireStoreAndPermissionOrRole(w, r, auth.PermWorkflowsWrite, []string{"admin"}, s.workflowEng) {
 		return
 	}
 	runID, ok := requirePathParam(w, r, "run_id")
@@ -361,7 +363,7 @@ func (s *server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleListApprovals(w http.ResponseWriter, r *http.Request) {
-	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.jobStore) {
+	if !s.requireStoreAndPermissionOrRole(w, r, auth.PermJobsApprove, []string{"admin"}, s.jobStore) {
 		return
 	}
 	s.syncApprovalQueueDepth(r.Context())
@@ -741,7 +743,7 @@ func (s *server) publishApprovalRepair(ctx context.Context, repaired *store.Appr
 }
 
 func (s *server) handleRepairApproval(w http.ResponseWriter, r *http.Request) {
-	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.jobStore) {
+	if !s.requireStoreAndPermissionOrRole(w, r, auth.PermJobsApprove, []string{"admin"}, s.jobStore) {
 		return
 	}
 	var body approvalRepairRequest
@@ -898,7 +900,7 @@ func (s *server) handleRepairApproval(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
-	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.jobStore, s.bus) {
+	if !s.requireStoreAndPermissionOrRole(w, r, auth.PermJobsApprove, []string{"admin"}, s.jobStore, s.bus) {
 		return
 	}
 	var body struct {
@@ -1045,6 +1047,20 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 			s.appendAuditEntryNamed(ctx, "approve_failed", "job", jobID, "", policyActorID(r), policyRole(r), "approval job hash unavailable")
 			result = handlerResult{http.StatusConflict, approvalConflictPayload(http.StatusConflict, model.ApprovalConflictStaleRequest, "approval job hash unavailable")}
 			return nil
+		}
+		// Lock in the JobHash to match what the reconciler will compute from
+		// the currently stored request. Without this, drift between the
+		// scheduler's post-mutation hash (computed after effective-config /
+		// constraints were attached to req.Env) and the reconciler's
+		// hashApprovalJobRequest(stored-req) can cause the approval to be
+		// auto-invalidated as stale_request after a successful approve.
+		if lockedHash, err := scheduler.HashJobRequest(req); err == nil && lockedHash != "" {
+			if lockedHash != safetyRecord.JobHash {
+				safetyRecord.JobHash = lockedHash
+				if err := s.jobStore.SetSafetyDecision(ctx, jobID, safetyRecord); err != nil {
+					slog.Warn("approve: failed to lock in job hash", "job_id", jobID, "error", err)
+				}
+			}
 		}
 		topic := strings.TrimSpace(req.GetTopic())
 		isWorkflowGate := topic == capsdk.SubjectApprovalGate || topic == capsdk.SubjectWorkflowApprovalGate
@@ -1199,7 +1215,7 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleRejectJob(w http.ResponseWriter, r *http.Request) {
-	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.jobStore, s.bus) {
+	if !s.requireStoreAndPermissionOrRole(w, r, auth.PermJobsApprove, []string{"admin"}, s.jobStore, s.bus) {
 		return
 	}
 	var body struct {
@@ -1419,7 +1435,7 @@ func (s *server) handleRejectJob(w http.ResponseWriter, r *http.Request) {
 // combining blast radius, prior approvals, rollback hints, policy snapshot
 // summary, time remaining, and parsed constraints in one response.
 func (s *server) handleApprovalContext(w http.ResponseWriter, r *http.Request) {
-	if !s.requireStoreAndRole(w, r, []string{"admin"}, s.jobStore) {
+	if !s.requireStoreAndPermissionOrRole(w, r, auth.PermJobsApprove, []string{"admin"}, s.jobStore) {
 		return
 	}
 	jobID, ok := requirePathParam(w, r, "job_id")
@@ -1467,18 +1483,18 @@ func (s *server) handleApprovalContext(w http.ResponseWriter, r *http.Request) {
 
 	// Build the approval item (same shape as list endpoint).
 	approvalItem := map[string]any{
-		"job_id":              jobID,
-		"state":               string(state),
-		"decision":            safetyRecord.Decision,
-		"policy_snapshot":     safetyRecord.PolicySnapshot,
-		"policy_rule_id":      safetyRecord.RuleID,
-		"policy_reason":       safetyRecord.Reason,
-		"constraints":         safetyRecord.Constraints,
-		"approval_required":   safetyRecord.ApprovalRequired,
-		"approval_ref":        safetyRecord.ApprovalRef,
-		"approval_status":     approvalRecord.Status,
+		"job_id":                 jobID,
+		"state":                  string(state),
+		"decision":               safetyRecord.Decision,
+		"policy_snapshot":        safetyRecord.PolicySnapshot,
+		"policy_rule_id":         safetyRecord.RuleID,
+		"policy_reason":          safetyRecord.Reason,
+		"constraints":            safetyRecord.Constraints,
+		"approval_required":      safetyRecord.ApprovalRequired,
+		"approval_ref":           safetyRecord.ApprovalRef,
+		"approval_status":        approvalRecord.Status,
 		"approval_actionability": approvalRecord.Actionability,
-		"approval_decision":   approvalRecord.Decision,
+		"approval_decision":      approvalRecord.Decision,
 	}
 	if approvalErr == nil && approvalRecord.ApprovedBy != "" {
 		approvalItem["resolved_by"] = approvalRecord.ApprovedBy
@@ -1587,13 +1603,13 @@ func (s *server) handleApprovalContext(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]any{
-		"approval":                 approvalItem,
-		"blast_radius":             blastRadius,
-		"prior_approvals":          s.queryPriorApprovals(ctx, jobTopic, jobTenant, 10),
-		"rollback_hint":            rollbackHint,
-		"policy_snapshot_summary":  buildPolicySnapshotSummary(safetyRecord),
-		"time_remaining_ms":        timeRemainingMs,
-		"constraints":              constraintsParsed,
+		"approval":                approvalItem,
+		"blast_radius":            blastRadius,
+		"prior_approvals":         s.queryPriorApprovals(ctx, jobTopic, jobTenant, 10),
+		"rollback_hint":           rollbackHint,
+		"policy_snapshot_summary": buildPolicySnapshotSummary(safetyRecord),
+		"time_remaining_ms":       timeRemainingMs,
+		"constraints":             constraintsParsed,
 	}
 
 	priorCount := len(response["prior_approvals"].([]map[string]any))
@@ -1754,12 +1770,12 @@ func (s *server) queryPriorApprovals(ctx context.Context, topic, tenant string, 
 		}
 
 		results = append(results, map[string]any{
-			"job_id":      id,
-			"topic":       jobTopic,
-			"tenant":      jobTenant,
-			"decision":    meta["approval_decision"],
-			"resolved_by": meta["approval_by"],
-			"resolved_at": approvedAt,
+			"job_id":       id,
+			"topic":        jobTopic,
+			"tenant":       jobTenant,
+			"decision":     meta["approval_decision"],
+			"resolved_by":  meta["approval_by"],
+			"resolved_at":  approvedAt,
 			"was_approved": wasApproved,
 		})
 	}

--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -1138,9 +1138,19 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 					requesterPrincipal = strings.TrimSpace(req.Meta.ActorId)
 				}
 				if requesterPrincipal == "" {
-					slog.Warn("approve: drift re-evaluation missing original principal; falling back to approver identity",
-						"job_id", jobID, "approver", policyActorID(r))
-					requesterPrincipal = strings.TrimSpace(policyActorID(r))
+					// Fail closed. Evaluating under the approver's identity can
+					// admit a request that the current (principal-sensitive)
+					// policy would have denied for the original submitter when
+					// the approver happens to be more privileged. Force the
+					// request to be resubmitted so the fresh policy sees the
+					// real principal on a request that carries it.
+					msg := "original requester identity unavailable; resubmit under current policy"
+					s.appendAuditEntryNamed(ctx, "approve_failed", "job", jobID, "", policyActorID(r), policyRole(r), msg)
+					result = handlerResult{
+						http.StatusConflict,
+						approvalConflictPayload(http.StatusConflict, model.ApprovalConflictStaleSnapshot, msg),
+					}
+					return nil
 				}
 				freshCheck, freshErr := buildPolicyCheckRequest(ctx, &policyCheckRequest{
 					JobId:       jobID,

--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -1122,13 +1122,27 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 					freshMeta.PackId = req.Meta.PackId
 					freshMeta.Labels = req.Meta.Labels
 				}
+				// Use the ORIGINAL requester principal, not the approver. A
+				// principal-sensitive policy must be re-run against the
+				// identity that submitted the job; evaluating against the
+				// approver (who is typically an admin) would mask policies
+				// whose effect depends on the actor.
+				requesterPrincipal := strings.TrimSpace(req.GetPrincipalId())
+				if requesterPrincipal == "" && req.Meta != nil {
+					requesterPrincipal = strings.TrimSpace(req.Meta.ActorId)
+				}
+				if requesterPrincipal == "" {
+					slog.Warn("approve: drift re-evaluation missing original principal; falling back to approver identity",
+						"job_id", jobID, "approver", policyActorID(r))
+					requesterPrincipal = strings.TrimSpace(policyActorID(r))
+				}
 				freshCheck, freshErr := buildPolicyCheckRequest(ctx, &policyCheckRequest{
 					JobId:       jobID,
 					Topic:       req.GetTopic(),
 					Tenant:      strings.TrimSpace(req.TenantId),
 					WorkflowId:  strings.TrimSpace(req.WorkflowId),
 					Priority:    req.Priority.String(),
-					PrincipalId: strings.TrimSpace(policyActorID(r)),
+					PrincipalId: requesterPrincipal,
 					Labels:      req.Labels,
 					Budget:      req.Budget,
 					MemoryId:    strings.TrimSpace(req.MemoryId),
@@ -1153,15 +1167,25 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 					pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS,
 					pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN:
 					// Fresh policy still admits this request (possibly with
-					// approval). Rotate the snapshot + rewrite the safety
-					// record so the scheduler fast-path binds to the new
-					// decision, not the pre-drift one.
+					// approval). Persist the FULL re-evaluated decision so
+					// the scheduler's fast-path sees the current rule / reason /
+					// constraints, not a hybrid of old decision + new snapshot.
+					// ApprovalRef and JobHash are preserved (approval identity
+					// is still this job); ApprovalRevision is bumped so
+					// downstream consumers can detect the drift.
 					s.appendAuditEntryNamed(ctx, "approve_snapshot_refreshed", "job", jobID, "", policyActorID(r), policyRole(r),
-						fmt.Sprintf("policy snapshot refreshed during approval (was=%s now=%s decision=%s)",
-							snapshotBase(policySnapshot), snapshotBase(currentSnapshot), freshDecision.String()))
+						fmt.Sprintf("policy snapshot refreshed during approval (was=%s now=%s decision=%s rule=%s)",
+							snapshotBase(policySnapshot), snapshotBase(currentSnapshot), freshDecision.String(), freshResp.GetRuleId()))
 					policySnapshot = currentSnapshot
+					safetyRecord.Decision = mapDecisionTypeToSafety(freshDecision)
+					safetyRecord.Reason = freshResp.GetReason()
+					safetyRecord.RuleID = freshResp.GetRuleId()
+					safetyRecord.Constraints = freshResp.GetConstraints()
+					safetyRecord.Remediations = freshResp.GetRemediations()
 					safetyRecord.PolicySnapshot = currentSnapshot
 					safetyRecord.ApprovalRequired = freshDecision == pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN
+					safetyRecord.CheckedAt = time.Now().UnixMicro()
+					safetyRecord.ApprovalRevision++
 					if err := s.jobStore.SetSafetyDecision(ctx, jobID, safetyRecord); err != nil {
 						slog.Warn("approve: failed to persist re-evaluated safety decision", "job_id", jobID, "error", err)
 					}

--- a/core/controlplane/gateway/handlers_approvals.go
+++ b/core/controlplane/gateway/handlers_approvals.go
@@ -1058,7 +1058,13 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 			if lockedHash != safetyRecord.JobHash {
 				safetyRecord.JobHash = lockedHash
 				if err := s.jobStore.SetSafetyDecision(ctx, jobID, safetyRecord); err != nil {
-					slog.Warn("approve: failed to lock in job hash", "job_id", jobID, "error", err)
+					// Fail the approval: proceeding would publish a job with a
+					// newer JobHash than the stored SafetyDecisionRecord, which
+					// the reconciler would auto-invalidate as stale_request.
+					s.appendAuditEntryNamed(ctx, "approve_failed", "job", jobID, "", policyActorID(r), policyRole(r),
+						fmt.Sprintf("failed to persist locked job hash: %v", err))
+					result = handlerResult{http.StatusServiceUnavailable, "failed to persist approval state"}
+					return nil
 				}
 			}
 		}
@@ -1187,7 +1193,14 @@ func (s *server) handleApproveJob(w http.ResponseWriter, r *http.Request) {
 					safetyRecord.CheckedAt = time.Now().UnixMicro()
 					safetyRecord.ApprovalRevision++
 					if err := s.jobStore.SetSafetyDecision(ctx, jobID, safetyRecord); err != nil {
-						slog.Warn("approve: failed to persist re-evaluated safety decision", "job_id", jobID, "error", err)
+						// Persisting the re-evaluated decision is on the
+						// critical path — continuing would ship a job whose
+						// stored safety record still reflects the pre-drift
+						// policy. Fail closed and let the caller retry.
+						s.appendAuditEntryNamed(ctx, "approve_failed", "job", jobID, "", policyActorID(r), policyRole(r),
+							fmt.Sprintf("failed to persist refreshed safety decision: %v", err))
+						result = handlerResult{http.StatusServiceUnavailable, "failed to persist refreshed safety decision"}
+						return nil
 					}
 				default:
 					// DENY / THROTTLE / UNSPECIFIED — the drifted policy no

--- a/core/controlplane/gateway/handlers_audit_compliance.go
+++ b/core/controlplane/gateway/handlers_audit_compliance.go
@@ -160,7 +160,7 @@ func (s *server) handleAuditExport(w http.ResponseWriter, r *http.Request) {
 		if opts.Format == audit.ComplianceExportFormatJSON {
 			_ = writeJSONLineErr(w, werr)
 		} else {
-			fmt.Fprintf(w, "# cordum-error: %s\n", strings.ReplaceAll(werr.Error(), "\n", " "))
+			_, _ = fmt.Fprintf(w, "# cordum-error: %s\n", strings.ReplaceAll(werr.Error(), "\n", " "))
 		}
 		slog.Error("compliance export failed",
 			"tenant", tenant,

--- a/core/controlplane/gateway/handlers_delegation.go
+++ b/core/controlplane/gateway/handlers_delegation.go
@@ -500,8 +500,8 @@ func delegationIssuedView(tenant string, claims delegation.DelegationClaims, aud
 		AllowedTopics:  append([]string(nil), claims.AllowedTopics...),
 		Chain:          append([]delegation.ChainLink(nil), claims.DelegationChain...),
 		ChainDepth:     claims.ChainDepth,
-		IssuedAt:       claims.IssuedAt.Time.UTC(),
-		ExpiresAt:      claims.ExpiresAt.Time.UTC(),
+		IssuedAt:       claims.IssuedAt.UTC(),
+		ExpiresAt:      claims.ExpiresAt.UTC(),
 		ParentJTI:      strings.TrimSpace(claims.ParentTokenJTI),
 	}
 }

--- a/core/controlplane/gateway/handlers_delegation_test.go
+++ b/core/controlplane/gateway/handlers_delegation_test.go
@@ -154,6 +154,7 @@ func TestHandleDelegateAgentCrossTenantAndScopeErrors(t *testing.T) {
 	// continues to exercise the scope-subset enforcement — the exact
 	// attack that matters at the delegation wire path.
 
+	createDelegationAgent(t, s, "default", "agent-a", []string{"read", "write"}, []string{"job.alpha"})
 	createDelegationAgent(t, s, "default", "agent-b", []string{"read", "write"}, []string{"job.alpha"})
 	createDelegationAgent(t, s, "default", "agent-c", []string{"read"}, []string{"job.alpha"})
 

--- a/core/controlplane/gateway/handlers_governance_approvals_test.go
+++ b/core/controlplane/gateway/handlers_governance_approvals_test.go
@@ -20,7 +20,6 @@ import (
 // override below.
 type approvalAnalyticsStore struct {
 	stubDecisionLogStore
-	approvals map[string]model.ApprovalRecord
 }
 
 // writeApprovalRecords primes the test's jobStore-equivalent. We

--- a/core/controlplane/gateway/handlers_mcp.go
+++ b/core/controlplane/gateway/handlers_mcp.go
@@ -531,18 +531,6 @@ func (s *server) setMCPInvocationAuditor(a mcp.ToolInvocationAuditor) {
 	gatewayMCPAuditor.Store(s, a)
 }
 
-func (s *server) getMCPInvocationAuditor() mcp.ToolInvocationAuditor {
-	if s == nil {
-		return nil
-	}
-	if raw, ok := gatewayMCPAuditor.Load(s); ok {
-		if a, _ := raw.(mcp.ToolInvocationAuditor); a != nil {
-			return a
-		}
-	}
-	return nil
-}
-
 // mcpArgumentRedactionConfigKey is the configsvc key the gateway reads
 // to pull policy-bundle-sourced MCP argument-redaction rules. Stored
 // as a JSON blob matching the LoadRulesFromPolicyBundle envelope.

--- a/core/controlplane/gateway/helpers.go
+++ b/core/controlplane/gateway/helpers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cordum/cordum/core/infra/locks"
 	"github.com/cordum/cordum/core/infra/store"
 	"github.com/cordum/cordum/core/licensing"
+	"github.com/cordum/cordum/core/model"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 	"github.com/gorilla/websocket"
 	"github.com/redis/go-redis/v9"
@@ -353,6 +354,27 @@ func stripReservedLabels(labels map[string]string) map[string]string {
 		clean[k] = v
 	}
 	return clean
+}
+
+// mapDecisionTypeToSafety converts a wire-level pb.DecisionType into the
+// model.SafetyDecision enum used on SafetyDecisionRecord. Used by paths that
+// translate a fresh PolicyCheckResponse back onto the persisted record
+// (approval drift re-evaluation, policy replay, etc.).
+func mapDecisionTypeToSafety(d pb.DecisionType) model.SafetyDecision {
+	switch d {
+	case pb.DecisionType_DECISION_TYPE_ALLOW:
+		return model.SafetyAllow
+	case pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS:
+		return model.SafetyAllowWithConstraints
+	case pb.DecisionType_DECISION_TYPE_DENY:
+		return model.SafetyDeny
+	case pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN:
+		return model.SafetyRequireApproval
+	case pb.DecisionType_DECISION_TYPE_THROTTLE:
+		return model.SafetyThrottle
+	default:
+		return model.SafetyUnavailable
+	}
 }
 
 // maxContentLabelBytes is the maximum payload size to include in policy check

--- a/core/controlplane/gateway/pack_install_verify_test.go
+++ b/core/controlplane/gateway/pack_install_verify_test.go
@@ -159,7 +159,7 @@ func TestGatewayVerify_PublisherMetadataFromRedis(t *testing.T) {
 	}
 	defer mr.Close()
 	client := redis.NewUniversalClient(&redis.UniversalOptions{Addrs: []string{mr.Addr()}})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	root, kid, pub := writeGatewayTestPack(t, true)
 	if err := client.Set(context.Background(), gatewayTrustedKeysRedisPrefix+kid, base64.StdEncoding.EncodeToString(pub), 0).Err(); err != nil {
@@ -229,7 +229,7 @@ func TestGatewayVerify_StrictFlagFlippedViaRedis(t *testing.T) {
 	}
 	defer mr.Close()
 	client := redis.NewUniversalClient(&redis.UniversalOptions{Addrs: []string{mr.Addr()}})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	root, _, _ := writeGatewayTestPack(t, false)
 
@@ -259,7 +259,7 @@ func TestGatewayVerify_TrustedKeyFromRedis(t *testing.T) {
 	}
 	defer mr.Close()
 	client := redis.NewUniversalClient(&redis.UniversalOptions{Addrs: []string{mr.Addr()}})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	root, kid, pub := writeGatewayTestPack(t, true)
 	if err := client.Set(context.Background(), gatewayTrustedKeysRedisPrefix+kid, base64.StdEncoding.EncodeToString(pub), 0).Err(); err != nil {

--- a/core/controlplane/safetykernel/delegation_context_test.go
+++ b/core/controlplane/safetykernel/delegation_context_test.go
@@ -12,7 +12,7 @@ func TestEvaluate_DelegationPredicatesFromLabels(t *testing.T) {
 	t.Setenv(envDelegationPolicyEnabled, "true")
 
 	srv := &server{}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		DefaultDecision: "allow",
 		Rules: []config.PolicyRule{
 			{
@@ -49,7 +49,7 @@ func TestEvaluate_DelegationPredicatesFeatureFlagOff(t *testing.T) {
 	t.Setenv(envDelegationPolicyEnabled, "false")
 
 	srv := &server{}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		DefaultDecision: "allow",
 		Rules: []config.PolicyRule{
 			{

--- a/core/controlplane/safetykernel/kernel.go
+++ b/core/controlplane/safetykernel/kernel.go
@@ -308,6 +308,20 @@ func RunWithEntitlements(cfg *config.Config, resolver *licensing.EntitlementReso
 		tagDeriverRegistry: tagRegistry,
 	}
 
+	// Phase-2 shadow dual-evaluation: constructs the shadow loader +
+	// evaluator and attaches them to srv via SetShadowEvaluator so
+	// evaluate() can Submit active decisions without a nil-panic. When
+	// configsvc or NATS is unavailable setupShadowEvaluation returns
+	// (nil, nil) and the kernel still boots with shadow eval as a no-op
+	// — see shadow_eval.go for the fallback chain.
+	shadowLoader, shadowEvaluator := setupShadowEvaluation(srv, loader, natsBus)
+	if shadowEvaluator != nil {
+		defer shadowEvaluator.Close()
+	}
+	if shadowLoader != nil {
+		defer shadowLoader.Close()
+	}
+
 	// Lifecycle context for background goroutines — cancelled when Run returns.
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	defer lifecycleCancel()

--- a/core/controlplane/safetykernel/kernel_cache_test.go
+++ b/core/controlplane/safetykernel/kernel_cache_test.go
@@ -285,7 +285,7 @@ func TestCacheInvalidatedOnPolicyChange(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 100,
 	}
-	srv.setPolicy(context.Background(), policyA, "snapA")
+	_ = srv.setPolicy(context.Background(), policyA, "snapA")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-1",
@@ -303,7 +303,7 @@ func TestCacheInvalidatedOnPolicyChange(t *testing.T) {
 	}
 
 	// Change to policy B — should invalidate cache.
-	srv.setPolicy(context.Background(), policyB, "snapB")
+	_ = srv.setPolicy(context.Background(), policyB, "snapB")
 
 	// Second evaluation with same request — must see DENY (not stale cache).
 	resp2, err := srv.evaluate(context.Background(), req, "check")
@@ -328,7 +328,7 @@ func TestCacheHitSamePolicyVersion(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 100,
 	}
-	srv.setPolicy(context.Background(), policy, "snap1")
+	_ = srv.setPolicy(context.Background(), policy, "snap1")
 
 	key := "test-key"
 	resp := &pb.PolicyCheckResponse{Decision: pb.DecisionType_DECISION_TYPE_ALLOW}
@@ -358,7 +358,7 @@ func TestSetPolicyBumpsVersion(t *testing.T) {
 
 	// Each setPolicy call bumps version by 1.
 	for i := uint64(1); i <= 5; i++ {
-		srv.setPolicy(context.Background(), nil, fmt.Sprintf("snap%d", i))
+		_ = srv.setPolicy(context.Background(), nil, fmt.Sprintf("snap%d", i))
 		if v := srv.policyVersion.Load(); v != i {
 			t.Fatalf("expected version %d after %d calls, got %d", i, i, v)
 		}
@@ -371,7 +371,7 @@ func TestCacheEntriesCarryVersion(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 100,
 	}
-	srv.setPolicy(context.Background(), nil, "snap1") // version = 1
+	_ = srv.setPolicy(context.Background(), nil, "snap1") // version = 1
 
 	key := "versioned-key"
 	resp := &pb.PolicyCheckResponse{Decision: pb.DecisionType_DECISION_TYPE_ALLOW}
@@ -389,7 +389,7 @@ func TestCacheEntriesCarryVersion(t *testing.T) {
 	}
 
 	// Bump to version 2.
-	srv.setPolicy(context.Background(), nil, "snap2") // version = 2, cache cleared
+	_ = srv.setPolicy(context.Background(), nil, "snap2") // version = 2, cache cleared
 
 	// The cache was cleared by setPolicy, so the entry should be gone.
 	if got := srv.getCachedDecision(key); got != nil {
@@ -409,7 +409,7 @@ func TestCacheClearedOnSetPolicy(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 100,
 	}
-	srv.setPolicy(context.Background(), nil, "snap1") // version = 1
+	_ = srv.setPolicy(context.Background(), nil, "snap1") // version = 1
 
 	// Populate cache.
 	for i := 0; i < 10; i++ {
@@ -427,7 +427,7 @@ func TestCacheClearedOnSetPolicy(t *testing.T) {
 	}
 
 	// Policy change should clear cache entirely.
-	srv.setPolicy(context.Background(), nil, "snap2")
+	_ = srv.setPolicy(context.Background(), nil, "snap2")
 
 	srv.cacheMu.Lock()
 	size = len(srv.cache)
@@ -443,7 +443,7 @@ func TestCacheVersionMismatchDeletesEntry(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 100,
 	}
-	srv.setPolicy(context.Background(), nil, "snap1") // version = 1
+	_ = srv.setPolicy(context.Background(), nil, "snap1") // version = 1
 
 	key := "stale-key"
 	resp := &pb.PolicyCheckResponse{Decision: pb.DecisionType_DECISION_TYPE_ALLOW}
@@ -543,7 +543,7 @@ func TestCacheBypassedForVelocityPolicies(t *testing.T) {
 		resultClient:    client,
 		velocityChecker: newVelocityChecker(client),
 	}
-	srv.setPolicy(context.Background(), policy, "snap-cache-velocity")
+	_ = srv.setPolicy(context.Background(), policy, "snap-cache-velocity")
 
 	// Make 3 requests — first 2 should allow (within limit), 3rd should deny.
 	for i := 1; i <= 3; i++ {
@@ -588,7 +588,7 @@ func TestCacheStillWorksForNonVelocityPolicies(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 100,
 	}
-	srv.setPolicy(context.Background(), policy, "snap-no-velocity")
+	_ = srv.setPolicy(context.Background(), policy, "snap-no-velocity")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-cached",
@@ -682,7 +682,7 @@ func TestPolicyCacheTOCTOU(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 1000,
 	}
-	srv.setPolicy(context.Background(), policyAllow, "snap-allow")
+	_ = srv.setPolicy(context.Background(), policyAllow, "snap-allow")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-toctou",
@@ -722,7 +722,7 @@ func TestPolicyCacheTOCTOU(t *testing.T) {
 	}
 
 	// Reload policy to deny.
-	srv.setPolicy(context.Background(), policyDeny, "snap-deny")
+	_ = srv.setPolicy(context.Background(), policyDeny, "snap-deny")
 
 	// After reload, all evaluations must return DENY — no stale ALLOW.
 	for i := 0; i < 100; i++ {

--- a/core/controlplane/safetykernel/kernel_test.go
+++ b/core/controlplane/safetykernel/kernel_test.go
@@ -378,7 +378,7 @@ func TestEvaluateExplainSimulate(t *testing.T) {
 			"default": {AllowTopics: []string{"job.*"}},
 		},
 	}
-	srv.setPolicy(context.Background(), policy, "snap-1")
+	_ = srv.setPolicy(context.Background(), policy, "snap-1")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-9",
@@ -400,7 +400,7 @@ func TestEvaluateExplainSimulate(t *testing.T) {
 func TestListSnapshotsTracksHistory(t *testing.T) {
 	srv := &server{}
 	for i := 0; i < 12; i++ {
-		srv.setPolicy(context.Background(), nil, fmt.Sprintf("snap-%d", i))
+		_ = srv.setPolicy(context.Background(), nil, fmt.Sprintf("snap-%d", i))
 	}
 
 	resp, err := srv.ListSnapshots(context.Background(), &pb.ListSnapshotsRequest{})
@@ -515,7 +515,7 @@ func TestWatchPolicy_ContextCancel(t *testing.T) {
 	loader := &policyLoader{source: policyPath}
 
 	srv := &server{}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{}, "initial")
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{}, "initial")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -544,7 +544,7 @@ func TestWatchPolicyNotificationTrigger(t *testing.T) {
 	}
 
 	srv := &server{}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		DefaultTenant: "default",
 		Tenants: map[string]config.TenantPolicy{
 			"default": {AllowTopics: []string{"job.default.*"}},
@@ -675,9 +675,9 @@ func newTestRedisServer(t *testing.T) (*server, *miniredis.Miniredis) {
 func TestSnapshotHistoryRedis(t *testing.T) {
 	srv, mr := newTestRedisServer(t)
 
-	srv.setPolicy(context.Background(), nil, "snap-a")
-	srv.setPolicy(context.Background(), nil, "snap-b")
-	srv.setPolicy(context.Background(), nil, "snap-c")
+	_ = srv.setPolicy(context.Background(), nil, "snap-a")
+	_ = srv.setPolicy(context.Background(), nil, "snap-b")
+	_ = srv.setPolicy(context.Background(), nil, "snap-c")
 
 	// Verify Redis has 3 entries in newest-first order.
 	vals, err := mr.List(snapshotHistoryKey)
@@ -708,7 +708,7 @@ func TestSnapshotHistoryTrim(t *testing.T) {
 	srv, mr := newTestRedisServer(t)
 
 	for i := 0; i < 12; i++ {
-		srv.setPolicy(context.Background(), nil, fmt.Sprintf("snap-%d", i))
+		_ = srv.setPolicy(context.Background(), nil, fmt.Sprintf("snap-%d", i))
 	}
 
 	// Verify Redis list trimmed to 10.
@@ -731,8 +731,8 @@ func TestSnapshotHistoryTrim(t *testing.T) {
 func TestSnapshotHistoryRedisFallback(t *testing.T) {
 	// No Redis — local slice is the fallback.
 	srv := &server{}
-	srv.setPolicy(context.Background(), nil, "local-a")
-	srv.setPolicy(context.Background(), nil, "local-b")
+	_ = srv.setPolicy(context.Background(), nil, "local-a")
+	_ = srv.setPolicy(context.Background(), nil, "local-b")
 
 	resp, err := srv.ListSnapshots(context.Background(), &pb.ListSnapshotsRequest{})
 	if err != nil {
@@ -749,9 +749,9 @@ func TestSnapshotHistoryRedisFallback(t *testing.T) {
 func TestSnapshotHistoryOrder(t *testing.T) {
 	srv, _ := newTestRedisServer(t)
 
-	srv.setPolicy(context.Background(), nil, "first")
-	srv.setPolicy(context.Background(), nil, "second")
-	srv.setPolicy(context.Background(), nil, "third")
+	_ = srv.setPolicy(context.Background(), nil, "first")
+	_ = srv.setPolicy(context.Background(), nil, "second")
+	_ = srv.setPolicy(context.Background(), nil, "third")
 
 	resp, err := srv.ListSnapshots(context.Background(), &pb.ListSnapshotsRequest{})
 	if err != nil {
@@ -798,7 +798,7 @@ func TestEvaluateNilPolicyDeniesFailClosed(t *testing.T) {
 func TestEvaluateNilPolicyAfterSetPolicyNilDenies(t *testing.T) {
 	// Explicitly calling setPolicy(nil, "") should result in deny.
 	srv := &server{}
-	srv.setPolicy(context.Background(), nil, "")
+	_ = srv.setPolicy(context.Background(), nil, "")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-explicit-nil",
@@ -828,7 +828,7 @@ func TestEvaluateAllErrorClassesDeny(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := &server{}
 			if tt.policy != nil {
-				srv.setPolicy(context.Background(), tt.policy, "test")
+				_ = srv.setPolicy(context.Background(), tt.policy, "test")
 			}
 			req := &pb.PolicyCheckRequest{
 				JobId:  "job-err",
@@ -1053,7 +1053,7 @@ func TestEvaluateDecisionReasonMetadata(t *testing.T) {
 			srv := &server{}
 			snap := "snap-meta"
 			if tt.policy != nil {
-				srv.setPolicy(context.Background(), tt.policy, snap)
+				_ = srv.setPolicy(context.Background(), tt.policy, snap)
 			}
 			resp, err := srv.evaluate(context.Background(), tt.req, "check")
 			if err != nil {
@@ -1102,7 +1102,7 @@ func TestCachedDecisionNotServedAfterPolicyNil(t *testing.T) {
 		DefaultDecision: "allow",
 		DefaultTenant:   "default",
 	}
-	srv.setPolicy(context.Background(), policy, "snap-cached")
+	_ = srv.setPolicy(context.Background(), policy, "snap-cached")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-cached",
@@ -1140,7 +1140,7 @@ func TestEvaluatePanicRecoveryReturnsDeny(t *testing.T) {
 			"default": {AllowTopics: []string{"job.*"}},
 		},
 	}
-	srv.setPolicy(context.Background(), policy, "snap-panic")
+	_ = srv.setPolicy(context.Background(), policy, "snap-panic")
 
 	// Inject a panic via the test hook.
 	origHook := policyEvalTestHook
@@ -1177,7 +1177,7 @@ func TestEvaluatePanicRecoveryWithNilMapAccess(t *testing.T) {
 			"default": {AllowTopics: []string{"job.*"}},
 		},
 	}
-	srv.setPolicy(context.Background(), policy, "snap-nilmap")
+	_ = srv.setPolicy(context.Background(), policy, "snap-nilmap")
 
 	origHook := policyEvalTestHook
 	policyEvalTestHook = func() {
@@ -1215,7 +1215,7 @@ func TestEvaluateDefaultDecisionIsDeny(t *testing.T) {
 		DefaultDecision: "unknown_decision_value",
 		DefaultTenant:   "default",
 	}
-	srv.setPolicy(context.Background(), policy, "snap-default")
+	_ = srv.setPolicy(context.Background(), policy, "snap-default")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-default",
@@ -1250,7 +1250,7 @@ func TestWatchPolicyReloadFailureKeepsOldPolicy(t *testing.T) {
 			"prod": {AllowTopics: []string{"job.prod.*"}},
 		},
 	}
-	srv.setPolicy(context.Background(), initialPolicy, "initial-snap")
+	_ = srv.setPolicy(context.Background(), initialPolicy, "initial-snap")
 
 	// Corrupt the policy file so reload fails.
 	if err := os.WriteFile(policyPath, []byte("invalid:\n  - [broken"), 0o600); err != nil {
@@ -1443,7 +1443,7 @@ func newTestServerWithVelocity(t *testing.T, policy *config.SafetyPolicy, snapsh
 		cacheMaxSize:    100,
 	}
 	if policy != nil {
-		srv.setPolicy(context.Background(), policy, snapshot)
+		_ = srv.setPolicy(context.Background(), policy, snapshot)
 	}
 	return srv, mr
 }
@@ -1602,7 +1602,7 @@ func TestVelocityBundleRule_RedisUnavailable_FailClosed(t *testing.T) {
 		cache:           map[string]cacheEntry{},
 		cacheMaxSize:    100,
 	}
-	srv.setPolicy(context.Background(), policy, "snap-velocity-failclosed")
+	_ = srv.setPolicy(context.Background(), policy, "snap-velocity-failclosed")
 
 	// Close Redis to simulate unavailability.
 	mr.Close()
@@ -1635,7 +1635,7 @@ func TestVelocityBundleRule_RedisUnavailable_FailOpenOverride(t *testing.T) {
 		cache:           map[string]cacheEntry{},
 		cacheMaxSize:    100,
 	}
-	srv.setPolicy(context.Background(), policy, "snap-velocity-failopen")
+	_ = srv.setPolicy(context.Background(), policy, "snap-velocity-failopen")
 
 	// Close Redis to simulate unavailability.
 	mr.Close()
@@ -1669,7 +1669,7 @@ func TestVelocityBundleRule_RedisError_NoRuleLeakInLogs(t *testing.T) {
 		cache:           map[string]cacheEntry{},
 		cacheMaxSize:    100,
 	}
-	srv.setPolicy(context.Background(), policy, "snap-velocity-logleak")
+	_ = srv.setPolicy(context.Background(), policy, "snap-velocity-logleak")
 
 	// Capture slog output.
 	var logBuf bytes.Buffer
@@ -1708,7 +1708,7 @@ func TestVelocityBundleRule_NilChecker_FailOpen(t *testing.T) {
 		cache:        map[string]cacheEntry{},
 		cacheMaxSize: 100,
 	}
-	srv.setPolicy(context.Background(), policy, "snap-velocity-nilchecker")
+	_ = srv.setPolicy(context.Background(), policy, "snap-velocity-nilchecker")
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-nilchecker",
@@ -1784,7 +1784,7 @@ func TestVelocityBundleRule_PolicyReloadActivatesVelocity(t *testing.T) {
 	}
 
 	// Simulate bundle reload that introduces velocity rules.
-	srv.setPolicy(context.Background(), bundleVelocityPolicy(), "snap-with-velocity")
+	_ = srv.setPolicy(context.Background(), bundleVelocityPolicy(), "snap-with-velocity")
 
 	// Now velocity should be active: 3 allows, 4th denied.
 	sessionID := "sess-post-reload"
@@ -1865,7 +1865,7 @@ func TestConcurrentEvaluateAndSetPolicy(t *testing.T) {
 	}
 
 	srv := &server{}
-	srv.setPolicy(context.Background(), policyA, "snap-a")
+	_ = srv.setPolicy(context.Background(), policyA, "snap-a")
 
 	const (
 		numEvaluators = 50
@@ -1881,9 +1881,9 @@ func TestConcurrentEvaluateAndSetPolicy(t *testing.T) {
 	go func() {
 		for i := 0; i < numReloads; i++ {
 			if i%2 == 0 {
-				srv.setPolicy(context.Background(), policyB, "snap-b")
+				_ = srv.setPolicy(context.Background(), policyB, "snap-b")
 			} else {
-				srv.setPolicy(context.Background(), policyA, "snap-a")
+				_ = srv.setPolicy(context.Background(), policyA, "snap-a")
 			}
 		}
 		close(done)
@@ -2141,7 +2141,7 @@ func TestRiskTagSpoofing_DerivedTagsOverrideClient(t *testing.T) {
 	srv := &server{
 		tagDeriverRegistry: tagRegistry,
 	}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	// RED-TEAM SCENARIO: $500 transfer with spoofed risk_tags=["low"].
 	// Without the fix: the "low" tag matches bank-transfer-allow → ALLOW (bypass!)
@@ -2208,7 +2208,7 @@ func TestRiskTagSpoofing_ReviewAmount(t *testing.T) {
 	registerBuiltinTagDerivers(tagRegistry)
 
 	srv := &server{tagDeriverRegistry: tagRegistry}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-review-1",
@@ -2264,7 +2264,7 @@ func TestRiskTagSpoofing_LegitLowAmount(t *testing.T) {
 	registerBuiltinTagDerivers(tagRegistry)
 
 	srv := &server{tagDeriverRegistry: tagRegistry}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-legit-1",
@@ -2316,7 +2316,7 @@ func TestRiskTagSpoofing_TopicWithoutDeriver(t *testing.T) {
 	registerBuiltinTagDerivers(tagRegistry)
 
 	srv := &server{tagDeriverRegistry: tagRegistry}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	// No deriver for job.cordclaw.exec → client tags used as-is.
 	req := &pb.PolicyCheckRequest{
@@ -2366,7 +2366,7 @@ func TestRiskTagSpoofing_MissingPayload(t *testing.T) {
 	registerBuiltinTagDerivers(tagRegistry)
 
 	srv := &server{tagDeriverRegistry: tagRegistry}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	// No payload content at all → deriver fails-closed → "blocked" tag.
 	req := &pb.PolicyCheckRequest{
@@ -2408,7 +2408,7 @@ func TestRiskTagSpoofing_NilTagDeriverRegistry(t *testing.T) {
 
 	// No tag deriver registry — should not panic.
 	srv := &server{}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	req := &pb.PolicyCheckRequest{
 		JobId:  "job-nil-1",
@@ -2459,7 +2459,7 @@ func TestDefaultTopicRestriction_Integration(t *testing.T) {
 	}
 
 	srv := &server{}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	// Internal probe with _internal label → ALLOW.
 	internalReq := &pb.PolicyCheckRequest{
@@ -2546,7 +2546,7 @@ func TestPromptInjectionScanning_Integration(t *testing.T) {
 	srv := &server{
 		scanners: loadOutputScanners(),
 	}
-	srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), policy, "test-snapshot", 0)
 
 	// RED-TEAM SCENARIO #4: injection prompt that should be caught.
 	injectionReq := &pb.PolicyCheckRequest{

--- a/core/controlplane/safetykernel/metrics_test.go
+++ b/core/controlplane/safetykernel/metrics_test.go
@@ -143,26 +143,26 @@ func TestSafetyRuleDelegationMatchMetricRegistered(t *testing.T) {
 
 func formatFloat(f float64) string {
 	// Rough but readable; we only need substring matches for the test.
-	switch {
-	case f == 0.001:
+	switch f {
+	case 0.001:
 		return "0.001"
-	case f == 0.005:
+	case 0.005:
 		return "0.005"
-	case f == 0.01:
+	case 0.01:
 		return "0.01"
-	case f == 0.025:
+	case 0.025:
 		return "0.025"
-	case f == 0.05:
+	case 0.05:
 		return "0.05"
-	case f == 0.1:
+	case 0.1:
 		return "0.1"
-	case f == 0.25:
+	case 0.25:
 		return "0.25"
-	case f == 0.5:
+	case 0.5:
 		return "0.5"
-	case f == 1:
+	case 1:
 		return "1"
-	case f == 5:
+	case 5:
 		return "5"
 	default:
 		return ""

--- a/core/controlplane/safetykernel/output_policy_test.go
+++ b/core/controlplane/safetykernel/output_policy_test.go
@@ -89,7 +89,7 @@ func TestCheckOutputScansSecretContent(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -128,7 +128,7 @@ func TestCheckOutputMatchesOutputSizeLimit(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -159,7 +159,7 @@ func TestCheckOutputDisabledPolicyReturnsAllow(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: false, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -314,7 +314,7 @@ func TestCheckOutputDereferencesResultPointer(t *testing.T) {
 		scanners:     defaultOutputScanners(),
 		resultClient: resultClient,
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -345,7 +345,7 @@ func TestCheckOutputKeywordMatching(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -391,7 +391,7 @@ func TestCheckOutputContentTypeFilter(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -438,7 +438,7 @@ func TestEvaluateOutputDirect(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -495,7 +495,7 @@ func TestEvaluateOutputKeywordAndContentType(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -613,7 +613,7 @@ func TestContentTruncationFinding(t *testing.T) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{
@@ -686,7 +686,7 @@ func BenchmarkCheckOutputFastPath(b *testing.B) {
 	srv := &server{
 		scanners: defaultOutputScanners(),
 	}
-	srv.setPolicy(context.Background(), &config.SafetyPolicy{
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
 		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
 		OutputRules: []config.OutputPolicyRule{
 			{

--- a/core/controlplane/safetykernel/shadow_integration_test.go
+++ b/core/controlplane/safetykernel/shadow_integration_test.go
@@ -296,9 +296,13 @@ func TestShadowIntegration_QueueOverflowDropsWithoutActiveLatencyImpact(t *testi
 // after Close returns, no goroutines should remain blocked on the
 // worker-pool's queue. Run under goroutine-count delta rather than the
 // race detector (unavailable on this platform).
+//
+// NOT t.Parallel(): this test measures runtime.NumGoroutine() on the
+// whole process. Under t.Parallel() sibling tests concurrently spawn
+// fixture goroutines, which leak into this test's "after" count and
+// produce false-positive leak reports. Running serially lets the
+// before/after delta reflect only THIS fixture's workers.
 func TestShadowIntegration_CloseDrainsWorkerPool(t *testing.T) {
-	t.Parallel()
-
 	before := runtime.NumGoroutine()
 
 	srv, sender, cleanup := newIntegrationFixture(t, shadowDenyFooPolicy)

--- a/core/controlplane/safetykernel/shadow_integration_test.go
+++ b/core/controlplane/safetykernel/shadow_integration_test.go
@@ -61,7 +61,7 @@ func newIntegrationFixture(t *testing.T, shadowContent string) (*server, *captur
 		t.Fatalf("parse active: %v", err)
 	}
 	srv := &server{policy: active}
-	srv.setPolicyWithBundleCount(context.Background(), active, "snapshot-active", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), active, "snapshot-active", 0)
 
 	store, cleanupStore := newShadowTestStore(t)
 	if shadowContent != "" {
@@ -238,7 +238,7 @@ func TestShadowIntegration_QueueOverflowDropsWithoutActiveLatencyImpact(t *testi
 	// the single worker backs up immediately.
 	active, _ := config.ParseSafetyPolicy([]byte(activeAllowFooPolicy))
 	srv := &server{policy: active}
-	srv.setPolicyWithBundleCount(context.Background(), active, "snapshot-active", 0)
+	_ = srv.setPolicyWithBundleCount(context.Background(), active, "snapshot-active", 0)
 
 	store, cleanupStore := newShadowTestStore(t)
 	defer cleanupStore()

--- a/core/controlplane/scheduler/approval_snapshot_binding_test.go
+++ b/core/controlplane/scheduler/approval_snapshot_binding_test.go
@@ -80,7 +80,7 @@ func TestCheckSafetyDecision_ApprovalFastPathRequiresSnapshotBinding(t *testing.
 		engine, sink, jobStore, req := newFixture(t, "job-accept")
 		req.Labels["approval_snapshot"] = snapshotV2 + "|cfg:any-overlay"
 
-		rec, err := engine.checkSafetyDecision(req)
+		rec, err := engine.checkSafetyDecision(context.Background(), req)
 		if err != nil {
 			t.Fatalf("checkSafetyDecision returned unexpected error: %v", err)
 		}
@@ -111,7 +111,7 @@ func TestCheckSafetyDecision_ApprovalFastPathRequiresSnapshotBinding(t *testing.
 		engine, sink, _, req := newFixture(t, "job-missing")
 		// No approval_snapshot label (old gateway, pre-binding payload).
 
-		rec, err := engine.checkSafetyDecision(req)
+		rec, err := engine.checkSafetyDecision(context.Background(), req)
 		// checkSafetyDecision falls through to SafetyBasic which
 		// happily allows this job; the important assertion is that
 		// the fast-path did NOT short-circuit and the mismatch event
@@ -149,7 +149,7 @@ func TestCheckSafetyDecision_ApprovalFastPathRequiresSnapshotBinding(t *testing.
 		// not be honored by the fast-path.
 		req.Labels["approval_snapshot"] = snapshotV1
 
-		rec, err := engine.checkSafetyDecision(req)
+		rec, err := engine.checkSafetyDecision(context.Background(), req)
 		if err != nil {
 			t.Fatalf("checkSafetyDecision returned unexpected error: %v", err)
 		}

--- a/core/controlplane/scheduler/approval_snapshot_binding_test.go
+++ b/core/controlplane/scheduler/approval_snapshot_binding_test.go
@@ -1,0 +1,183 @@
+package scheduler
+
+// Regression coverage for the scheduler half of PR #204 blocker 2:
+// the approval fast-path must bind the short-circuit-to-SafetyAllow
+// decision to the PolicySnapshot under which the human actually
+// approved. Without this binding, an approval granted under policy v1
+// would dispatch under policy v2 if the safety kernel's policy
+// rotated between admission and dispatch.
+//
+// The gateway writes approval_snapshot onto the resubmitted
+// JobRequest and rotates the stored SafetyDecisionRecord.PolicySnapshot
+// to the human-approved snapshot. The scheduler fast-path requires the
+// two to match (via snapshotBase, which ignores config-overlay churn).
+// A mismatch emits an approval.revision_mismatch SIEM event and falls
+// through to a full safety re-check.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cordum/cordum/core/audit"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// TestCheckSafetyDecision_ApprovalFastPathRequiresSnapshotBinding
+// exercises both sides of the binding:
+//
+//   - Accept: approval_snapshot label matches stored PolicySnapshot
+//     (base-compared) → fast-path short-circuits to SafetyAllow.
+//   - Reject (missing label): no approval_snapshot label → fast-path
+//     falls through and emits approval.revision_mismatch.
+//   - Reject (mismatched label): approval_snapshot carries a stale
+//     snapshot vs stored → fast-path falls through and emits
+//     approval.revision_mismatch.
+func TestCheckSafetyDecision_ApprovalFastPathRequiresSnapshotBinding(t *testing.T) {
+	t.Parallel()
+
+	// Shared fixture: fresh engine + sink + seeded safety record
+	// under policy v2 (post-rotation snapshot). The gateway has
+	// rotated SafetyDecisionRecord.PolicySnapshot to v2 on approve.
+	const (
+		snapshotV1 = "sha256:policy-v1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		snapshotV2 = "sha256:policy-v2-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	newFixture := func(t *testing.T, jobID string) (*Engine, *recordingSink, *fakeJobStore, *pb.JobRequest) {
+		t.Helper()
+		sink := &recordingSink{}
+		jobStore := newFakeJobStore()
+		engine := NewEngine(&fakeBus{}, NewSafetyBasic(), newTestRegistry(t), NewNaiveStrategy(), jobStore, nil).
+			WithDispatchAuditSink(sink)
+
+		req := &pb.JobRequest{
+			JobId: jobID,
+			Topic: "job.gtm-engine.send-email",
+			Labels: map[string]string{
+				"approval_granted": "true",
+				"workflow_id":      "wf-1",
+				"run_id":           "run-1",
+				"step_id":          "send-email",
+			},
+		}
+		hash, err := HashJobRequest(req)
+		if err != nil {
+			t.Fatalf("hash job: %v", err)
+		}
+		// Simulate gateway having just resolved the approval: stored
+		// PolicySnapshot now reflects the snapshot under which the
+		// human approved (v2, after drift re-evaluation).
+		jobStore.safety[jobID] = SafetyDecisionRecord{
+			Decision:         SafetyRequireApproval,
+			ApprovalRequired: true,
+			PolicySnapshot:   snapshotV2,
+			JobHash:          hash,
+		}
+		return engine, sink, jobStore, req
+	}
+
+	t.Run("accept_matching_snapshot", func(t *testing.T) {
+		engine, sink, jobStore, req := newFixture(t, "job-accept")
+		req.Labels["approval_snapshot"] = snapshotV2 + "|cfg:any-overlay"
+
+		rec, err := engine.checkSafetyDecision(req)
+		if err != nil {
+			t.Fatalf("checkSafetyDecision returned unexpected error: %v", err)
+		}
+		if rec.Decision != SafetyAllow {
+			t.Fatalf("expected fast-path SafetyAllow, got %q (reason=%q)", rec.Decision, rec.Reason)
+		}
+		if rec.Reason != "approval granted" {
+			t.Fatalf("expected fast-path reason 'approval granted', got %q", rec.Reason)
+		}
+		// Fast-path persists the SafetyAllow record.
+		stored, ok := jobStore.safety["job-accept"]
+		if !ok {
+			t.Fatalf("expected safety record persisted")
+		}
+		if stored.Decision != SafetyAllow {
+			t.Fatalf("expected stored Decision=SafetyAllow, got %q", stored.Decision)
+		}
+		// No mismatch event emitted on the happy path.
+		for i := 0; i < sink.count(); i++ {
+			ev := sink.events[i]
+			if ev.EventType == audit.EventApprovalRevisionMismatch {
+				t.Fatalf("unexpected revision_mismatch event on matching snapshot: %+v", ev)
+			}
+		}
+	})
+
+	t.Run("reject_missing_snapshot_label", func(t *testing.T) {
+		engine, sink, _, req := newFixture(t, "job-missing")
+		// No approval_snapshot label (old gateway, pre-binding payload).
+
+		rec, err := engine.checkSafetyDecision(req)
+		// checkSafetyDecision falls through to SafetyBasic which
+		// happily allows this job; the important assertion is that
+		// the fast-path did NOT short-circuit and the mismatch event
+		// was emitted.
+		if err != nil {
+			t.Fatalf("checkSafetyDecision returned unexpected error: %v", err)
+		}
+		if rec.Reason == "approval granted" {
+			t.Fatalf("fast-path must not short-circuit without approval_snapshot label")
+		}
+		if sink.count() != 1 {
+			t.Fatalf("expected exactly 1 SIEM event, got %d", sink.count())
+		}
+		ev := sink.last()
+		if ev.EventType != audit.EventApprovalRevisionMismatch {
+			t.Fatalf("expected event_type=%q, got %q", audit.EventApprovalRevisionMismatch, ev.EventType)
+		}
+		if ev.Severity != audit.SeverityHigh {
+			t.Fatalf("expected severity=HIGH, got %q", ev.Severity)
+		}
+		if ev.Extra["stored_snapshot"] != snapshotV2 {
+			t.Errorf("extra.stored_snapshot=%q want %q", ev.Extra["stored_snapshot"], snapshotV2)
+		}
+		if ev.Extra["asserted_snapshot"] != "" {
+			t.Errorf("extra.asserted_snapshot=%q want empty", ev.Extra["asserted_snapshot"])
+		}
+	})
+
+	t.Run("reject_mismatched_snapshot_label", func(t *testing.T) {
+		engine, sink, _, req := newFixture(t, "job-mismatch")
+		// approval_snapshot predates the policy rotation (v1) but
+		// the stored SafetyDecisionRecord now reflects v2. This is
+		// the TOCTOU window: gateway resolved under v2 but an
+		// attacker-controlled resubmit with a stale label should
+		// not be honored by the fast-path.
+		req.Labels["approval_snapshot"] = snapshotV1
+
+		rec, err := engine.checkSafetyDecision(req)
+		if err != nil {
+			t.Fatalf("checkSafetyDecision returned unexpected error: %v", err)
+		}
+		if rec.Reason == "approval granted" {
+			t.Fatalf("fast-path must not short-circuit on snapshot mismatch")
+		}
+		if sink.count() != 1 {
+			t.Fatalf("expected exactly 1 SIEM event, got %d", sink.count())
+		}
+		ev := sink.last()
+		if ev.EventType != audit.EventApprovalRevisionMismatch {
+			t.Fatalf("expected event_type=%q, got %q", audit.EventApprovalRevisionMismatch, ev.EventType)
+		}
+		if ev.Extra["stored_snapshot"] != snapshotV2 {
+			t.Errorf("extra.stored_snapshot=%q want %q", ev.Extra["stored_snapshot"], snapshotV2)
+		}
+		if ev.Extra["asserted_snapshot"] != snapshotV1 {
+			t.Errorf("extra.asserted_snapshot=%q want %q", ev.Extra["asserted_snapshot"], snapshotV1)
+		}
+		if ev.Extra["topic"] != "job.gtm-engine.send-email" {
+			t.Errorf("extra.topic=%q want job.gtm-engine.send-email", ev.Extra["topic"])
+		}
+		if ev.Action != "scheduler.approval_fast_path_reject" {
+			t.Errorf("action=%q want scheduler.approval_fast_path_reject", ev.Action)
+		}
+	})
+}
+
+// Ensure the import is retained even if future refactors drop
+// the only consumer accidentally.
+var _ context.Context = context.Background()

--- a/core/controlplane/scheduler/engine.go
+++ b/core/controlplane/scheduler/engine.go
@@ -669,6 +669,52 @@ func (e *Engine) emitHeartbeatDisagreement(jobID, topic string, disagreement Hea
 	})
 }
 
+// emitApprovalRevisionMismatch records a SIEM event when the approval
+// fast-path refuses to short-circuit to SafetyAllow because the
+// approval_snapshot label on the resubmitted JobRequest does not match
+// (base-compared) the PolicySnapshot currently stored on the job's
+// SafetyDecisionRecord. Callers fall through to a full safety re-check;
+// this event gives SIEM operators a tamper/stale-approval signal
+// independent of whether the subsequent re-check allows or denies.
+func (e *Engine) emitApprovalRevisionMismatch(req *pb.JobRequest, stored, asserted string) {
+	if e == nil || req == nil {
+		return
+	}
+	jobID := strings.TrimSpace(req.GetJobId())
+	topic := strings.TrimSpace(req.GetTopic())
+	if e.dispatchAuditSink == nil {
+		return
+	}
+	ctx := e.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	extra := map[string]string{
+		"stored_snapshot":   stored,
+		"asserted_snapshot": asserted,
+	}
+	if topic != "" {
+		extra["topic"] = topic
+	}
+	tenant := ""
+	if req.Labels != nil {
+		if t := strings.TrimSpace(req.Labels["tenant"]); t != "" {
+			tenant = t
+		}
+	}
+	e.dispatchAuditSink.Emit(ctx, audit.SIEMEvent{
+		Timestamp:     time.Now().UTC(),
+		EventType:     audit.EventApprovalRevisionMismatch,
+		Severity:      audit.SeverityHigh,
+		TenantID:      tenant,
+		JobID:         jobID,
+		Action:        "scheduler.approval_fast_path_reject",
+		Reason:        "approval_snapshot label does not match stored PolicySnapshot",
+		PolicyVersion: snapshotBase(stored),
+		Extra:         extra,
+	})
+}
+
 // HandlePacketWithContext is the context-aware version of HandlePacket.
 // It receives trace context extracted from NATS headers and threads it
 // through to processJob for distributed tracing continuity.
@@ -1932,26 +1978,49 @@ func (e *Engine) checkSafetyDecision(req *pb.JobRequest, _ ...string) (SafetyDec
 			if err == nil && (prev.ApprovalRequired || prev.Decision == SafetyRequireApproval) && prev.JobHash != "" {
 				hash, err := HashJobRequest(req)
 				if err == nil && hash == prev.JobHash {
-					record = SafetyDecisionRecord{
-						Decision:       SafetyAllow,
-						Reason:         "approval granted",
-						CheckedAt:      time.Now().UTC().UnixNano() / int64(time.Microsecond),
-						Constraints:    prev.Constraints,
-						PolicySnapshot: prev.PolicySnapshot,
-						RuleID:         prev.RuleID,
-						JobHash:        prev.JobHash,
-					}
-					if e.jobStore != nil {
-						ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
-						defer cancel()
-						if err := e.jobStore.SetSafetyDecision(ctx, jobID, record); err != nil {
-							return record, err
+					// Bind the fast-path to the PolicySnapshot this approval
+					// was admitted against. The gateway stamps approval_snapshot
+					// onto the resubmitted request when it resolves the
+					// approval; we compare it (base only, to ignore config-
+					// overlay churn) against the stored safety record's
+					// PolicySnapshot — which ResolveApproval rotates to the
+					// human-approved snapshot on approve. A mismatch means the
+					// stored safety decision drifted after admission (reconciler
+					// invalidated it, or the label predates this binding), so
+					// we fall through to a full safety check instead of
+					// short-circuiting to SafetyAllow.
+					asserted := strings.TrimSpace(req.Labels["approval_snapshot"])
+					stored := strings.TrimSpace(prev.PolicySnapshot)
+					if asserted == "" || stored == "" || snapshotBase(asserted) != snapshotBase(stored) {
+						e.emitApprovalRevisionMismatch(req, stored, asserted)
+						slog.Warn("approval fast-path rejected: policy snapshot mismatch",
+							"job_id", jobID,
+							"stored_snapshot", stored,
+							"asserted_snapshot", asserted,
+						)
+					} else {
+						record = SafetyDecisionRecord{
+							Decision:       SafetyAllow,
+							Reason:         "approval granted",
+							CheckedAt:      time.Now().UTC().UnixNano() / int64(time.Microsecond),
+							Constraints:    prev.Constraints,
+							PolicySnapshot: prev.PolicySnapshot,
+							RuleID:         prev.RuleID,
+							JobHash:        prev.JobHash,
 						}
-						e.appendDecisionLog(req, record)
+						if e.jobStore != nil {
+							ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+							defer cancel()
+							if err := e.jobStore.SetSafetyDecision(ctx, jobID, record); err != nil {
+								return record, err
+							}
+							e.appendDecisionLog(req, record)
+						}
+						return record, nil
 					}
-					return record, nil
+				} else {
+					slog.Warn("approval label ignored (hash mismatch)", "job_id", jobID)
 				}
-				slog.Warn("approval label ignored (hash mismatch)", "job_id", jobID)
 			} else {
 				slog.Warn("approval label ignored (no approval record)", "job_id", jobID)
 			}

--- a/core/controlplane/scheduler/engine.go
+++ b/core/controlplane/scheduler/engine.go
@@ -696,11 +696,12 @@ func (e *Engine) emitApprovalRevisionMismatch(req *pb.JobRequest, stored, assert
 	if topic != "" {
 		extra["topic"] = topic
 	}
-	tenant := ""
-	if req.Labels != nil {
-		if t := strings.TrimSpace(req.Labels["tenant"]); t != "" {
-			tenant = t
-		}
+	// Canonical tenant source is req.TenantId (set by the gateway from the
+	// authenticated principal). Fall back to the "tenant" label only when
+	// the request body omits it, so SIEM alerts are scoped correctly.
+	tenant := strings.TrimSpace(req.TenantId)
+	if tenant == "" && req.Labels != nil {
+		tenant = strings.TrimSpace(req.Labels["tenant"])
 	}
 	e.dispatchAuditSink.Emit(ctx, audit.SIEMEvent{
 		Timestamp:     time.Now().UTC(),
@@ -1235,11 +1236,12 @@ func (e *Engine) handleJobRequest(req *pb.JobRequest, traceID string) error {
 			}
 		}
 
-		if currentState == "" {
+		switch currentState {
+		case "":
 			if err := e.setJobState(jobID, JobStatePending); err != nil {
 				return RetryAfter(err, retryDelayStore)
 			}
-		} else if currentState == JobStateScheduled {
+		case JobStateScheduled:
 			if inc, ok := e.jobStore.(interface {
 				IncrAttempts(context.Context, string) error
 			}); ok {
@@ -1941,7 +1943,7 @@ func (e *Engine) checkSafetyDecisionTraced(ctx context.Context, req *pb.JobReque
 		safetySpan.SetAttributes(attribute.String("cordum.job_id", strings.TrimSpace(req.JobId)))
 	}
 
-	record, err := e.checkSafetyDecision(req)
+	record, err := e.checkSafetyDecision(ctx, req)
 	if err != nil {
 		safetySpan.SetStatus(otelcodes.Error, err.Error())
 		safetySpan.RecordError(err)
@@ -1954,7 +1956,14 @@ func (e *Engine) checkSafetyDecisionTraced(ctx context.Context, req *pb.JobReque
 	return record, err
 }
 
-func (e *Engine) checkSafetyDecision(req *pb.JobRequest, _ ...string) (SafetyDecisionRecord, error) {
+// checkSafetyDecision evaluates safety for a job. The caller's ctx MUST be the
+// lock-fenced context from withJobLock — any state mutations derived from this
+// call (notably the approval fast-path SetSafetyDecision) must be cancelled
+// when the lock is lost to prevent stale-lock writes racing a takeover handler.
+func (e *Engine) checkSafetyDecision(ctx context.Context, req *pb.JobRequest) (SafetyDecisionRecord, error) {
+	if ctx == nil {
+		ctx = e.ctx
+	}
 	record := SafetyDecisionRecord{}
 	if req == nil {
 		return record, fmt.Errorf("missing job request")
@@ -1972,9 +1981,9 @@ func (e *Engine) checkSafetyDecision(req *pb.JobRequest, _ ...string) (SafetyDec
 	}
 	if approved {
 		if e.jobStore != nil {
-			ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+			storeCtx, cancel := context.WithTimeout(ctx, storeOpTimeout)
 			defer cancel()
-			prev, err := e.jobStore.GetSafetyDecision(ctx, jobID)
+			prev, err := e.jobStore.GetSafetyDecision(storeCtx, jobID)
 			if err == nil && (prev.ApprovalRequired || prev.Decision == SafetyRequireApproval) && prev.JobHash != "" {
 				hash, err := HashJobRequest(req)
 				if err == nil && hash == prev.JobHash {
@@ -1991,7 +2000,14 @@ func (e *Engine) checkSafetyDecision(req *pb.JobRequest, _ ...string) (SafetyDec
 					// short-circuiting to SafetyAllow.
 					asserted := strings.TrimSpace(req.Labels["approval_snapshot"])
 					stored := strings.TrimSpace(prev.PolicySnapshot)
-					if asserted == "" || stored == "" || snapshotBase(asserted) != snapshotBase(stored) {
+					// Workflow approval gates (sys.approval.gate /
+					// sys.workflow.approval.gate) carry no policy decision —
+					// SafetyBasic returns an empty PolicySnapshot for them.
+					// There is no TOCTOU concern to bind to, so skip the
+					// snapshot match for gate topics. Regular jobs still
+					// require the binding.
+					isGate := isApprovalGateTopic(strings.TrimSpace(req.GetTopic()))
+					if !isGate && (asserted == "" || stored == "" || snapshotBase(asserted) != snapshotBase(stored)) {
 						e.emitApprovalRevisionMismatch(req, stored, asserted)
 						slog.Warn("approval fast-path rejected: policy snapshot mismatch",
 							"job_id", jobID,
@@ -2009,9 +2025,14 @@ func (e *Engine) checkSafetyDecision(req *pb.JobRequest, _ ...string) (SafetyDec
 							JobHash:        prev.JobHash,
 						}
 						if e.jobStore != nil {
-							ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+							// Derive the store-op timeout from the caller's
+							// lock-fenced ctx, NOT e.ctx. If the lock is lost
+							// mid-evaluation the fenced ctx is cancelled and
+							// this write must not complete after the takeover
+							// handler has already mutated the job state.
+							writeCtx, cancel := context.WithTimeout(ctx, storeOpTimeout)
 							defer cancel()
-							if err := e.jobStore.SetSafetyDecision(ctx, jobID, record); err != nil {
+							if err := e.jobStore.SetSafetyDecision(writeCtx, jobID, record); err != nil {
 								return record, err
 							}
 							e.appendDecisionLog(req, record)
@@ -2039,7 +2060,7 @@ func (e *Engine) checkSafetyDecision(req *pb.JobRequest, _ ...string) (SafetyDec
 		}, e.ctx.Err()
 	}
 
-	safetyCtx, safetyCancel := context.WithTimeout(e.ctx, safetyCheckTimeout)
+	safetyCtx, safetyCancel := context.WithTimeout(ctx, safetyCheckTimeout)
 	defer safetyCancel()
 
 	record, err := e.safety.Check(safetyCtx, req)

--- a/core/controlplane/scheduler/engine_hardening_test.go
+++ b/core/controlplane/scheduler/engine_hardening_test.go
@@ -212,11 +212,11 @@ func TestSafetyCheckDefenseTimeout(t *testing.T) {
 	engine := NewEngine(&fakeBus{}, slow, newTestRegistry(t), NewNaiveStrategy(), store, nil)
 
 	start := time.Now()
-	record, err := engine.checkSafetyDecision(&pb.JobRequest{
+	record, err := engine.checkSafetyDecision(context.Background(), &pb.JobRequest{
 		JobId:    "job-timeout",
 		Topic:    "job.test",
 		TenantId: "default",
-	}, "")
+	})
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -253,11 +253,11 @@ func TestSafetyCheck_TimeoutCancelsContext(t *testing.T) {
 	engine := NewEngine(&fakeBus{}, tracker, newTestRegistry(t), NewNaiveStrategy(), store, nil)
 
 	start := time.Now()
-	record, _ := engine.checkSafetyDecision(&pb.JobRequest{
+	record, _ := engine.checkSafetyDecision(context.Background(), &pb.JobRequest{
 		JobId:    "job-ctx-cancel",
 		Topic:    "job.test",
 		TenantId: "default",
-	}, "")
+	})
 	elapsed := time.Since(start)
 
 	if record.Decision != SafetyUnavailable {

--- a/core/controlplane/scheduler/engine_test.go
+++ b/core/controlplane/scheduler/engine_test.go
@@ -1295,8 +1295,9 @@ func TestProcessJobApprovalGateApprovedAutoCompletes(t *testing.T) {
 		JobId: "job-gate-2",
 		Topic: capsdk.SubjectApprovalGate,
 		Labels: map[string]string{
-			"approval_granted": "true",
-			"gate_type":        "workflow_approval",
+			"approval_granted":  "true",
+			"approval_snapshot": workflowGateSnapshot,
+			"gate_type":         "workflow_approval",
 		},
 	}
 	jobHash, err := HashJobRequest(req)
@@ -1371,7 +1372,8 @@ func TestProcessJobApprovalGatePublishFailureReturnsRetryableError(t *testing.T)
 		JobId: "job-gate-4",
 		Topic: capsdk.SubjectApprovalGate,
 		Labels: map[string]string{
-			"approval_granted": "true",
+			"approval_granted":  "true",
+			"approval_snapshot": workflowGateSnapshot,
 		},
 	}
 	jobHash, err := HashJobRequest(req)
@@ -1471,8 +1473,9 @@ func TestApprovalGateTopicStillAutoCompletes(t *testing.T) {
 			JobId: jobID,
 			Topic: topic,
 			Labels: map[string]string{
-				"approval_granted": "true",
-				"gate_type":        "workflow_approval",
+				"approval_granted":  "true",
+				"approval_snapshot": workflowGateSnapshot,
+				"gate_type":         "workflow_approval",
 			},
 		}
 		jobHash, err := HashJobRequest(req)
@@ -1773,7 +1776,7 @@ func TestCheckSafetyDecision_EngineShutdown_DeniesImmediately(t *testing.T) {
 	// Simulate engine shutdown by cancelling the engine context.
 	engine.cancel()
 
-	record, err := engine.checkSafetyDecision(req, "")
+	record, err := engine.checkSafetyDecision(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error during shutdown, got nil")
 	}
@@ -2582,7 +2585,7 @@ func TestCheckSafetyDecisionAppendsDecisionLog(t *testing.T) {
 				Labels:   map[string]string{"agent_id": "agent-123"},
 			}
 
-			record, err := engine.checkSafetyDecision(req)
+			record, err := engine.checkSafetyDecision(context.Background(), req)
 			if err != nil {
 				t.Fatalf("checkSafetyDecision() error = %v", err)
 			}
@@ -2643,8 +2646,9 @@ func TestCheckSafetyDecisionApprovalGrantedAppendsDecisionLog(t *testing.T) {
 		Topic:    "job.test",
 		TenantId: "tenant-a",
 		Labels: map[string]string{
-			"approval_granted": "true",
-			"agent_id":         "agent-approved",
+			"approval_granted":  "true",
+			"approval_snapshot": "snap-approved|sha256:abc",
+			"agent_id":          "agent-approved",
 		},
 	}
 	jobHash, err := HashJobRequest(req)
@@ -2660,7 +2664,7 @@ func TestCheckSafetyDecisionApprovalGrantedAppendsDecisionLog(t *testing.T) {
 		CheckedAt:        time.Date(2026, time.April, 20, 10, 0, 0, 0, time.UTC).UnixNano() / int64(time.Microsecond),
 	}
 
-	record, err := engine.checkSafetyDecision(req)
+	record, err := engine.checkSafetyDecision(context.Background(), req)
 	if err != nil {
 		t.Fatalf("checkSafetyDecision() error = %v", err)
 	}
@@ -2759,7 +2763,7 @@ func TestCheckSafetyDecisionShutdownDeniesNotFailOpen(t *testing.T) {
 	// Cancel the engine context to simulate shutdown
 	engine.cancel()
 
-	record, err := engine.checkSafetyDecision(req, "")
+	record, err := engine.checkSafetyDecision(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error from checkSafetyDecision during shutdown, got nil")
 	}

--- a/core/controlplane/scheduler/reconciler.go
+++ b/core/controlplane/scheduler/reconciler.go
@@ -296,7 +296,7 @@ func (r *Reconciler) handleApprovalRepairs(ctx context.Context, now time.Time) {
 			classifyOpts := infraStore.ApprovalRepairClassifyOptions{}
 			if currentSnapshot != "" {
 				storedSnap := snapshot.SafetyRecord.PolicySnapshot
-				if storedSnap != "" && reconcilerSnapshotBase(currentSnapshot) != reconcilerSnapshotBase(storedSnap) {
+				if storedSnap != "" && snapshotBase(currentSnapshot) != snapshotBase(storedSnap) {
 					classifyOpts.StaleSnapshot = true
 				}
 			}
@@ -345,10 +345,12 @@ func autoApplyApprovalRepair(plan infraStore.ApprovalRepairPlan) bool {
 	}
 }
 
-// reconcilerSnapshotBase returns the base policy hash from a combined snapshot
-// string. Combined snapshots have the form "base|cfg:hash"; this extracts just
-// "base" so that config-overlay changes don't affect staleness detection.
-func reconcilerSnapshotBase(snap string) string {
+// snapshotBase returns the base policy hash from a combined snapshot string.
+// Combined snapshots have the form "base|cfg:hash"; this extracts just "base"
+// so that config-overlay changes don't affect approval-binding comparisons.
+// Shared by the reconciler's stale-snapshot detection and the engine's
+// approval fast-path revision check.
+func snapshotBase(snap string) string {
 	if i := strings.Index(snap, "|"); i >= 0 {
 		return snap[:i]
 	}

--- a/core/evals/extraction/helpers_extra_test.go
+++ b/core/evals/extraction/helpers_extra_test.go
@@ -38,7 +38,7 @@ func TestServiceRunValidatesRequiredDependencies(t *testing.T) {
 	if _, err := nilSvc.Validate(ExtractionRequest{}); err == nil || !strings.Contains(err.Error(), "extractor is nil") {
 		t.Fatalf("Validate(nil) error = %v", err)
 	}
-	if _, err := nilSvc.Run(nil, ExtractionRequest{}); err == nil || !strings.Contains(err.Error(), "extractor is nil") {
+	if _, err := nilSvc.Run(context.TODO(), ExtractionRequest{}); err == nil || !strings.Contains(err.Error(), "extractor is nil") {
 		t.Fatalf("Run(nil) error = %v", err)
 	}
 

--- a/core/infra/bus/nats.go
+++ b/core/infra/bus/nats.go
@@ -935,10 +935,14 @@ func natsTLSConfigFromEnv() (*tls.Config, error) {
 				return nil, fmt.Errorf("nats tls: %w", verr)
 			}
 		}
-		// Chain verified (or skipped when caPath/insecure bypass it) — emit
-		// the success gauge so freshness/expiry dashboards stay green.
+		// Emit the success gauge. chainValid MUST reflect whether chain
+		// verification actually ran — when caPath is empty or insecure
+		// is set, VerifyChain was skipped, so we cannot claim chain
+		// validity and must emit false to avoid false-positive TLS
+		// health signals in cordum_cert_chain_valid.
+		chainValid := caPath != "" && !insecure
 		if leaf := firstLeaf(cert); leaf != nil {
-			tlsutil.EmitCertMetrics("nats", "client", certPath, leaf.NotAfter, true)
+			tlsutil.EmitCertMetrics("nats", "client", certPath, leaf.NotAfter, chainValid)
 		}
 		cfg.Certificates = []tls.Certificate{cert}
 	}

--- a/core/infra/bus/nats.go
+++ b/core/infra/bus/nats.go
@@ -923,10 +923,8 @@ func natsTLSConfigFromEnv() (*tls.Config, error) {
 		// as "remote error: tls: certificate required" from the server — the
 		// operator has no signal what's wrong. ChainError prints both cert
 		// DNs, both validity windows, and the exact cordumctl command to fix.
-		chainValid := true
 		if caPath != "" && !insecure {
 			if verr := tlsutil.VerifyChain(certPath, caPath, tlsutil.RoleClient); verr != nil {
-				chainValid = false
 				// Emit metrics before failing so a one-off restart loop
 				// still leaves a measurable signal in /metrics. The gauge
 				// goes to 0 and Grafana fires, even though this goroutine
@@ -937,8 +935,10 @@ func natsTLSConfigFromEnv() (*tls.Config, error) {
 				return nil, fmt.Errorf("nats tls: %w", verr)
 			}
 		}
+		// Chain verified (or skipped when caPath/insecure bypass it) — emit
+		// the success gauge so freshness/expiry dashboards stay green.
 		if leaf := firstLeaf(cert); leaf != nil {
-			tlsutil.EmitCertMetrics("nats", "client", certPath, leaf.NotAfter, chainValid)
+			tlsutil.EmitCertMetrics("nats", "client", certPath, leaf.NotAfter, true)
 		}
 		cfg.Certificates = []tls.Certificate{cert}
 	}

--- a/core/infra/redisutil/redisutil.go
+++ b/core/infra/redisutil/redisutil.go
@@ -231,10 +231,14 @@ func tlsConfigFromEnv(existing *tls.Config) (*tls.Config, error) {
 				return nil, fmt.Errorf("redis tls: %w", verr)
 			}
 		}
-		// Chain verified (or skipped when caPath/insecure bypass it) — emit
-		// the success gauge so freshness/expiry dashboards stay green.
+		// Emit the success gauge. chainValid MUST reflect whether chain
+		// verification actually ran — when caPath is empty or insecure
+		// is set, VerifyChain was skipped, so we cannot claim chain
+		// validity and must emit false to avoid false-positive TLS
+		// health signals in cordum_cert_chain_valid.
+		chainValid := caPath != "" && !insecure
 		if leaf := firstLeafFromTLSCert(cert); leaf != nil {
-			tlsutil.EmitCertMetrics("redis", "client", certPath, leaf.NotAfter, true)
+			tlsutil.EmitCertMetrics("redis", "client", certPath, leaf.NotAfter, chainValid)
 		}
 		cfg.Certificates = []tls.Certificate{cert}
 	}

--- a/core/infra/redisutil/redisutil.go
+++ b/core/infra/redisutil/redisutil.go
@@ -223,18 +223,18 @@ func tlsConfigFromEnv(existing *tls.Config) (*tls.Config, error) {
 		// Chain-verify so CA-rotated-without-client drift surfaces with a
 		// rich error (issuer DNs, validity windows, remediation) instead of
 		// bubbling up as an opaque "certificate required" handshake failure.
-		chainValid := true
 		if caPath != "" && !insecure {
 			if verr := tlsutil.VerifyChain(certPath, caPath, tlsutil.RoleClient); verr != nil {
-				chainValid = false
 				if leaf := firstLeafFromTLSCert(cert); leaf != nil {
 					tlsutil.EmitCertMetrics("redis", "client", certPath, leaf.NotAfter, false)
 				}
 				return nil, fmt.Errorf("redis tls: %w", verr)
 			}
 		}
+		// Chain verified (or skipped when caPath/insecure bypass it) — emit
+		// the success gauge so freshness/expiry dashboards stay green.
 		if leaf := firstLeafFromTLSCert(cert); leaf != nil {
-			tlsutil.EmitCertMetrics("redis", "client", certPath, leaf.NotAfter, chainValid)
+			tlsutil.EmitCertMetrics("redis", "client", certPath, leaf.NotAfter, true)
 		}
 		cfg.Certificates = []tls.Certificate{cert}
 	}

--- a/core/infra/store/eval_dataset_store_test.go
+++ b/core/infra/store/eval_dataset_store_test.go
@@ -609,7 +609,7 @@ func BenchmarkListEvalDatasets1k(b *testing.B) {
 	}
 	defer srv.Close()
 	client := redis.NewClient(&redis.Options{Addr: srv.Addr()})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	s := NewEvalDatasetStoreFromClient(client)
 	ctx := context.Background()
 

--- a/core/infra/store/eval_run_store.go
+++ b/core/infra/store/eval_run_store.go
@@ -400,10 +400,6 @@ func (s *EvalRunStore) GCExpired(ctx context.Context, tenant string) (int, error
 		return 0, fmt.Errorf("gc eval runs: %w", err)
 	}
 	stale := make([]any, 0)
-	staleWithDataset := make([]struct {
-		id        string
-		datasetID string
-	}, 0)
 	for _, id := range ids {
 		exists, err := s.client.Exists(ctx, evalRunRecordKey(tenant, id)).Result()
 		if err != nil {
@@ -411,10 +407,6 @@ func (s *EvalRunStore) GCExpired(ctx context.Context, tenant string) (int, error
 		}
 		if exists == 0 {
 			stale = append(stale, id)
-			staleWithDataset = append(staleWithDataset, struct {
-				id        string
-				datasetID string
-			}{id: id})
 		}
 	}
 	if len(stale) == 0 {

--- a/core/infra/store/job_store.go
+++ b/core/infra/store/job_store.go
@@ -2682,6 +2682,11 @@ func (s *RedisJobStore) ResolveApproval(ctx context.Context, params ApprovalReso
 		// aligned with the approval_snapshot label written onto the request.
 		if params.Decision == model.ApprovalDecisionApprove && strings.TrimSpace(resolvedRecord.PolicySnapshot) != "" {
 			fields[metaFieldSafetySnapshot] = resolvedRecord.PolicySnapshot
+			// Keep the returned SafetyRecord aligned with what we just wrote
+			// to Redis. Callers (e.g. the approval publish step) that read
+			// ApprovalResolutionResult.SafetyRecord.PolicySnapshot must see
+			// the rotated snapshot, not the pre-rotation value.
+			safetyRecord.PolicySnapshot = resolvedRecord.PolicySnapshot
 		}
 		if len(req.Labels) > 0 {
 			if labelsJSON, err := json.Marshal(req.Labels); err == nil {

--- a/core/infra/store/job_store.go
+++ b/core/infra/store/job_store.go
@@ -2674,6 +2674,15 @@ func (s *RedisJobStore) ResolveApproval(ctx context.Context, params ApprovalReso
 		if resolvedRecord.PublishTarget != "" {
 			fields[metaFieldApprovalPublishTarget] = string(resolvedRecord.PublishTarget)
 		}
+		// On approve, rotate the SafetyDecisionRecord.PolicySnapshot to the
+		// snapshot under which the human actually approved. The gateway has
+		// already refreshed params.PolicySnapshot to the current snapshot if
+		// it detected drift, so anchoring the stored safety record here keeps
+		// the scheduler's fast-path comparison against safety.PolicySnapshot
+		// aligned with the approval_snapshot label written onto the request.
+		if params.Decision == model.ApprovalDecisionApprove && strings.TrimSpace(resolvedRecord.PolicySnapshot) != "" {
+			fields[metaFieldSafetySnapshot] = resolvedRecord.PolicySnapshot
+		}
 		if len(req.Labels) > 0 {
 			if labelsJSON, err := json.Marshal(req.Labels); err == nil {
 				fields[metaFieldLabels] = string(labelsJSON)

--- a/core/infra/store/job_store_test.go
+++ b/core/infra/store/job_store_test.go
@@ -2067,7 +2067,7 @@ func TestSetStateWithContext_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create job store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	ctx := context.Background()
 	jobID := "job-evt-1"
@@ -2128,7 +2128,7 @@ func TestSetStateWithContext_NilCtx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create job store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	ctx := context.Background()
 	jobID := "job-evt-nil"
@@ -2161,7 +2161,7 @@ func TestSetState_StillWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create job store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	ctx := context.Background()
 	jobID := "job-evt-legacy"
@@ -2201,7 +2201,7 @@ func TestGetJobEvents_NonExistentJob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create job store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	events, err := store.GetJobEvents(context.Background(), "job-does-not-exist")
 	if err != nil {
@@ -2221,7 +2221,7 @@ func TestGetJobEvents_ChronologicalOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create job store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	ctx := context.Background()
 	jobID := "job-evt-order"
@@ -2266,7 +2266,7 @@ func TestGetJobEvents_MixedFormats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create job store: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	ctx := context.Background()
 	jobID := "job-evt-mixed"

--- a/core/mcp/bridge_mutating_test.go
+++ b/core/mcp/bridge_mutating_test.go
@@ -29,7 +29,7 @@ func newStubGateway(t *testing.T, status int, response map[string]any) (*httptes
 		captured.method = r.Method
 		captured.path = r.URL.RequestURI()
 		captured.header = r.Header.Clone()
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 		raw, _ := io.ReadAll(r.Body)
 		if len(raw) > 0 {
 			_ = json.Unmarshal(raw, &captured.body)

--- a/core/mcp/filter_cache.go
+++ b/core/mcp/filter_cache.go
@@ -118,18 +118,6 @@ func (c *filterCache) put(id *AgentIdentity, tools []Tool) {
 	c.mu.Unlock()
 }
 
-// clear drops every entry. Used by tests and by SetConfig when a
-// version bump alone isn't sufficient (defensive — bumpVersion already
-// makes old entries unreachable via keyFor).
-func (c *filterCache) clear() {
-	if c == nil {
-		return
-	}
-	c.mu.Lock()
-	c.entries = make(map[string]filterCacheEntry)
-	c.mu.Unlock()
-}
-
 // keyFor produces a stable cache key over everything that affects the
 // filter output: identity fields + config version. A nil identity
 // produces a deterministic "empty" key so the fail-closed result is

--- a/core/mcp/filter_test.go
+++ b/core/mcp/filter_test.go
@@ -65,9 +65,8 @@ func TestFilterForIdentity_RiskTierCeiling(t *testing.T) {
 	}
 	got := toolNames(FilterForIdentity(filterCatalog, id))
 	// medium can call low+medium. high, critical, and untagged (defaults high) are denied.
-	want := []string{"fs.read", "fs.write", "jobs.submit", "pii.read"}
 	// pii.read requires pii classification which this identity doesn't have.
-	want = []string{"fs.read", "fs.write", "jobs.submit"}
+	want := []string{"fs.read", "fs.write", "jobs.submit"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("risk-tier filter: want %v, got %v", want, got)
 	}

--- a/core/mcp/outbound/keys.go
+++ b/core/mcp/outbound/keys.go
@@ -120,7 +120,7 @@ func parsePrivateKey(raw string) (*ecdsa.PrivateKey, error) {
 			if err != nil {
 				return nil, fmt.Errorf("%w: %v", ErrInvalidPrivateKey, err)
 			}
-			if k.PublicKey.Curve != elliptic.P256() {
+			if k.Curve != elliptic.P256() {
 				return nil, fmt.Errorf("%w: not P-256", ErrInvalidPrivateKey)
 			}
 			return k, nil
@@ -130,7 +130,7 @@ func parsePrivateKey(raw string) (*ecdsa.PrivateKey, error) {
 				return nil, fmt.Errorf("%w: %v", ErrInvalidPrivateKey, err)
 			}
 			ec, ok := parsed.(*ecdsa.PrivateKey)
-			if !ok || ec.PublicKey.Curve != elliptic.P256() {
+			if !ok || ec.Curve != elliptic.P256() {
 				return nil, fmt.Errorf("%w: not P-256 ecdsa", ErrInvalidPrivateKey)
 			}
 			return ec, nil
@@ -146,13 +146,13 @@ func parsePrivateKey(raw string) (*ecdsa.PrivateKey, error) {
 		}
 	}
 	if k, err := x509.ParseECPrivateKey(data); err == nil {
-		if k.PublicKey.Curve != elliptic.P256() {
+		if k.Curve != elliptic.P256() {
 			return nil, fmt.Errorf("%w: not P-256", ErrInvalidPrivateKey)
 		}
 		return k, nil
 	}
 	if parsed, err := x509.ParsePKCS8PrivateKey(data); err == nil {
-		if ec, ok := parsed.(*ecdsa.PrivateKey); ok && ec.PublicKey.Curve == elliptic.P256() {
+		if ec, ok := parsed.(*ecdsa.PrivateKey); ok && ec.Curve == elliptic.P256() {
 			return ec, nil
 		}
 	}

--- a/core/mcp/outbound/signing.go
+++ b/core/mcp/outbound/signing.go
@@ -113,7 +113,7 @@ type Signer struct {
 // than P-256 is rejected at construction — a mistyped curve at boot
 // is far easier to debug than a verifier rejecting every request.
 func NewSigner(key *ecdsa.PrivateKey, keyID string) (*Signer, error) {
-	if key == nil || key.PublicKey.Curve != elliptic.P256() {
+	if key == nil || key.Curve != elliptic.P256() {
 		return nil, ErrInvalidPrivateKey
 	}
 	keyID = strings.TrimSpace(keyID)

--- a/core/mcp/outbound/signing_test.go
+++ b/core/mcp/outbound/signing_test.go
@@ -226,7 +226,7 @@ func TestLoadPrivateKeyFromEnv_Roundtrip(t *testing.T) {
 	if id != "test-k" {
 		t.Errorf("id = %q want test-k", id)
 	}
-	if got == nil || got.PublicKey.X.Cmp(priv.PublicKey.X) != 0 || got.PublicKey.Y.Cmp(priv.PublicKey.Y) != 0 {
+	if got == nil || got.X.Cmp(priv.X) != 0 || got.Y.Cmp(priv.Y) != 0 {
 		t.Error("loaded key differs from original")
 	}
 }

--- a/core/mcp/prompts.go
+++ b/core/mcp/prompts.go
@@ -494,7 +494,7 @@ func isValidApprovalsWindow(w string) bool {
 	if w == "" {
 		return false
 	}
-	if !(strings.HasSuffix(w, "h") || strings.HasSuffix(w, "d")) {
+	if !strings.HasSuffix(w, "h") && !strings.HasSuffix(w, "d") {
 		return false
 	}
 	num := w[:len(w)-1]

--- a/core/mcp/risktier_test.go
+++ b/core/mcp/risktier_test.go
@@ -29,7 +29,7 @@ func TestParseRiskTier(t *testing.T) {
 func TestRiskTierOrdering(t *testing.T) {
 	t.Parallel()
 
-	if !(RiskTierLow < RiskTierMedium && RiskTierMedium < RiskTierHigh && RiskTierHigh < RiskTierCritical) {
+	if RiskTierLow >= RiskTierMedium || RiskTierMedium >= RiskTierHigh || RiskTierHigh >= RiskTierCritical {
 		t.Fatalf("risk tier ordering broken")
 	}
 }

--- a/core/mcp/tool_description_test.go
+++ b/core/mcp/tool_description_test.go
@@ -105,7 +105,7 @@ func pickBestTool(prompt string, index map[string]string) string {
 
 func tokenize(s string) []string {
 	out := strings.FieldsFunc(s, func(r rune) bool {
-		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 	})
 	filtered := out[:0]
 	for _, t := range out {

--- a/core/mcp/tools/register.go
+++ b/core/mcp/tools/register.go
@@ -191,7 +191,7 @@ func (c *GatewayClient) FetchAgentIdentity(ctx context.Context, agentID string) 
 	if err != nil {
 		return nil, fmt.Errorf("fetch agent identity: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil
 	}

--- a/core/packs/signing/manifest.go
+++ b/core/packs/signing/manifest.go
@@ -236,7 +236,7 @@ func readRegularFile(p string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return io.ReadAll(f)
 }
 

--- a/core/policyshadow/store.go
+++ b/core/policyshadow/store.go
@@ -21,10 +21,13 @@ import (
 const ShadowScope configsvc.Scope = "policy_shadow"
 
 // maxPutAttempts is the retry budget for ETag-guarded Put/Delete calls.
-// Concurrent writes are rare (admin operations) so 3 attempts with
-// small jitter is plenty; more than that suggests a systemic
-// contention issue worth surfacing as an error.
-const maxPutAttempts = 3
+// Concurrent writes are rare (admin operations), but the ConcurrentPutSameBundle
+// torture test fires 8 racers at the same tenant+bundle — at 3 attempts the
+// last loser can exhaust its budget before converging. 10 comfortably absorbs
+// that worst case while still surfacing a real systemic contention issue
+// (it would take 10 concurrent admins writing to the exact same bundle to
+// saturate, which indicates a deeper operational problem worth the error).
+const maxPutAttempts = 10
 
 // Store persists shadow policies on top of configsvc. One configsvc
 // document holds all shadows for a tenant (Data keyed by bundle ID)
@@ -35,10 +38,6 @@ type Store struct {
 	// clock is overridden in tests so created_at/activated_at are
 	// deterministic. Defaults to time.Now().UTC().
 	clock func() time.Time
-
-	// rng drives retry jitter. Defaults to a lazily-seeded source so
-	// tests can inject a deterministic stream if they want.
-	rng *rand.Rand
 }
 
 // StoreOption configures a Store at construction.
@@ -58,8 +57,6 @@ func NewStore(cfg *configsvc.Service, opts ...StoreOption) *Store {
 	s := &Store{
 		cfg:   cfg,
 		clock: func() time.Time { return time.Now().UTC() },
-		// #nosec G404 -- jitter only, not a security-sensitive RNG.
-		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -290,9 +287,12 @@ func decodeShadow(raw any) (*ShadowPolicy, bool) {
 }
 
 // sleepWithJitter blocks for up to ~20ms then returns. Respects ctx
-// cancellation so shutdown is prompt.
+// cancellation so shutdown is prompt. Uses the package-level rand
+// source which is goroutine-safe; the custom *rand.Rand field this
+// replaced raced under concurrent Put calls on the race-detector CI.
 func (s *Store) sleepWithJitter(ctx context.Context) error {
-	d := time.Duration(s.rng.Intn(20)+5) * time.Millisecond
+	// #nosec G404 -- jitter only, not a security-sensitive RNG.
+	d := time.Duration(rand.Intn(20)+5) * time.Millisecond
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/core/policyshadow/types_test.go
+++ b/core/policyshadow/types_test.go
@@ -22,7 +22,7 @@ func TestNewShadowBundleID_FormatAndUniqueness(t *testing.T) {
 			t.Fatalf("id %q suffix len = %d, want %d", id, len(suffix), shadowBundleIDHexLen)
 		}
 		for _, r := range suffix {
-			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
 				t.Fatalf("id %q has non-hex char %q", id, r)
 			}
 		}

--- a/docs/api/openapi/cordum-api.yaml
+++ b/docs/api/openapi/cordum-api.yaml
@@ -77,142 +77,6 @@ security:
 - apiKey: []
 - bearerAuth: []
 paths:
-  # Agent Identity CRUD. The full request / response schemas ship in a
-  # follow-up OpenAPI authoring pass; for now each op carries a minimal
-  # shape that satisfies the conformance-fixture validator (which keys
-  # off operationId + status) without overspecifying the body contract.
-  /api/v1/agents:
-    get:
-      operationId: listAgents
-      summary: List agent identities
-      tags: [Agents]
-      responses:
-        '200':
-          description: Agents
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-    post:
-      operationId: createAgent
-      summary: Create an agent identity
-      tags: [Agents]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-      responses:
-        '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-  /api/v1/agents/{id}:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      operationId: getAgent
-      summary: Get an agent identity
-      tags: [Agents]
-      responses:
-        '200':
-          description: Agent
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-    put:
-      operationId: updateAgent
-      summary: Update an agent identity
-      tags: [Agents]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-      responses:
-        '200':
-          description: Updated
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-    delete:
-      operationId: deleteAgent
-      summary: Delete an agent identity
-      tags: [Agents]
-      responses:
-        '204':
-          description: Deleted
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-  /api/v1/agents/{id}/stats:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      operationId: getAgentStats
-      summary: Get per-agent statistics
-      tags: [Agents]
-      responses:
-        '200':
-          description: Stats
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
   /api/v1/auth/config:
     get:
       operationId: getAuthConfig
@@ -5172,6 +5036,108 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /api/v1/mcp/tools:
+    get:
+      operationId: listMcpTools
+      summary: List MCP tools visible to an agent or the full catalogue
+      description: >-
+        Returns the MCP tool catalogue. Without an `agent_id` query parameter,
+        returns the unfiltered admin view. With `agent_id`, returns the subset
+        of tools the identity is entitled to call after applying the MCP risk-
+        tier and data-classification filter.
+      tags:
+      - MCP
+      security:
+      - apiKey: []
+      - bearerAuth: []
+      parameters:
+      - $ref: '#/components/parameters/TenantID'
+      - name: agent_id
+        in: query
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Tool list for the requested scope
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/v1/agents/{id}/tools:
+    get:
+      operationId: getAgentToolVisibility
+      summary: List MCP tools visible to a specific agent identity
+      description: >-
+        Returns the subset of the MCP tool catalogue this agent identity can
+        call after applying the identity-aware filter (risk tier + data
+        classification). A revoked or suspended identity returns an empty
+        list with an advisory `note` field rather than failing.
+      tags:
+      - MCP
+      security:
+      - apiKey: []
+      - bearerAuth: []
+      parameters:
+      - $ref: '#/components/parameters/TenantID'
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Tool list filtered for the agent identity
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /api/v1/agents/{id}/denied-events:
+    get:
+      operationId: getAgentDeniedEvents
+      summary: Recent mcp_tool_denied events for an agent identity
+      description: >-
+        Returns up to 50 of the most recent `mcp_tool_denied` audit events
+        for the identity from the gateway's in-memory ring. Feeds the
+        dashboard "recent denials" panel without requiring a SIEM pipeline.
+      tags:
+      - MCP
+      security:
+      - apiKey: []
+      - bearerAuth: []
+      parameters:
+      - $ref: '#/components/parameters/TenantID'
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Most recent denial records for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/v1/evals/datasets/from-incidents:
     post:
       operationId: createEvalDatasetFromIncidents

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/create_agent.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/create_agent.py
@@ -17,9 +17,12 @@ from typing import Dict
 def _get_kwargs(
     *,
     body: CreateAgentBody,
+    x_tenant_id: str,
 
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
 
 
     
@@ -57,6 +60,12 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 403:
         response_403 = cast(Any, None)
         return response_403
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -76,11 +85,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateAgentBody,
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, CreateAgentResponse201]]:
     """ Create an agent identity
 
     Args:
+        x_tenant_id (str):
         body (CreateAgentBody):
 
     Raises:
@@ -94,6 +105,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -107,11 +119,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateAgentBody,
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, CreateAgentResponse201]]:
     """ Create an agent identity
 
     Args:
+        x_tenant_id (str):
         body (CreateAgentBody):
 
     Raises:
@@ -126,6 +140,7 @@ def sync(
     return sync_detailed(
         client=client,
 body=body,
+x_tenant_id=x_tenant_id,
 
     ).parsed
 
@@ -133,11 +148,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateAgentBody,
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, CreateAgentResponse201]]:
     """ Create an agent identity
 
     Args:
+        x_tenant_id (str):
         body (CreateAgentBody):
 
     Raises:
@@ -151,6 +168,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -164,11 +182,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateAgentBody,
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, CreateAgentResponse201]]:
     """ Create an agent identity
 
     Args:
+        x_tenant_id (str):
         body (CreateAgentBody):
 
     Raises:
@@ -183,5 +203,6 @@ async def asyncio(
     return (await asyncio_detailed(
         client=client,
 body=body,
+x_tenant_id=x_tenant_id,
 
     )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/delete_agent.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/delete_agent.py
@@ -12,9 +12,14 @@ from ... import errors
 
 def _get_kwargs(
     id: str,
+    *,
+    x_tenant_id: str,
 
 ) -> Dict[str, Any]:
-    
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
 
     
 
@@ -26,6 +31,7 @@ def _get_kwargs(
     }
 
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -37,6 +43,8 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 403:
         return None
     if response.status_code == 404:
+        return None
+    if response.status_code == 503:
         return None
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
@@ -57,12 +65,14 @@ def sync_detailed(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Response[Any]:
     """ Delete an agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -75,6 +85,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         id=id,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -89,12 +100,14 @@ async def asyncio_detailed(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Response[Any]:
     """ Delete an agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,6 +120,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         id=id,
+x_tenant_id=x_tenant_id,
 
     )
 

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/get_agent.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/get_agent.py
@@ -15,9 +15,14 @@ from typing import Dict
 
 def _get_kwargs(
     id: str,
+    *,
+    x_tenant_id: str,
 
 ) -> Dict[str, Any]:
-    
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
 
     
 
@@ -29,6 +34,7 @@ def _get_kwargs(
     }
 
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -48,6 +54,9 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 404:
         response_404 = cast(Any, None)
         return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -67,12 +76,14 @@ def sync_detailed(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, GetAgentResponse200]]:
-    """ Get an agent identity
+    """ Get one agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -85,6 +96,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         id=id,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -98,12 +110,14 @@ def sync(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, GetAgentResponse200]]:
-    """ Get an agent identity
+    """ Get one agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -117,6 +131,7 @@ def sync(
     return sync_detailed(
         id=id,
 client=client,
+x_tenant_id=x_tenant_id,
 
     ).parsed
 
@@ -124,12 +139,14 @@ async def asyncio_detailed(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, GetAgentResponse200]]:
-    """ Get an agent identity
+    """ Get one agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -142,6 +159,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         id=id,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -155,12 +173,14 @@ async def asyncio(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, GetAgentResponse200]]:
-    """ Get an agent identity
+    """ Get one agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -174,5 +194,6 @@ async def asyncio(
     return (await asyncio_detailed(
         id=id,
 client=client,
+x_tenant_id=x_tenant_id,
 
     )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/get_agent_stats.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/get_agent_stats.py
@@ -15,9 +15,14 @@ from typing import Dict
 
 def _get_kwargs(
     id: str,
+    *,
+    x_tenant_id: str,
 
 ) -> Dict[str, Any]:
-    
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
 
     
 
@@ -29,6 +34,7 @@ def _get_kwargs(
     }
 
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -48,6 +54,9 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 404:
         response_404 = cast(Any, None)
         return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -67,12 +76,14 @@ def sync_detailed(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, GetAgentStatsResponse200]]:
-    """ Get per-agent statistics
+    """ Get per-agent runtime statistics
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -85,6 +96,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         id=id,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -98,12 +110,14 @@ def sync(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, GetAgentStatsResponse200]]:
-    """ Get per-agent statistics
+    """ Get per-agent runtime statistics
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -117,6 +131,7 @@ def sync(
     return sync_detailed(
         id=id,
 client=client,
+x_tenant_id=x_tenant_id,
 
     ).parsed
 
@@ -124,12 +139,14 @@ async def asyncio_detailed(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, GetAgentStatsResponse200]]:
-    """ Get per-agent statistics
+    """ Get per-agent runtime statistics
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -142,6 +159,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         id=id,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -155,12 +173,14 @@ async def asyncio(
     id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, GetAgentStatsResponse200]]:
-    """ Get per-agent statistics
+    """ Get per-agent runtime statistics
 
     Args:
         id (str):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -174,5 +194,6 @@ async def asyncio(
     return (await asyncio_detailed(
         id=id,
 client=client,
+x_tenant_id=x_tenant_id,
 
     )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/issue_delegation_token.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/issue_delegation_token.py
@@ -1,0 +1,227 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.issue_delegation_token_body import IssueDelegationTokenBody
+from ...models.issue_delegation_token_response_201 import IssueDelegationTokenResponse201
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    body: IssueDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/agents/{id}/delegate".format(id=id,),
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, IssueDelegationTokenResponse201]]:
+    if response.status_code == 201:
+        response_201 = IssueDelegationTokenResponse201.from_dict(response.json())
+
+
+
+        return response_201
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 429:
+        response_429 = cast(Any, None)
+        return response_429
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, IssueDelegationTokenResponse201]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IssueDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, IssueDelegationTokenResponse201]]:
+    """ Issue a delegation token from one agent to another
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (IssueDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, IssueDelegationTokenResponse201]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IssueDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, IssueDelegationTokenResponse201]]:
+    """ Issue a delegation token from one agent to another
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (IssueDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, IssueDelegationTokenResponse201]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IssueDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, IssueDelegationTokenResponse201]]:
+    """ Issue a delegation token from one agent to another
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (IssueDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, IssueDelegationTokenResponse201]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: IssueDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, IssueDelegationTokenResponse201]]:
+    """ Issue a delegation token from one agent to another
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (IssueDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, IssueDelegationTokenResponse201]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/list_agents.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/list_agents.py
@@ -8,26 +8,54 @@ from ...types import Response, UNSET
 from ... import errors
 
 from ...models.list_agents_response_200 import ListAgentsResponse200
+from ...types import UNSET, Unset
 from typing import cast
 from typing import Dict
+from typing import Union
 
 
 
 def _get_kwargs(
-    
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    status: Union[Unset, str] = UNSET,
+    risk_tier: Union[Unset, str] = UNSET,
+    team: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
 ) -> Dict[str, Any]:
-    
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
 
     
 
-    
+    params: Dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    params["status"] = status
+
+    params["risk_tier"] = risk_tier
+
+    params["team"] = team
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
 
     _kwargs: Dict[str, Any] = {
         "method": "get",
         "url": "/api/v1/agents",
+        "params": params,
     }
 
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -44,6 +72,9 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 403:
         response_403 = cast(Any, None)
         return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -62,9 +93,23 @@ def _build_response(*, client: Union[AuthenticatedClient, Client], response: htt
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    status: Union[Unset, str] = UNSET,
+    risk_tier: Union[Unset, str] = UNSET,
+    team: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, ListAgentsResponse200]]:
     """ List agent identities
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        status (Union[Unset, str]):
+        risk_tier (Union[Unset, str]):
+        team (Union[Unset, str]):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -76,7 +121,13 @@ def sync_detailed(
 
 
     kwargs = _get_kwargs(
-        
+        cursor=cursor,
+limit=limit,
+status=status,
+risk_tier=risk_tier,
+team=team,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = client.get_httpx_client().request(
@@ -88,9 +139,23 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    status: Union[Unset, str] = UNSET,
+    risk_tier: Union[Unset, str] = UNSET,
+    team: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, ListAgentsResponse200]]:
     """ List agent identities
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        status (Union[Unset, str]):
+        risk_tier (Union[Unset, str]):
+        team (Union[Unset, str]):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,15 +168,35 @@ def sync(
 
     return sync_detailed(
         client=client,
+cursor=cursor,
+limit=limit,
+status=status,
+risk_tier=risk_tier,
+team=team,
+x_tenant_id=x_tenant_id,
 
     ).parsed
 
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    status: Union[Unset, str] = UNSET,
+    risk_tier: Union[Unset, str] = UNSET,
+    team: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, ListAgentsResponse200]]:
     """ List agent identities
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        status (Union[Unset, str]):
+        risk_tier (Union[Unset, str]):
+        team (Union[Unset, str]):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -123,7 +208,13 @@ async def asyncio_detailed(
 
 
     kwargs = _get_kwargs(
-        
+        cursor=cursor,
+limit=limit,
+status=status,
+risk_tier=risk_tier,
+team=team,
+x_tenant_id=x_tenant_id,
+
     )
 
     response = await client.get_async_httpx_client().request(
@@ -135,9 +226,23 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    status: Union[Unset, str] = UNSET,
+    risk_tier: Union[Unset, str] = UNSET,
+    team: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, ListAgentsResponse200]]:
     """ List agent identities
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        status (Union[Unset, str]):
+        risk_tier (Union[Unset, str]):
+        team (Union[Unset, str]):
+        x_tenant_id (str):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -150,5 +255,11 @@ async def asyncio(
 
     return (await asyncio_detailed(
         client=client,
+cursor=cursor,
+limit=limit,
+status=status,
+risk_tier=risk_tier,
+team=team,
+x_tenant_id=x_tenant_id,
 
     )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/list_delegations.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/list_delegations.py
@@ -1,0 +1,314 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.delegation_list_response import DelegationListResponse
+from ...models.list_delegations_status import ListDelegationsStatus
+from ...types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import Dict
+from typing import Union
+import datetime
+
+
+
+def _get_kwargs(
+    *,
+    status: Union[Unset, ListDelegationsStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    json_status: Union[Unset, str] = UNSET
+    if not isinstance(status, Unset):
+        json_status = status.value
+
+    params["status"] = json_status
+
+    params["scope"] = scope
+
+    json_before_expiry: Union[Unset, str] = UNSET
+    if not isinstance(before_expiry, Unset):
+        json_before_expiry = before_expiry.isoformat()
+    params["before_expiry"] = json_before_expiry
+
+    json_since_issued: Union[Unset, str] = UNSET
+    if not isinstance(since_issued, Unset):
+        json_since_issued = since_issued.isoformat()
+    params["since_issued"] = json_since_issued
+
+    json_until_issued: Union[Unset, str] = UNSET
+    if not isinstance(until_issued, Unset):
+        json_until_issued = until_issued.isoformat()
+    params["until_issued"] = json_until_issued
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/delegations",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, DelegationListResponse]]:
+    if response.status_code == 200:
+        response_200 = DelegationListResponse.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, DelegationListResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens for the current tenant
+
+    Args:
+        status (Union[Unset, ListDelegationsStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, DelegationListResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens for the current tenant
+
+    Args:
+        status (Union[Unset, ListDelegationsStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, DelegationListResponse]
+     """
+
+
+    return sync_detailed(
+        client=client,
+status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens for the current tenant
+
+    Args:
+        status (Union[Unset, ListDelegationsStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, DelegationListResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens for the current tenant
+
+    Args:
+        status (Union[Unset, ListDelegationsStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, DelegationListResponse]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/list_delegations_for_agent.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/list_delegations_for_agent.py
@@ -1,0 +1,327 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.delegation_list_response import DelegationListResponse
+from ...models.list_delegations_for_agent_status import ListDelegationsForAgentStatus
+from ...types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import Dict
+from typing import Union
+import datetime
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    status: Union[Unset, ListDelegationsForAgentStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    json_status: Union[Unset, str] = UNSET
+    if not isinstance(status, Unset):
+        json_status = status.value
+
+    params["status"] = json_status
+
+    params["scope"] = scope
+
+    json_before_expiry: Union[Unset, str] = UNSET
+    if not isinstance(before_expiry, Unset):
+        json_before_expiry = before_expiry.isoformat()
+    params["before_expiry"] = json_before_expiry
+
+    json_since_issued: Union[Unset, str] = UNSET
+    if not isinstance(since_issued, Unset):
+        json_since_issued = since_issued.isoformat()
+    params["since_issued"] = json_since_issued
+
+    json_until_issued: Union[Unset, str] = UNSET
+    if not isinstance(until_issued, Unset):
+        json_until_issued = until_issued.isoformat()
+    params["until_issued"] = json_until_issued
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/agents/{id}/delegations".format(id=id,),
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, DelegationListResponse]]:
+    if response.status_code == 200:
+        response_200 = DelegationListResponse.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, DelegationListResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsForAgentStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens issued by a specific agent
+
+    Args:
+        id (str):
+        status (Union[Unset, ListDelegationsForAgentStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, DelegationListResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsForAgentStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens issued by a specific agent
+
+    Args:
+        id (str):
+        status (Union[Unset, ListDelegationsForAgentStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, DelegationListResponse]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsForAgentStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens issued by a specific agent
+
+    Args:
+        id (str):
+        status (Union[Unset, ListDelegationsForAgentStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, DelegationListResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, ListDelegationsForAgentStatus] = UNSET,
+    scope: Union[Unset, str] = UNSET,
+    before_expiry: Union[Unset, datetime.datetime] = UNSET,
+    since_issued: Union[Unset, datetime.datetime] = UNSET,
+    until_issued: Union[Unset, datetime.datetime] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, DelegationListResponse]]:
+    """ List delegation tokens issued by a specific agent
+
+    Args:
+        id (str):
+        status (Union[Unset, ListDelegationsForAgentStatus]):
+        scope (Union[Unset, str]):
+        before_expiry (Union[Unset, datetime.datetime]):
+        since_issued (Union[Unset, datetime.datetime]):
+        until_issued (Union[Unset, datetime.datetime]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, DelegationListResponse]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+status=status,
+scope=scope,
+before_expiry=before_expiry,
+since_issued=since_issued,
+until_issued=until_issued,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/revoke_delegation_token.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/revoke_delegation_token.py
@@ -1,0 +1,220 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.revoke_delegation_token_body import RevokeDelegationTokenBody
+from ...models.revoke_delegation_token_response_200 import RevokeDelegationTokenResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    *,
+    body: RevokeDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/agents/revoke-delegation",
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, RevokeDelegationTokenResponse200]]:
+    if response.status_code == 200:
+        response_200 = RevokeDelegationTokenResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, RevokeDelegationTokenResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: RevokeDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, RevokeDelegationTokenResponse200]]:
+    """ Revoke a delegation token by JTI
+
+     By default revoking a token cascades to every downstream delegation that extended it. Set
+    `cascade=false` for narrow-scoped revocation.
+
+    Args:
+        x_tenant_id (str):
+        body (RevokeDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, RevokeDelegationTokenResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: RevokeDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, RevokeDelegationTokenResponse200]]:
+    """ Revoke a delegation token by JTI
+
+     By default revoking a token cascades to every downstream delegation that extended it. Set
+    `cascade=false` for narrow-scoped revocation.
+
+    Args:
+        x_tenant_id (str):
+        body (RevokeDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, RevokeDelegationTokenResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: RevokeDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, RevokeDelegationTokenResponse200]]:
+    """ Revoke a delegation token by JTI
+
+     By default revoking a token cascades to every downstream delegation that extended it. Set
+    `cascade=false` for narrow-scoped revocation.
+
+    Args:
+        x_tenant_id (str):
+        body (RevokeDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, RevokeDelegationTokenResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: RevokeDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, RevokeDelegationTokenResponse200]]:
+    """ Revoke a delegation token by JTI
+
+     By default revoking a token cascades to every downstream delegation that extended it. Set
+    `cascade=false` for narrow-scoped revocation.
+
+    Args:
+        x_tenant_id (str):
+        body (RevokeDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, RevokeDelegationTokenResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/update_agent.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/update_agent.py
@@ -18,9 +18,12 @@ def _get_kwargs(
     id: str,
     *,
     body: UpdateAgentBody,
+    x_tenant_id: str,
 
 ) -> Dict[str, Any]:
     headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
 
 
     
@@ -61,6 +64,9 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 404:
         response_404 = cast(Any, None)
         return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -81,12 +87,14 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateAgentBody,
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, UpdateAgentResponse200]]:
     """ Update an agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
         body (UpdateAgentBody):
 
     Raises:
@@ -101,6 +109,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         id=id,
 body=body,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -115,12 +124,14 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateAgentBody,
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, UpdateAgentResponse200]]:
     """ Update an agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
         body (UpdateAgentBody):
 
     Raises:
@@ -136,6 +147,7 @@ def sync(
         id=id,
 client=client,
 body=body,
+x_tenant_id=x_tenant_id,
 
     ).parsed
 
@@ -144,12 +156,14 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateAgentBody,
+    x_tenant_id: str,
 
 ) -> Response[Union[Any, UpdateAgentResponse200]]:
     """ Update an agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
         body (UpdateAgentBody):
 
     Raises:
@@ -164,6 +178,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         id=id,
 body=body,
+x_tenant_id=x_tenant_id,
 
     )
 
@@ -178,12 +193,14 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateAgentBody,
+    x_tenant_id: str,
 
 ) -> Optional[Union[Any, UpdateAgentResponse200]]:
     """ Update an agent identity
 
     Args:
         id (str):
+        x_tenant_id (str):
         body (UpdateAgentBody):
 
     Raises:
@@ -199,5 +216,6 @@ async def asyncio(
         id=id,
 client=client,
 body=body,
+x_tenant_id=x_tenant_id,
 
     )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/agents/verify_delegation_token.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/agents/verify_delegation_token.py
@@ -1,0 +1,202 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.verify_delegation_token_body import VerifyDelegationTokenBody
+from ...models.verify_delegation_token_response_200 import VerifyDelegationTokenResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    *,
+    body: VerifyDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/agents/verify-delegation",
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, VerifyDelegationTokenResponse200]]:
+    if response.status_code == 200:
+        response_200 = VerifyDelegationTokenResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, VerifyDelegationTokenResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: VerifyDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, VerifyDelegationTokenResponse200]]:
+    """ Verify a delegation token for an expected audience
+
+    Args:
+        x_tenant_id (str):
+        body (VerifyDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, VerifyDelegationTokenResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: VerifyDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, VerifyDelegationTokenResponse200]]:
+    """ Verify a delegation token for an expected audience
+
+    Args:
+        x_tenant_id (str):
+        body (VerifyDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, VerifyDelegationTokenResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: VerifyDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, VerifyDelegationTokenResponse200]]:
+    """ Verify a delegation token for an expected audience
+
+    Args:
+        x_tenant_id (str):
+        body (VerifyDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, VerifyDelegationTokenResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: VerifyDelegationTokenBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, VerifyDelegationTokenResponse200]]:
+    """ Verify a delegation token for an expected audience
+
+    Args:
+        x_tenant_id (str):
+        body (VerifyDelegationTokenBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, VerifyDelegationTokenResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/create_eval_dataset.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/create_eval_dataset.py
@@ -1,0 +1,211 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.create_eval_dataset_body import CreateEvalDatasetBody
+from ...models.create_eval_dataset_response_201 import CreateEvalDatasetResponse201
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    *,
+    body: CreateEvalDatasetBody,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/evals/datasets",
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CreateEvalDatasetResponse201]]:
+    if response.status_code == 201:
+        response_201 = CreateEvalDatasetResponse201.from_dict(response.json())
+
+
+
+        return response_201
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 413:
+        response_413 = cast(Any, None)
+        return response_413
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CreateEvalDatasetResponse201]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, CreateEvalDatasetResponse201]]:
+    """ Create a curated eval dataset
+
+    Args:
+        x_tenant_id (str):
+        body (CreateEvalDatasetBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateEvalDatasetResponse201]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, CreateEvalDatasetResponse201]]:
+    """ Create a curated eval dataset
+
+    Args:
+        x_tenant_id (str):
+        body (CreateEvalDatasetBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateEvalDatasetResponse201]
+     """
+
+
+    return sync_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, CreateEvalDatasetResponse201]]:
+    """ Create a curated eval dataset
+
+    Args:
+        x_tenant_id (str):
+        body (CreateEvalDatasetBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateEvalDatasetResponse201]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, CreateEvalDatasetResponse201]]:
+    """ Create a curated eval dataset
+
+    Args:
+        x_tenant_id (str):
+        body (CreateEvalDatasetBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateEvalDatasetResponse201]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/create_eval_dataset_from_incidents.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/create_eval_dataset_from_incidents.py
@@ -1,0 +1,243 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.create_eval_dataset_from_incidents_body import CreateEvalDatasetFromIncidentsBody
+from ...models.create_eval_dataset_from_incidents_response_200 import CreateEvalDatasetFromIncidentsResponse200
+from ...models.create_eval_dataset_from_incidents_response_201 import CreateEvalDatasetFromIncidentsResponse201
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+
+
+def _get_kwargs(
+    *,
+    body: CreateEvalDatasetFromIncidentsBody,
+    dry_run: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["dry_run"] = dry_run
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/evals/datasets/from-incidents",
+        "params": params,
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]:
+    if response.status_code == 200:
+        response_200 = CreateEvalDatasetFromIncidentsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 201:
+        response_201 = CreateEvalDatasetFromIncidentsResponse201.from_dict(response.json())
+
+
+
+        return response_201
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 429:
+        response_429 = cast(Any, None)
+        return response_429
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetFromIncidentsBody,
+    dry_run: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]:
+    """ Derive an eval dataset from governance incidents
+
+    Args:
+        dry_run (Union[Unset, bool]):
+        x_tenant_id (str):
+        body (CreateEvalDatasetFromIncidentsBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+dry_run=dry_run,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetFromIncidentsBody,
+    dry_run: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]:
+    """ Derive an eval dataset from governance incidents
+
+    Args:
+        dry_run (Union[Unset, bool]):
+        x_tenant_id (str):
+        body (CreateEvalDatasetFromIncidentsBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]
+     """
+
+
+    return sync_detailed(
+        client=client,
+body=body,
+dry_run=dry_run,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetFromIncidentsBody,
+    dry_run: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]:
+    """ Derive an eval dataset from governance incidents
+
+    Args:
+        dry_run (Union[Unset, bool]):
+        x_tenant_id (str):
+        body (CreateEvalDatasetFromIncidentsBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+dry_run=dry_run,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetFromIncidentsBody,
+    dry_run: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]]:
+    """ Derive an eval dataset from governance incidents
+
+    Args:
+        dry_run (Union[Unset, bool]):
+        x_tenant_id (str):
+        body (CreateEvalDatasetFromIncidentsBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateEvalDatasetFromIncidentsResponse200, CreateEvalDatasetFromIncidentsResponse201]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+dry_run=dry_run,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/create_eval_dataset_successor.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/create_eval_dataset_successor.py
@@ -1,0 +1,227 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.create_eval_dataset_successor_body import CreateEvalDatasetSuccessorBody
+from ...models.create_eval_dataset_successor_response_200 import CreateEvalDatasetSuccessorResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    body: CreateEvalDatasetSuccessorBody,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "put",
+        "url": "/api/v1/evals/datasets/{id}".format(id=id,),
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CreateEvalDatasetSuccessorResponse200]]:
+    if response.status_code == 200:
+        response_200 = CreateEvalDatasetSuccessorResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 413:
+        response_413 = cast(Any, None)
+        return response_413
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CreateEvalDatasetSuccessorResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetSuccessorBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, CreateEvalDatasetSuccessorResponse200]]:
+    """ Create a successor version from an existing dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (CreateEvalDatasetSuccessorBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateEvalDatasetSuccessorResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetSuccessorBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, CreateEvalDatasetSuccessorResponse200]]:
+    """ Create a successor version from an existing dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (CreateEvalDatasetSuccessorBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateEvalDatasetSuccessorResponse200]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetSuccessorBody,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, CreateEvalDatasetSuccessorResponse200]]:
+    """ Create a successor version from an existing dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (CreateEvalDatasetSuccessorBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CreateEvalDatasetSuccessorResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CreateEvalDatasetSuccessorBody,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, CreateEvalDatasetSuccessorResponse200]]:
+    """ Create a successor version from an existing dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (CreateEvalDatasetSuccessorBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CreateEvalDatasetSuccessorResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/delete_eval_dataset.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/delete_eval_dataset.py
@@ -1,0 +1,150 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...types import UNSET, Unset
+from typing import Union
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    force: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["force"] = force
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v1/evals/datasets/{id}".format(id=id,),
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+    if response.status_code == 204:
+        return None
+    if response.status_code == 400:
+        return None
+    if response.status_code == 401:
+        return None
+    if response.status_code == 403:
+        return None
+    if response.status_code == 404:
+        return None
+    if response.status_code == 503:
+        return None
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    force: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Any]:
+    """ Delete an eval dataset
+
+    Args:
+        id (str):
+        force (Union[Unset, bool]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+force=force,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    force: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Any]:
+    """ Delete an eval dataset
+
+    Args:
+        id (str):
+        force (Union[Unset, bool]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+force=force,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/delete_eval_run.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/delete_eval_run.py
@@ -1,0 +1,150 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...types import UNSET, Unset
+from typing import Union
+
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    force: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["force"] = force
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "delete",
+        "url": "/api/v1/evals/runs/{run_id}".format(run_id=run_id,),
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+    if response.status_code == 204:
+        return None
+    if response.status_code == 400:
+        return None
+    if response.status_code == 401:
+        return None
+    if response.status_code == 403:
+        return None
+    if response.status_code == 404:
+        return None
+    if response.status_code == 503:
+        return None
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    force: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Any]:
+    """ Delete a historical eval run
+
+    Args:
+        run_id (str):
+        force (Union[Unset, bool]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+     """
+
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+force=force,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    force: Union[Unset, bool] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Any]:
+    """ Delete a historical eval run
+
+    Args:
+        run_id (str):
+        force (Union[Unset, bool]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+     """
+
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+force=force,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/get_eval_dataset.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/get_eval_dataset.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.get_eval_dataset_response_200 import GetEvalDatasetResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/evals/datasets/{id}".format(id=id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, GetEvalDatasetResponse200]]:
+    if response.status_code == 200:
+        response_200 = GetEvalDatasetResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, GetEvalDatasetResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetEvalDatasetResponse200]]:
+    """ Get one eval dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetEvalDatasetResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetEvalDatasetResponse200]]:
+    """ Get one eval dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetEvalDatasetResponse200]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetEvalDatasetResponse200]]:
+    """ Get one eval dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetEvalDatasetResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetEvalDatasetResponse200]]:
+    """ Get one eval dataset
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetEvalDatasetResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/get_eval_dataset_by_name_version.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/get_eval_dataset_by_name_version.py
@@ -1,0 +1,215 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.get_eval_dataset_by_name_version_response_200 import GetEvalDatasetByNameVersionResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    name: str,
+    version: int,
+    *,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/evals/datasets/by-name/{name}/versions/{version}".format(name=name,version=version,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, GetEvalDatasetByNameVersionResponse200]]:
+    if response.status_code == 200:
+        response_200 = GetEvalDatasetByNameVersionResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, GetEvalDatasetByNameVersionResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    version: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetEvalDatasetByNameVersionResponse200]]:
+    """ Get a dataset by name and version
+
+    Args:
+        name (str):
+        version (int):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetEvalDatasetByNameVersionResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        name=name,
+version=version,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    name: str,
+    version: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetEvalDatasetByNameVersionResponse200]]:
+    """ Get a dataset by name and version
+
+    Args:
+        name (str):
+        version (int):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetEvalDatasetByNameVersionResponse200]
+     """
+
+
+    return sync_detailed(
+        name=name,
+version=version,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    name: str,
+    version: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetEvalDatasetByNameVersionResponse200]]:
+    """ Get a dataset by name and version
+
+    Args:
+        name (str):
+        version (int):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetEvalDatasetByNameVersionResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        name=name,
+version=version,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    name: str,
+    version: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetEvalDatasetByNameVersionResponse200]]:
+    """ Get a dataset by name and version
+
+    Args:
+        name (str):
+        version (int):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetEvalDatasetByNameVersionResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        name=name,
+version=version,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/get_eval_run.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/get_eval_run.py
@@ -1,0 +1,206 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.eval_run_accepted_response import EvalRunAcceptedResponse
+from ...models.eval_run_result import EvalRunResult
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/evals/runs/{run_id}".format(run_id=run_id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    if response.status_code == 200:
+        response_200 = EvalRunResult.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 202:
+        response_202 = EvalRunAcceptedResponse.from_dict(response.json())
+
+
+
+        return response_202
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Get one eval run
+
+    Args:
+        run_id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]
+     """
+
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    run_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Get one eval run
+
+    Args:
+        run_id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EvalRunAcceptedResponse, EvalRunResult]
+     """
+
+
+    return sync_detailed(
+        run_id=run_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Get one eval run
+
+    Args:
+        run_id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]
+     """
+
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Get one eval run
+
+    Args:
+        run_id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EvalRunAcceptedResponse, EvalRunResult]
+     """
+
+
+    return (await asyncio_detailed(
+        run_id=run_id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/list_eval_dataset_versions.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/list_eval_dataset_versions.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.list_eval_dataset_versions_response_200 import ListEvalDatasetVersionsResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    name: str,
+    *,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/evals/datasets/by-name/{name}".format(name=name,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ListEvalDatasetVersionsResponse200]]:
+    if response.status_code == 200:
+        response_200 = ListEvalDatasetVersionsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ListEvalDatasetVersionsResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListEvalDatasetVersionsResponse200]]:
+    """ List versions for an eval dataset family
+
+    Args:
+        name (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListEvalDatasetVersionsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        name=name,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListEvalDatasetVersionsResponse200]]:
+    """ List versions for an eval dataset family
+
+    Args:
+        name (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListEvalDatasetVersionsResponse200]
+     """
+
+
+    return sync_detailed(
+        name=name,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListEvalDatasetVersionsResponse200]]:
+    """ List versions for an eval dataset family
+
+    Args:
+        name (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListEvalDatasetVersionsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        name=name,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListEvalDatasetVersionsResponse200]]:
+    """ List versions for an eval dataset family
+
+    Args:
+        name (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListEvalDatasetVersionsResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        name=name,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/list_eval_datasets.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/list_eval_datasets.py
@@ -1,0 +1,268 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.list_eval_datasets_response_200 import ListEvalDatasetsResponse200
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+
+
+def _get_kwargs(
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    name_prefix: Union[Unset, str] = UNSET,
+    created_after: Union[Unset, str] = UNSET,
+    created_before: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    params["name_prefix"] = name_prefix
+
+    params["created_after"] = created_after
+
+    params["created_before"] = created_before
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/evals/datasets",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ListEvalDatasetsResponse200]]:
+    if response.status_code == 200:
+        response_200 = ListEvalDatasetsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ListEvalDatasetsResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    name_prefix: Union[Unset, str] = UNSET,
+    created_after: Union[Unset, str] = UNSET,
+    created_before: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListEvalDatasetsResponse200]]:
+    """ List eval datasets
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        name_prefix (Union[Unset, str]):
+        created_after (Union[Unset, str]):
+        created_before (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListEvalDatasetsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        cursor=cursor,
+limit=limit,
+name_prefix=name_prefix,
+created_after=created_after,
+created_before=created_before,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    name_prefix: Union[Unset, str] = UNSET,
+    created_after: Union[Unset, str] = UNSET,
+    created_before: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListEvalDatasetsResponse200]]:
+    """ List eval datasets
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        name_prefix (Union[Unset, str]):
+        created_after (Union[Unset, str]):
+        created_before (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListEvalDatasetsResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+cursor=cursor,
+limit=limit,
+name_prefix=name_prefix,
+created_after=created_after,
+created_before=created_before,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    name_prefix: Union[Unset, str] = UNSET,
+    created_after: Union[Unset, str] = UNSET,
+    created_before: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListEvalDatasetsResponse200]]:
+    """ List eval datasets
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        name_prefix (Union[Unset, str]):
+        created_after (Union[Unset, str]):
+        created_before (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListEvalDatasetsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        cursor=cursor,
+limit=limit,
+name_prefix=name_prefix,
+created_after=created_after,
+created_before=created_before,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    name_prefix: Union[Unset, str] = UNSET,
+    created_after: Union[Unset, str] = UNSET,
+    created_before: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListEvalDatasetsResponse200]]:
+    """ List eval datasets
+
+    Args:
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        name_prefix (Union[Unset, str]):
+        created_after (Union[Unset, str]):
+        created_before (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListEvalDatasetsResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+cursor=cursor,
+limit=limit,
+name_prefix=name_prefix,
+created_after=created_after,
+created_before=created_before,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/list_eval_runs.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/list_eval_runs.py
@@ -1,0 +1,307 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.eval_runs_response import EvalRunsResponse
+from ...types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import Dict
+from typing import Union
+import datetime
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    has_regression: Union[Unset, bool] = UNSET,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    min_score: Union[Unset, float] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+    params["has_regression"] = has_regression
+
+    json_since: Union[Unset, str] = UNSET
+    if not isinstance(since, Unset):
+        json_since = since.isoformat()
+    params["since"] = json_since
+
+    json_until: Union[Unset, str] = UNSET
+    if not isinstance(until, Unset):
+        json_until = until.isoformat()
+    params["until"] = json_until
+
+    params["min_score"] = min_score
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/evals/datasets/{id}/runs".format(id=id,),
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, EvalRunsResponse]]:
+    if response.status_code == 200:
+        response_200 = EvalRunsResponse.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, EvalRunsResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    has_regression: Union[Unset, bool] = UNSET,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    min_score: Union[Unset, float] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EvalRunsResponse]]:
+    """ List historical runs for one eval dataset
+
+    Args:
+        id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        has_regression (Union[Unset, bool]):
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        min_score (Union[Unset, float]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EvalRunsResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+cursor=cursor,
+limit=limit,
+has_regression=has_regression,
+since=since,
+until=until,
+min_score=min_score,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    has_regression: Union[Unset, bool] = UNSET,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    min_score: Union[Unset, float] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EvalRunsResponse]]:
+    """ List historical runs for one eval dataset
+
+    Args:
+        id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        has_regression (Union[Unset, bool]):
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        min_score (Union[Unset, float]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EvalRunsResponse]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+cursor=cursor,
+limit=limit,
+has_regression=has_regression,
+since=since,
+until=until,
+min_score=min_score,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    has_regression: Union[Unset, bool] = UNSET,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    min_score: Union[Unset, float] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EvalRunsResponse]]:
+    """ List historical runs for one eval dataset
+
+    Args:
+        id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        has_regression (Union[Unset, bool]):
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        min_score (Union[Unset, float]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EvalRunsResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+cursor=cursor,
+limit=limit,
+has_regression=has_regression,
+since=since,
+until=until,
+min_score=min_score,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    has_regression: Union[Unset, bool] = UNSET,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    min_score: Union[Unset, float] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EvalRunsResponse]]:
+    """ List historical runs for one eval dataset
+
+    Args:
+        id (str):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        has_regression (Union[Unset, bool]):
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        min_score (Union[Unset, float]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EvalRunsResponse]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+cursor=cursor,
+limit=limit,
+has_regression=has_regression,
+since=since,
+until=until,
+min_score=min_score,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/evals/run_eval_dataset.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/evals/run_eval_dataset.py
@@ -1,0 +1,246 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.eval_run_accepted_response import EvalRunAcceptedResponse
+from ...models.eval_run_request import EvalRunRequest
+from ...models.eval_run_result import EvalRunResult
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    body: EvalRunRequest,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/evals/datasets/{id}/run".format(id=id,),
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    if response.status_code == 200:
+        response_200 = EvalRunResult.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 202:
+        response_202 = EvalRunAcceptedResponse.from_dict(response.json())
+
+
+
+        return response_202
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 429:
+        response_429 = cast(Any, None)
+        return response_429
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EvalRunRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Run an eval dataset against the active or candidate policy
+
+     Synchronous for ≤500 entries (returns 200 with full result), asynchronous for larger datasets
+    (returns 202 with run_id; poll GET /evals/runs/{runId}).
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (EvalRunRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EvalRunRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Run an eval dataset against the active or candidate policy
+
+     Synchronous for ≤500 entries (returns 200 with full result), asynchronous for larger datasets
+    (returns 202 with run_id; poll GET /evals/runs/{runId}).
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (EvalRunRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EvalRunAcceptedResponse, EvalRunResult]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EvalRunRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Run an eval dataset against the active or candidate policy
+
+     Synchronous for ≤500 entries (returns 200 with full result), asynchronous for larger datasets
+    (returns 202 with run_id; poll GET /evals/runs/{runId}).
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (EvalRunRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EvalRunRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EvalRunAcceptedResponse, EvalRunResult]]:
+    """ Run an eval dataset against the active or candidate policy
+
+     Synchronous for ≤500 entries (returns 200 with full result), asynchronous for larger datasets
+    (returns 202 with run_id; poll GET /evals/runs/{runId}).
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (EvalRunRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EvalRunAcceptedResponse, EvalRunResult]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/governance/get_approval_analytics.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/governance/get_approval_analytics.py
@@ -1,0 +1,334 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.approval_analytics_response import ApprovalAnalyticsResponse
+from ...models.error import Error
+from ...models.get_approval_analytics_group_by import GetApprovalAnalyticsGroupBy
+from ...models.get_approval_analytics_window import GetApprovalAnalyticsWindow
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+
+
+def _get_kwargs(
+    *,
+    window: Union[Unset, GetApprovalAnalyticsWindow] = UNSET,
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    group_by: Union[Unset, GetApprovalAnalyticsGroupBy] = GetApprovalAnalyticsGroupBy.OVERALL,
+    limit: Union[Unset, int] = 10,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    json_window: Union[Unset, str] = UNSET
+    if not isinstance(window, Unset):
+        json_window = window.value
+
+    params["window"] = json_window
+
+    params["since"] = since
+
+    params["until"] = until
+
+    json_group_by: Union[Unset, str] = UNSET
+    if not isinstance(group_by, Unset):
+        json_group_by = group_by.value
+
+    params["group_by"] = json_group_by
+
+    params["limit"] = limit
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/governance/approvals/analytics",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ApprovalAnalyticsResponse, Error]]:
+    if response.status_code == 200:
+        response_200 = ApprovalAnalyticsResponse.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = Error.from_dict(response.json())
+
+
+
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ApprovalAnalyticsResponse, Error]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    window: Union[Unset, GetApprovalAnalyticsWindow] = UNSET,
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    group_by: Union[Unset, GetApprovalAnalyticsGroupBy] = GetApprovalAnalyticsGroupBy.OVERALL,
+    limit: Union[Unset, int] = 10,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ApprovalAnalyticsResponse, Error]]:
+    """ Approval analytics (time-to-approve, auto vs manual, bottlenecks)
+
+     Aggregated approval KPIs for the requested window. Consumes the
+    Policy Decision Log as the source of truth, pairs each
+    require_approval verdict with its ApprovalRecord, and computes
+    per-group breakdowns sorted with the slowest approvers first so
+    bottlenecks surface at the top.
+
+    Requires the `governance.read` permission.
+
+    Responses are memoised per `(tenant, window, group_by, limit)`
+    tuple for 30 seconds so dashboards can poll without thrashing
+    the decision-log index.
+
+    Args:
+        window (Union[Unset, GetApprovalAnalyticsWindow]):
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        group_by (Union[Unset, GetApprovalAnalyticsGroupBy]):  Default:
+            GetApprovalAnalyticsGroupBy.OVERALL.
+        limit (Union[Unset, int]):  Default: 10.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ApprovalAnalyticsResponse, Error]]
+     """
+
+
+    kwargs = _get_kwargs(
+        window=window,
+since=since,
+until=until,
+group_by=group_by,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    window: Union[Unset, GetApprovalAnalyticsWindow] = UNSET,
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    group_by: Union[Unset, GetApprovalAnalyticsGroupBy] = GetApprovalAnalyticsGroupBy.OVERALL,
+    limit: Union[Unset, int] = 10,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ApprovalAnalyticsResponse, Error]]:
+    """ Approval analytics (time-to-approve, auto vs manual, bottlenecks)
+
+     Aggregated approval KPIs for the requested window. Consumes the
+    Policy Decision Log as the source of truth, pairs each
+    require_approval verdict with its ApprovalRecord, and computes
+    per-group breakdowns sorted with the slowest approvers first so
+    bottlenecks surface at the top.
+
+    Requires the `governance.read` permission.
+
+    Responses are memoised per `(tenant, window, group_by, limit)`
+    tuple for 30 seconds so dashboards can poll without thrashing
+    the decision-log index.
+
+    Args:
+        window (Union[Unset, GetApprovalAnalyticsWindow]):
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        group_by (Union[Unset, GetApprovalAnalyticsGroupBy]):  Default:
+            GetApprovalAnalyticsGroupBy.OVERALL.
+        limit (Union[Unset, int]):  Default: 10.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ApprovalAnalyticsResponse, Error]
+     """
+
+
+    return sync_detailed(
+        client=client,
+window=window,
+since=since,
+until=until,
+group_by=group_by,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    window: Union[Unset, GetApprovalAnalyticsWindow] = UNSET,
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    group_by: Union[Unset, GetApprovalAnalyticsGroupBy] = GetApprovalAnalyticsGroupBy.OVERALL,
+    limit: Union[Unset, int] = 10,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ApprovalAnalyticsResponse, Error]]:
+    """ Approval analytics (time-to-approve, auto vs manual, bottlenecks)
+
+     Aggregated approval KPIs for the requested window. Consumes the
+    Policy Decision Log as the source of truth, pairs each
+    require_approval verdict with its ApprovalRecord, and computes
+    per-group breakdowns sorted with the slowest approvers first so
+    bottlenecks surface at the top.
+
+    Requires the `governance.read` permission.
+
+    Responses are memoised per `(tenant, window, group_by, limit)`
+    tuple for 30 seconds so dashboards can poll without thrashing
+    the decision-log index.
+
+    Args:
+        window (Union[Unset, GetApprovalAnalyticsWindow]):
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        group_by (Union[Unset, GetApprovalAnalyticsGroupBy]):  Default:
+            GetApprovalAnalyticsGroupBy.OVERALL.
+        limit (Union[Unset, int]):  Default: 10.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ApprovalAnalyticsResponse, Error]]
+     """
+
+
+    kwargs = _get_kwargs(
+        window=window,
+since=since,
+until=until,
+group_by=group_by,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    window: Union[Unset, GetApprovalAnalyticsWindow] = UNSET,
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    group_by: Union[Unset, GetApprovalAnalyticsGroupBy] = GetApprovalAnalyticsGroupBy.OVERALL,
+    limit: Union[Unset, int] = 10,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ApprovalAnalyticsResponse, Error]]:
+    """ Approval analytics (time-to-approve, auto vs manual, bottlenecks)
+
+     Aggregated approval KPIs for the requested window. Consumes the
+    Policy Decision Log as the source of truth, pairs each
+    require_approval verdict with its ApprovalRecord, and computes
+    per-group breakdowns sorted with the slowest approvers first so
+    bottlenecks surface at the top.
+
+    Requires the `governance.read` permission.
+
+    Responses are memoised per `(tenant, window, group_by, limit)`
+    tuple for 30 seconds so dashboards can poll without thrashing
+    the decision-log index.
+
+    Args:
+        window (Union[Unset, GetApprovalAnalyticsWindow]):
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        group_by (Union[Unset, GetApprovalAnalyticsGroupBy]):  Default:
+            GetApprovalAnalyticsGroupBy.OVERALL.
+        limit (Union[Unset, int]):  Default: 10.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ApprovalAnalyticsResponse, Error]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+window=window,
+since=since,
+until=until,
+group_by=group_by,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/governance/list_governance_decisions.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/governance/list_governance_decisions.py
@@ -1,0 +1,313 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.list_governance_decisions_response_200 import ListGovernanceDecisionsResponse200
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+
+
+def _get_kwargs(
+    *,
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    topic: Union[Unset, str] = UNSET,
+    rule_id: Union[Unset, str] = UNSET,
+    verdict: Union[Unset, str] = UNSET,
+    agent_id: Union[Unset, str] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["since"] = since
+
+    params["until"] = until
+
+    params["topic"] = topic
+
+    params["rule_id"] = rule_id
+
+    params["verdict"] = verdict
+
+    params["agent_id"] = agent_id
+
+    params["cursor"] = cursor
+
+    params["limit"] = limit
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/governance/decisions",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ListGovernanceDecisionsResponse200]]:
+    if response.status_code == 200:
+        response_200 = ListGovernanceDecisionsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ListGovernanceDecisionsResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    topic: Union[Unset, str] = UNSET,
+    rule_id: Union[Unset, str] = UNSET,
+    verdict: Union[Unset, str] = UNSET,
+    agent_id: Union[Unset, str] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListGovernanceDecisionsResponse200]]:
+    """ Query the governance decision log
+
+    Args:
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        topic (Union[Unset, str]):
+        rule_id (Union[Unset, str]):
+        verdict (Union[Unset, str]):
+        agent_id (Union[Unset, str]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListGovernanceDecisionsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        since=since,
+until=until,
+topic=topic,
+rule_id=rule_id,
+verdict=verdict,
+agent_id=agent_id,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    topic: Union[Unset, str] = UNSET,
+    rule_id: Union[Unset, str] = UNSET,
+    verdict: Union[Unset, str] = UNSET,
+    agent_id: Union[Unset, str] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListGovernanceDecisionsResponse200]]:
+    """ Query the governance decision log
+
+    Args:
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        topic (Union[Unset, str]):
+        rule_id (Union[Unset, str]):
+        verdict (Union[Unset, str]):
+        agent_id (Union[Unset, str]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListGovernanceDecisionsResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+since=since,
+until=until,
+topic=topic,
+rule_id=rule_id,
+verdict=verdict,
+agent_id=agent_id,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    topic: Union[Unset, str] = UNSET,
+    rule_id: Union[Unset, str] = UNSET,
+    verdict: Union[Unset, str] = UNSET,
+    agent_id: Union[Unset, str] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListGovernanceDecisionsResponse200]]:
+    """ Query the governance decision log
+
+    Args:
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        topic (Union[Unset, str]):
+        rule_id (Union[Unset, str]):
+        verdict (Union[Unset, str]):
+        agent_id (Union[Unset, str]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListGovernanceDecisionsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        since=since,
+until=until,
+topic=topic,
+rule_id=rule_id,
+verdict=verdict,
+agent_id=agent_id,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    since: Union[Unset, str] = UNSET,
+    until: Union[Unset, str] = UNSET,
+    topic: Union[Unset, str] = UNSET,
+    rule_id: Union[Unset, str] = UNSET,
+    verdict: Union[Unset, str] = UNSET,
+    agent_id: Union[Unset, str] = UNSET,
+    cursor: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListGovernanceDecisionsResponse200]]:
+    """ Query the governance decision log
+
+    Args:
+        since (Union[Unset, str]):
+        until (Union[Unset, str]):
+        topic (Union[Unset, str]):
+        rule_id (Union[Unset, str]):
+        verdict (Union[Unset, str]):
+        agent_id (Union[Unset, str]):
+        cursor (Union[Unset, str]):
+        limit (Union[Unset, int]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListGovernanceDecisionsResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+since=since,
+until=until,
+topic=topic,
+rule_id=rule_id,
+verdict=verdict,
+agent_id=agent_id,
+cursor=cursor,
+limit=limit,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/approve_mcp_approval.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/approve_mcp_approval.py
@@ -1,0 +1,221 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.approval_decision_request import ApprovalDecisionRequest
+from ...models.approve_mcp_approval_response_200 import ApproveMcpApprovalResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/mcp/approvals/{id}/approve".format(id=id,),
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ApproveMcpApprovalResponse200]]:
+    if response.status_code == 200:
+        response_200 = ApproveMcpApprovalResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ApproveMcpApprovalResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ApproveMcpApprovalResponse200]]:
+    """ Approve an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ApproveMcpApprovalResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ApproveMcpApprovalResponse200]]:
+    """ Approve an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ApproveMcpApprovalResponse200]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ApproveMcpApprovalResponse200]]:
+    """ Approve an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ApproveMcpApprovalResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ApproveMcpApprovalResponse200]]:
+    """ Approve an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ApproveMcpApprovalResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/get_agent_denied_events.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/get_agent_denied_events.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.get_agent_denied_events_response_200 import GetAgentDeniedEventsResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/agents/{id}/denied-events".format(id=id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, GetAgentDeniedEventsResponse200]]:
+    if response.status_code == 200:
+        response_200 = GetAgentDeniedEventsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, GetAgentDeniedEventsResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetAgentDeniedEventsResponse200]]:
+    r""" Recent mcp_tool_denied events for an agent identity
+
+     Returns up to 50 of the most recent `mcp_tool_denied` audit events for the identity from the
+    gateway's in-memory ring. Feeds the dashboard \"recent denials\" panel without requiring a SIEM
+    pipeline.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetAgentDeniedEventsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetAgentDeniedEventsResponse200]]:
+    r""" Recent mcp_tool_denied events for an agent identity
+
+     Returns up to 50 of the most recent `mcp_tool_denied` audit events for the identity from the
+    gateway's in-memory ring. Feeds the dashboard \"recent denials\" panel without requiring a SIEM
+    pipeline.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetAgentDeniedEventsResponse200]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetAgentDeniedEventsResponse200]]:
+    r""" Recent mcp_tool_denied events for an agent identity
+
+     Returns up to 50 of the most recent `mcp_tool_denied` audit events for the identity from the
+    gateway's in-memory ring. Feeds the dashboard \"recent denials\" panel without requiring a SIEM
+    pipeline.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetAgentDeniedEventsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetAgentDeniedEventsResponse200]]:
+    r""" Recent mcp_tool_denied events for an agent identity
+
+     Returns up to 50 of the most recent `mcp_tool_denied` audit events for the identity from the
+    gateway's in-memory ring. Feeds the dashboard \"recent denials\" panel without requiring a SIEM
+    pipeline.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetAgentDeniedEventsResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/get_agent_tool_visibility.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/get_agent_tool_visibility.py
@@ -1,0 +1,215 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.get_agent_tool_visibility_response_200 import GetAgentToolVisibilityResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/agents/{id}/tools".format(id=id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, GetAgentToolVisibilityResponse200]]:
+    if response.status_code == 200:
+        response_200 = GetAgentToolVisibilityResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, GetAgentToolVisibilityResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetAgentToolVisibilityResponse200]]:
+    """ List MCP tools visible to a specific agent identity
+
+     Returns the subset of the MCP tool catalogue this agent identity can call after applying the
+    identity-aware filter (risk tier + data classification). A revoked or suspended identity returns an
+    empty list with an advisory `note` field rather than failing.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetAgentToolVisibilityResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetAgentToolVisibilityResponse200]]:
+    """ List MCP tools visible to a specific agent identity
+
+     Returns the subset of the MCP tool catalogue this agent identity can call after applying the
+    identity-aware filter (risk tier + data classification). A revoked or suspended identity returns an
+    empty list with an advisory `note` field rather than failing.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetAgentToolVisibilityResponse200]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetAgentToolVisibilityResponse200]]:
+    """ List MCP tools visible to a specific agent identity
+
+     Returns the subset of the MCP tool catalogue this agent identity can call after applying the
+    identity-aware filter (risk tier + data classification). A revoked or suspended identity returns an
+    empty list with an advisory `note` field rather than failing.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetAgentToolVisibilityResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetAgentToolVisibilityResponse200]]:
+    """ List MCP tools visible to a specific agent identity
+
+     Returns the subset of the MCP tool catalogue this agent identity can call after applying the
+    identity-aware filter (risk tier + data classification). A revoked or suspended identity returns an
+    empty list with an advisory `note` field rather than failing.
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetAgentToolVisibilityResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/get_mcp_approval.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/get_mcp_approval.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.get_mcp_approval_response_200 import GetMcpApprovalResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/mcp/approvals/{id}".format(id=id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, GetMcpApprovalResponse200]]:
+    if response.status_code == 200:
+        response_200 = GetMcpApprovalResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, GetMcpApprovalResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetMcpApprovalResponse200]]:
+    """ Get one MCP approval record
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetMcpApprovalResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetMcpApprovalResponse200]]:
+    """ Get one MCP approval record
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetMcpApprovalResponse200]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetMcpApprovalResponse200]]:
+    """ Get one MCP approval record
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetMcpApprovalResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetMcpApprovalResponse200]]:
+    """ Get one MCP approval record
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetMcpApprovalResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/get_mcp_usage.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/get_mcp_usage.py
@@ -1,0 +1,260 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.get_mcp_usage_group_by import GetMcpUsageGroupBy
+from ...models.get_mcp_usage_response_200 import GetMcpUsageResponse200
+from ...types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import Dict
+from typing import Union
+import datetime
+
+
+
+def _get_kwargs(
+    *,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    group_by: Union[Unset, GetMcpUsageGroupBy] = GetMcpUsageGroupBy.SUBJECT,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    json_since: Union[Unset, str] = UNSET
+    if not isinstance(since, Unset):
+        json_since = since.isoformat()
+    params["since"] = json_since
+
+    json_until: Union[Unset, str] = UNSET
+    if not isinstance(until, Unset):
+        json_until = until.isoformat()
+    params["until"] = json_until
+
+    json_group_by: Union[Unset, str] = UNSET
+    if not isinstance(group_by, Unset):
+        json_group_by = group_by.value
+
+    params["group_by"] = json_group_by
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/mcp/usage",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, GetMcpUsageResponse200]]:
+    if response.status_code == 200:
+        response_200 = GetMcpUsageResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, GetMcpUsageResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    group_by: Union[Unset, GetMcpUsageGroupBy] = GetMcpUsageGroupBy.SUBJECT,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetMcpUsageResponse200]]:
+    """ Outbound MCP usage buckets from the audit chain
+
+     Walks the tenant's audit chain and buckets outbound MCP calls by subject, method, and tool for usage
+    analytics. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        group_by (Union[Unset, GetMcpUsageGroupBy]):  Default: GetMcpUsageGroupBy.SUBJECT.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetMcpUsageResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        since=since,
+until=until,
+group_by=group_by,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    group_by: Union[Unset, GetMcpUsageGroupBy] = GetMcpUsageGroupBy.SUBJECT,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetMcpUsageResponse200]]:
+    """ Outbound MCP usage buckets from the audit chain
+
+     Walks the tenant's audit chain and buckets outbound MCP calls by subject, method, and tool for usage
+    analytics. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        group_by (Union[Unset, GetMcpUsageGroupBy]):  Default: GetMcpUsageGroupBy.SUBJECT.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetMcpUsageResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+since=since,
+until=until,
+group_by=group_by,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    group_by: Union[Unset, GetMcpUsageGroupBy] = GetMcpUsageGroupBy.SUBJECT,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, GetMcpUsageResponse200]]:
+    """ Outbound MCP usage buckets from the audit chain
+
+     Walks the tenant's audit chain and buckets outbound MCP calls by subject, method, and tool for usage
+    analytics. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        group_by (Union[Unset, GetMcpUsageGroupBy]):  Default: GetMcpUsageGroupBy.SUBJECT.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, GetMcpUsageResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        since=since,
+until=until,
+group_by=group_by,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    group_by: Union[Unset, GetMcpUsageGroupBy] = GetMcpUsageGroupBy.SUBJECT,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, GetMcpUsageResponse200]]:
+    """ Outbound MCP usage buckets from the audit chain
+
+     Walks the tenant's audit chain and buckets outbound MCP calls by subject, method, and tool for usage
+    analytics. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        group_by (Union[Unset, GetMcpUsageGroupBy]):  Default: GetMcpUsageGroupBy.SUBJECT.
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, GetMcpUsageResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+since=since,
+until=until,
+group_by=group_by,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/list_mcp_approvals.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/list_mcp_approvals.py
@@ -1,0 +1,235 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.list_mcp_approvals_response_200 import ListMcpApprovalsResponse200
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+
+
+def _get_kwargs(
+    *,
+    status: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["status"] = status
+
+    params["limit"] = limit
+
+    params["cursor"] = cursor
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/mcp/approvals",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ListMcpApprovalsResponse200]]:
+    if response.status_code == 200:
+        response_200 = ListMcpApprovalsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ListMcpApprovalsResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListMcpApprovalsResponse200]]:
+    """ List MCP tool-call approvals
+
+    Args:
+        status (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListMcpApprovalsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        status=status,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListMcpApprovalsResponse200]]:
+    """ List MCP tool-call approvals
+
+    Args:
+        status (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListMcpApprovalsResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+status=status,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListMcpApprovalsResponse200]]:
+    """ List MCP tool-call approvals
+
+    Args:
+        status (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListMcpApprovalsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        status=status,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    status: Union[Unset, str] = UNSET,
+    limit: Union[Unset, int] = 50,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListMcpApprovalsResponse200]]:
+    """ List MCP tool-call approvals
+
+    Args:
+        status (Union[Unset, str]):
+        limit (Union[Unset, int]):  Default: 50.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListMcpApprovalsResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+status=status,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/list_mcp_outbound.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/list_mcp_outbound.py
@@ -1,0 +1,270 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.list_mcp_outbound_response_200 import ListMcpOutboundResponse200
+from ...types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import Dict
+from typing import Union
+import datetime
+
+
+
+def _get_kwargs(
+    *,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    limit: Union[Unset, int] = 100,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    json_since: Union[Unset, str] = UNSET
+    if not isinstance(since, Unset):
+        json_since = since.isoformat()
+    params["since"] = json_since
+
+    json_until: Union[Unset, str] = UNSET
+    if not isinstance(until, Unset):
+        json_until = until.isoformat()
+    params["until"] = json_until
+
+    params["limit"] = limit
+
+    params["cursor"] = cursor
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/mcp/outbound",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ListMcpOutboundResponse200]]:
+    if response.status_code == 200:
+        response_200 = ListMcpOutboundResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ListMcpOutboundResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    limit: Union[Unset, int] = 100,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListMcpOutboundResponse200]]:
+    """ List outbound MCP signed-call events
+
+     Walks the tenant's audit chain stream and returns observed outbound MCP calls, filtered by time
+    range + subject. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        limit (Union[Unset, int]):  Default: 100.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListMcpOutboundResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        since=since,
+until=until,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    limit: Union[Unset, int] = 100,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListMcpOutboundResponse200]]:
+    """ List outbound MCP signed-call events
+
+     Walks the tenant's audit chain stream and returns observed outbound MCP calls, filtered by time
+    range + subject. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        limit (Union[Unset, int]):  Default: 100.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListMcpOutboundResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+since=since,
+until=until,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    limit: Union[Unset, int] = 100,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListMcpOutboundResponse200]]:
+    """ List outbound MCP signed-call events
+
+     Walks the tenant's audit chain stream and returns observed outbound MCP calls, filtered by time
+    range + subject. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        limit (Union[Unset, int]):  Default: 100.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListMcpOutboundResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        since=since,
+until=until,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    since: Union[Unset, datetime.datetime] = UNSET,
+    until: Union[Unset, datetime.datetime] = UNSET,
+    limit: Union[Unset, int] = 100,
+    cursor: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListMcpOutboundResponse200]]:
+    """ List outbound MCP signed-call events
+
+     Walks the tenant's audit chain stream and returns observed outbound MCP calls, filtered by time
+    range + subject. Admin-only.
+
+    Args:
+        since (Union[Unset, datetime.datetime]):
+        until (Union[Unset, datetime.datetime]):
+        limit (Union[Unset, int]):  Default: 100.
+        cursor (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListMcpOutboundResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+since=since,
+until=until,
+limit=limit,
+cursor=cursor,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/list_mcp_tools.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/list_mcp_tools.py
@@ -1,0 +1,218 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.list_mcp_tools_response_200 import ListMcpToolsResponse200
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+
+
+def _get_kwargs(
+    *,
+    agent_id: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    params: Dict[str, Any] = {}
+
+    params["agent_id"] = agent_id
+
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/api/v1/mcp/tools",
+        "params": params,
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ListMcpToolsResponse200]]:
+    if response.status_code == 200:
+        response_200 = ListMcpToolsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ListMcpToolsResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    agent_id: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListMcpToolsResponse200]]:
+    """ List MCP tools visible to an agent or the full catalogue
+
+     Returns the MCP tool catalogue. Without an `agent_id` query parameter, returns the unfiltered admin
+    view. With `agent_id`, returns the subset of tools the identity is entitled to call after applying
+    the MCP risk- tier and data-classification filter.
+
+    Args:
+        agent_id (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListMcpToolsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    agent_id: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListMcpToolsResponse200]]:
+    """ List MCP tools visible to an agent or the full catalogue
+
+     Returns the MCP tool catalogue. Without an `agent_id` query parameter, returns the unfiltered admin
+    view. With `agent_id`, returns the subset of tools the identity is entitled to call after applying
+    the MCP risk- tier and data-classification filter.
+
+    Args:
+        agent_id (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListMcpToolsResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+agent_id=agent_id,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    agent_id: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, ListMcpToolsResponse200]]:
+    """ List MCP tools visible to an agent or the full catalogue
+
+     Returns the MCP tool catalogue. Without an `agent_id` query parameter, returns the unfiltered admin
+    view. With `agent_id`, returns the subset of tools the identity is entitled to call after applying
+    the MCP risk- tier and data-classification filter.
+
+    Args:
+        agent_id (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ListMcpToolsResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        agent_id=agent_id,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    agent_id: Union[Unset, str] = UNSET,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, ListMcpToolsResponse200]]:
+    """ List MCP tools visible to an agent or the full catalogue
+
+     Returns the MCP tool catalogue. Without an `agent_id` query parameter, returns the unfiltered admin
+    view. With `agent_id`, returns the subset of tools the identity is entitled to call after applying
+    the MCP risk- tier and data-classification filter.
+
+    Args:
+        agent_id (Union[Unset, str]):
+        x_tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ListMcpToolsResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+agent_id=agent_id,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/reject_mcp_approval.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/reject_mcp_approval.py
@@ -1,0 +1,221 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.approval_decision_request import ApprovalDecisionRequest
+from ...models.reject_mcp_approval_response_200 import RejectMcpApprovalResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/mcp/approvals/{id}/reject".format(id=id,),
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, RejectMcpApprovalResponse200]]:
+    if response.status_code == 200:
+        response_200 = RejectMcpApprovalResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 409:
+        response_409 = cast(Any, None)
+        return response_409
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, RejectMcpApprovalResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, RejectMcpApprovalResponse200]]:
+    """ Reject an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, RejectMcpApprovalResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, RejectMcpApprovalResponse200]]:
+    """ Reject an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, RejectMcpApprovalResponse200]
+     """
+
+
+    return sync_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, RejectMcpApprovalResponse200]]:
+    """ Reject an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, RejectMcpApprovalResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        id=id,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    id: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ApprovalDecisionRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, RejectMcpApprovalResponse200]]:
+    """ Reject an MCP tool-call approval request
+
+    Args:
+        id (str):
+        x_tenant_id (str):
+        body (ApprovalDecisionRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, RejectMcpApprovalResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        id=id,
+client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/mcp/verify_mcp_signature.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/mcp/verify_mcp_signature.py
@@ -1,0 +1,202 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.verify_mcp_signature_body import VerifyMcpSignatureBody
+from ...models.verify_mcp_signature_response_200 import VerifyMcpSignatureResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    *,
+    body: VerifyMcpSignatureBody,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/mcp/verify-signature",
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, VerifyMcpSignatureResponse200]]:
+    if response.status_code == 200:
+        response_200 = VerifyMcpSignatureResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, VerifyMcpSignatureResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: VerifyMcpSignatureBody,
+
+) -> Response[Union[Any, VerifyMcpSignatureResponse200]]:
+    """ Verify an outbound MCP signature (admin-gated)
+
+     Verify an ECDSA signature over an MCP request against the trusted-key store. Admin-only. See
+    docs/mcp/outbound-signing.md.
+
+    Args:
+        body (VerifyMcpSignatureBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, VerifyMcpSignatureResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: VerifyMcpSignatureBody,
+
+) -> Optional[Union[Any, VerifyMcpSignatureResponse200]]:
+    """ Verify an outbound MCP signature (admin-gated)
+
+     Verify an ECDSA signature over an MCP request against the trusted-key store. Admin-only. See
+    docs/mcp/outbound-signing.md.
+
+    Args:
+        body (VerifyMcpSignatureBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, VerifyMcpSignatureResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+body=body,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: VerifyMcpSignatureBody,
+
+) -> Response[Union[Any, VerifyMcpSignatureResponse200]]:
+    """ Verify an outbound MCP signature (admin-gated)
+
+     Verify an ECDSA signature over an MCP request against the trusted-key store. Admin-only. See
+    docs/mcp/outbound-signing.md.
+
+    Args:
+        body (VerifyMcpSignatureBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, VerifyMcpSignatureResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: VerifyMcpSignatureBody,
+
+) -> Optional[Union[Any, VerifyMcpSignatureResponse200]]:
+    """ Verify an outbound MCP signature (admin-gated)
+
+     Verify an ECDSA signature over an MCP request against the trusted-key store. Admin-only. See
+    docs/mcp/outbound-signing.md.
+
+    Args:
+        body (VerifyMcpSignatureBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, VerifyMcpSignatureResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/models/__init__.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/__init__.py
@@ -72,8 +72,10 @@ from .eval_run_result import EvalRunResult
 from .eval_run_summary import EvalRunSummary
 from .eval_runs_response import EvalRunsResponse
 from .generic_object import GenericObject
+from .get_agent_denied_events_response_200 import GetAgentDeniedEventsResponse200
 from .get_agent_response_200 import GetAgentResponse200
 from .get_agent_stats_response_200 import GetAgentStatsResponse200
+from .get_agent_tool_visibility_response_200 import GetAgentToolVisibilityResponse200
 from .get_approval_analytics_group_by import GetApprovalAnalyticsGroupBy
 from .get_approval_analytics_window import GetApprovalAnalyticsWindow
 from .get_approval_context_response_200 import GetApprovalContextResponse200
@@ -137,6 +139,7 @@ from .list_jobs_response_200 import ListJobsResponse200
 from .list_mcp_approvals_response_200 import ListMcpApprovalsResponse200
 from .list_mcp_approvals_response_200_items_item import ListMcpApprovalsResponse200ItemsItem
 from .list_mcp_outbound_response_200 import ListMcpOutboundResponse200
+from .list_mcp_tools_response_200 import ListMcpToolsResponse200
 from .list_packs_response_200 import ListPacksResponse200
 from .list_policy_bundles_response_200 import ListPolicyBundlesResponse200
 from .list_policy_rules_response_200 import ListPolicyRulesResponse200
@@ -346,8 +349,10 @@ __all__ = (
     "EvalRunsResponse",
     "EvalRunSummary",
     "GenericObject",
+    "GetAgentDeniedEventsResponse200",
     "GetAgentResponse200",
     "GetAgentStatsResponse200",
+    "GetAgentToolVisibilityResponse200",
     "GetApprovalAnalyticsGroupBy",
     "GetApprovalAnalyticsWindow",
     "GetApprovalContextResponse200",
@@ -411,6 +416,7 @@ __all__ = (
     "ListMcpApprovalsResponse200",
     "ListMcpApprovalsResponse200ItemsItem",
     "ListMcpOutboundResponse200",
+    "ListMcpToolsResponse200",
     "ListPacksResponse200",
     "ListPolicyBundlesResponse200",
     "ListPolicyRulesResponse200",

--- a/sdk/python/src/cordum_sdk/_generated/models/__init__.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/__init__.py
@@ -2,10 +2,15 @@
 
 from .admin_lock import AdminLock
 from .api_key_info import APIKeyInfo
+from .approval_analytics_group import ApprovalAnalyticsGroup
+from .approval_analytics_response import ApprovalAnalyticsResponse
+from .approval_analytics_response_window import ApprovalAnalyticsResponseWindow
+from .approval_analytics_summary import ApprovalAnalyticsSummary
 from .approval_decision_request import ApprovalDecisionRequest
 from .approval_item import ApprovalItem
 from .approval_item_constraints_type_0 import ApprovalItemConstraintsType0
 from .approval_item_decision import ApprovalItemDecision
+from .approve_mcp_approval_response_200 import ApproveMcpApprovalResponse200
 from .artifact_detail import ArtifactDetail
 from .artifact_detail_metadata import ArtifactDetailMetadata
 from .artifact_detail_metadata_labels import ArtifactDetailMetadataLabels
@@ -26,12 +31,28 @@ from .create_artifact_request import CreateArtifactRequest
 from .create_artifact_request_labels import CreateArtifactRequestLabels
 from .create_artifact_response import CreateArtifactResponse
 from .create_bundle_snapshot_body import CreateBundleSnapshotBody
+from .create_eval_dataset_body import CreateEvalDatasetBody
+from .create_eval_dataset_body_entries_item import CreateEvalDatasetBodyEntriesItem
+from .create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
+from .create_eval_dataset_body_entries_item_metadata import CreateEvalDatasetBodyEntriesItemMetadata
+from .create_eval_dataset_from_incidents_body import CreateEvalDatasetFromIncidentsBody
+from .create_eval_dataset_from_incidents_response_200 import CreateEvalDatasetFromIncidentsResponse200
+from .create_eval_dataset_from_incidents_response_201 import CreateEvalDatasetFromIncidentsResponse201
+from .create_eval_dataset_response_201 import CreateEvalDatasetResponse201
+from .create_eval_dataset_successor_body import CreateEvalDatasetSuccessorBody
+from .create_eval_dataset_successor_body_entries_item import CreateEvalDatasetSuccessorBodyEntriesItem
+from .create_eval_dataset_successor_response_200 import CreateEvalDatasetSuccessorResponse200
 from .create_legal_hold_body import CreateLegalHoldBody
 from .create_pool_body import CreatePoolBody
 from .create_topic_body import CreateTopicBody
 from .create_user_request import CreateUserRequest
 from .create_worker_credential_body import CreateWorkerCredentialBody
 from .create_workflow_response_201 import CreateWorkflowResponse201
+from .delegation_chain_link import DelegationChainLink
+from .delegation_lineage_chain_link import DelegationLineageChainLink
+from .delegation_lineage_view import DelegationLineageView
+from .delegation_list_response import DelegationListResponse
+from .delegation_view import DelegationView
 from .delete_role_response_200 import DeleteRoleResponse200
 from .dlq_entry import DLQEntry
 from .drain_pool_body import DrainPoolBody
@@ -40,9 +61,21 @@ from .dry_run_workflow_body import DryRunWorkflowBody
 from .dry_run_workflow_body_environment import DryRunWorkflowBodyEnvironment
 from .dry_run_workflow_body_input import DryRunWorkflowBodyInput
 from .error import Error
+from .eval_entry_result import EvalEntryResult
+from .eval_entry_result_drift_direction import EvalEntryResultDriftDirection
+from .eval_entry_result_input import EvalEntryResultInput
+from .eval_entry_result_status import EvalEntryResultStatus
+from .eval_run_accepted_response import EvalRunAcceptedResponse
+from .eval_run_accepted_response_status import EvalRunAcceptedResponseStatus
+from .eval_run_request import EvalRunRequest
+from .eval_run_result import EvalRunResult
+from .eval_run_summary import EvalRunSummary
+from .eval_runs_response import EvalRunsResponse
 from .generic_object import GenericObject
 from .get_agent_response_200 import GetAgentResponse200
 from .get_agent_stats_response_200 import GetAgentStatsResponse200
+from .get_approval_analytics_group_by import GetApprovalAnalyticsGroupBy
+from .get_approval_analytics_window import GetApprovalAnalyticsWindow
 from .get_approval_context_response_200 import GetApprovalContextResponse200
 from .get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
 from .get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
@@ -51,7 +84,12 @@ from .get_approval_context_response_200_policy_snapshot_summary import GetApprov
 from .get_approval_context_response_200_policy_snapshot_summary_matched_rule import GetApprovalContextResponse200PolicySnapshotSummaryMatchedRule
 from .get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
 from .get_config_scope import GetConfigScope
+from .get_eval_dataset_by_name_version_response_200 import GetEvalDatasetByNameVersionResponse200
+from .get_eval_dataset_response_200 import GetEvalDatasetResponse200
 from .get_license_response_200 import GetLicenseResponse200
+from .get_mcp_approval_response_200 import GetMcpApprovalResponse200
+from .get_mcp_usage_group_by import GetMcpUsageGroupBy
+from .get_mcp_usage_response_200 import GetMcpUsageResponse200
 from .get_memory_response_200 import GetMemoryResponse200
 from .get_output_policy_stats_response_200 import GetOutputPolicyStatsResponse200
 from .get_run_chat_response_200 import GetRunChatResponse200
@@ -59,6 +97,10 @@ from .get_telemetry_status_response_200 import GetTelemetryStatusResponse200
 from .get_velocity_rule_stats_response_200 import GetVelocityRuleStatsResponse200
 from .get_worker_jobs_response_200 import GetWorkerJobsResponse200
 from .install_pack_body import InstallPackBody
+from .installed_pack_verification import InstalledPackVerification
+from .installed_pack_verification_signature_algorithm import InstalledPackVerificationSignatureAlgorithm
+from .issue_delegation_token_body import IssueDelegationTokenBody
+from .issue_delegation_token_response_201 import IssueDelegationTokenResponse201
 from .job_detail import JobDetail
 from .job_detail_labels import JobDetailLabels
 from .job_detail_result_type_0 import JobDetailResultType0
@@ -76,12 +118,25 @@ from .license_info import LicenseInfo
 from .license_info_limits import LicenseInfoLimits
 from .list_admin_locks_response_200 import ListAdminLocksResponse200
 from .list_agents_response_200 import ListAgentsResponse200
+from .list_agents_response_200_items_item import ListAgentsResponse200ItemsItem
 from .list_all_workflow_runs_response_200 import ListAllWorkflowRunsResponse200
 from .list_api_keys_response_200 import ListAPIKeysResponse200
 from .list_approvals_response_200 import ListApprovalsResponse200
 from .list_bundle_snapshots_response_200 import ListBundleSnapshotsResponse200
+from .list_delegations_for_agent_status import ListDelegationsForAgentStatus
+from .list_delegations_status import ListDelegationsStatus
 from .list_dlq_paginated_response_200 import ListDLQPaginatedResponse200
+from .list_eval_dataset_versions_response_200 import ListEvalDatasetVersionsResponse200
+from .list_eval_dataset_versions_response_200_items_item import ListEvalDatasetVersionsResponse200ItemsItem
+from .list_eval_datasets_response_200 import ListEvalDatasetsResponse200
+from .list_eval_datasets_response_200_items_item import ListEvalDatasetsResponse200ItemsItem
+from .list_governance_decisions_response_200 import ListGovernanceDecisionsResponse200
+from .list_governance_decisions_response_200_items_item import ListGovernanceDecisionsResponse200ItemsItem
+from .list_governance_decisions_response_200_items_item_constraints import ListGovernanceDecisionsResponse200ItemsItemConstraints
 from .list_jobs_response_200 import ListJobsResponse200
+from .list_mcp_approvals_response_200 import ListMcpApprovalsResponse200
+from .list_mcp_approvals_response_200_items_item import ListMcpApprovalsResponse200ItemsItem
+from .list_mcp_outbound_response_200 import ListMcpOutboundResponse200
 from .list_packs_response_200 import ListPacksResponse200
 from .list_policy_bundles_response_200 import ListPolicyBundlesResponse200
 from .list_policy_rules_response_200 import ListPolicyRulesResponse200
@@ -145,6 +200,7 @@ from .post_chat_request_role import PostChatRequestRole
 from .publish_policy_request import PublishPolicyRequest
 from .put_role_response_200 import PutRoleResponse200
 from .reject_job_response_200 import RejectJobResponse200
+from .reject_mcp_approval_response_200 import RejectMcpApprovalResponse200
 from .release_lock_response_200 import ReleaseLockResponse200
 from .reload_license_response_200 import ReloadLicenseResponse200
 from .remediate_job_body import RemediateJobBody
@@ -153,6 +209,8 @@ from .rerun_workflow_body import RerunWorkflowBody
 from .rerun_workflow_response_200 import RerunWorkflowResponse200
 from .reset_user_password_body import ResetUserPasswordBody
 from .retry_dlq_entry_response_200 import RetryDLQEntryResponse200
+from .revoke_delegation_token_body import RevokeDelegationTokenBody
+from .revoke_delegation_token_response_200 import RevokeDelegationTokenResponse200
 from .role_definition import RoleDefinition
 from .role_detail_response import RoleDetailResponse
 from .role_list_response import RoleListResponse
@@ -200,6 +258,10 @@ from .update_user_request import UpdateUserRequest
 from .velocity_rule import VelocityRule
 from .velocity_rule_match import VelocityRuleMatch
 from .velocity_stats import VelocityStats
+from .verify_delegation_token_body import VerifyDelegationTokenBody
+from .verify_delegation_token_response_200 import VerifyDelegationTokenResponse200
+from .verify_mcp_signature_body import VerifyMcpSignatureBody
+from .verify_mcp_signature_response_200 import VerifyMcpSignatureResponse200
 from .worker_credential import WorkerCredential
 from .worker_credential_issue import WorkerCredentialIssue
 from .worker_runtime import WorkerRuntime
@@ -214,10 +276,15 @@ from .workflow_step_retry import WorkflowStepRetry
 __all__ = (
     "AdminLock",
     "APIKeyInfo",
+    "ApprovalAnalyticsGroup",
+    "ApprovalAnalyticsResponse",
+    "ApprovalAnalyticsResponseWindow",
+    "ApprovalAnalyticsSummary",
     "ApprovalDecisionRequest",
     "ApprovalItem",
     "ApprovalItemConstraintsType0",
     "ApprovalItemDecision",
+    "ApproveMcpApprovalResponse200",
     "ArtifactDetail",
     "ArtifactDetailMetadata",
     "ArtifactDetailMetadataLabels",
@@ -238,12 +305,28 @@ __all__ = (
     "CreateArtifactRequestLabels",
     "CreateArtifactResponse",
     "CreateBundleSnapshotBody",
+    "CreateEvalDatasetBody",
+    "CreateEvalDatasetBodyEntriesItem",
+    "CreateEvalDatasetBodyEntriesItemInput",
+    "CreateEvalDatasetBodyEntriesItemMetadata",
+    "CreateEvalDatasetFromIncidentsBody",
+    "CreateEvalDatasetFromIncidentsResponse200",
+    "CreateEvalDatasetFromIncidentsResponse201",
+    "CreateEvalDatasetResponse201",
+    "CreateEvalDatasetSuccessorBody",
+    "CreateEvalDatasetSuccessorBodyEntriesItem",
+    "CreateEvalDatasetSuccessorResponse200",
     "CreateLegalHoldBody",
     "CreatePoolBody",
     "CreateTopicBody",
     "CreateUserRequest",
     "CreateWorkerCredentialBody",
     "CreateWorkflowResponse201",
+    "DelegationChainLink",
+    "DelegationLineageChainLink",
+    "DelegationLineageView",
+    "DelegationListResponse",
+    "DelegationView",
     "DeleteRoleResponse200",
     "DLQEntry",
     "DrainPoolBody",
@@ -252,9 +335,21 @@ __all__ = (
     "DryRunWorkflowBodyEnvironment",
     "DryRunWorkflowBodyInput",
     "Error",
+    "EvalEntryResult",
+    "EvalEntryResultDriftDirection",
+    "EvalEntryResultInput",
+    "EvalEntryResultStatus",
+    "EvalRunAcceptedResponse",
+    "EvalRunAcceptedResponseStatus",
+    "EvalRunRequest",
+    "EvalRunResult",
+    "EvalRunsResponse",
+    "EvalRunSummary",
     "GenericObject",
     "GetAgentResponse200",
     "GetAgentStatsResponse200",
+    "GetApprovalAnalyticsGroupBy",
+    "GetApprovalAnalyticsWindow",
     "GetApprovalContextResponse200",
     "GetApprovalContextResponse200Approval",
     "GetApprovalContextResponse200BlastRadius",
@@ -263,14 +358,23 @@ __all__ = (
     "GetApprovalContextResponse200PolicySnapshotSummaryMatchedRule",
     "GetApprovalContextResponse200PriorApprovalsItem",
     "GetConfigScope",
+    "GetEvalDatasetByNameVersionResponse200",
+    "GetEvalDatasetResponse200",
     "GetLicenseResponse200",
+    "GetMcpApprovalResponse200",
+    "GetMcpUsageGroupBy",
+    "GetMcpUsageResponse200",
     "GetMemoryResponse200",
     "GetOutputPolicyStatsResponse200",
     "GetRunChatResponse200",
     "GetTelemetryStatusResponse200",
     "GetVelocityRuleStatsResponse200",
     "GetWorkerJobsResponse200",
+    "InstalledPackVerification",
+    "InstalledPackVerificationSignatureAlgorithm",
     "InstallPackBody",
+    "IssueDelegationTokenBody",
+    "IssueDelegationTokenResponse201",
     "JobDetail",
     "JobDetailLabels",
     "JobDetailResultType0",
@@ -288,12 +392,25 @@ __all__ = (
     "LicenseInfoLimits",
     "ListAdminLocksResponse200",
     "ListAgentsResponse200",
+    "ListAgentsResponse200ItemsItem",
     "ListAllWorkflowRunsResponse200",
     "ListAPIKeysResponse200",
     "ListApprovalsResponse200",
     "ListBundleSnapshotsResponse200",
+    "ListDelegationsForAgentStatus",
+    "ListDelegationsStatus",
     "ListDLQPaginatedResponse200",
+    "ListEvalDatasetsResponse200",
+    "ListEvalDatasetsResponse200ItemsItem",
+    "ListEvalDatasetVersionsResponse200",
+    "ListEvalDatasetVersionsResponse200ItemsItem",
+    "ListGovernanceDecisionsResponse200",
+    "ListGovernanceDecisionsResponse200ItemsItem",
+    "ListGovernanceDecisionsResponse200ItemsItemConstraints",
     "ListJobsResponse200",
+    "ListMcpApprovalsResponse200",
+    "ListMcpApprovalsResponse200ItemsItem",
+    "ListMcpOutboundResponse200",
     "ListPacksResponse200",
     "ListPolicyBundlesResponse200",
     "ListPolicyRulesResponse200",
@@ -357,6 +474,7 @@ __all__ = (
     "PublishPolicyRequest",
     "PutRoleResponse200",
     "RejectJobResponse200",
+    "RejectMcpApprovalResponse200",
     "ReleaseLockResponse200",
     "ReloadLicenseResponse200",
     "RemediateJobBody",
@@ -365,6 +483,8 @@ __all__ = (
     "RerunWorkflowResponse200",
     "ResetUserPasswordBody",
     "RetryDLQEntryResponse200",
+    "RevokeDelegationTokenBody",
+    "RevokeDelegationTokenResponse200",
     "RoleDefinition",
     "RoleDetailResponse",
     "RoleListResponse",
@@ -412,6 +532,10 @@ __all__ = (
     "VelocityRule",
     "VelocityRuleMatch",
     "VelocityStats",
+    "VerifyDelegationTokenBody",
+    "VerifyDelegationTokenResponse200",
+    "VerifyMcpSignatureBody",
+    "VerifyMcpSignatureResponse200",
     "WorkerCredential",
     "WorkerCredentialIssue",
     "WorkerRuntime",

--- a/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_group.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_group.py
@@ -1,0 +1,173 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast, Union
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="ApprovalAnalyticsGroup")
+
+
+@_attrs_define
+class ApprovalAnalyticsGroup:
+    """ 
+        Attributes:
+            key (str): Group identifier (rule id, agent id, or topic string).
+            label (str):
+            total (int):
+            approved (int):
+            rejected (int):
+            expired (int):
+            auto_count (int):
+            manual_count (int):
+            avg_ttar_seconds (Union[None, Unset, float]):
+            p90_seconds (Union[None, Unset, float]):
+     """
+
+    key: str
+    label: str
+    total: int
+    approved: int
+    rejected: int
+    expired: int
+    auto_count: int
+    manual_count: int
+    avg_ttar_seconds: Union[None, Unset, float] = UNSET
+    p90_seconds: Union[None, Unset, float] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        key = self.key
+
+        label = self.label
+
+        total = self.total
+
+        approved = self.approved
+
+        rejected = self.rejected
+
+        expired = self.expired
+
+        auto_count = self.auto_count
+
+        manual_count = self.manual_count
+
+        avg_ttar_seconds: Union[None, Unset, float]
+        if isinstance(self.avg_ttar_seconds, Unset):
+            avg_ttar_seconds = UNSET
+        else:
+            avg_ttar_seconds = self.avg_ttar_seconds
+
+        p90_seconds: Union[None, Unset, float]
+        if isinstance(self.p90_seconds, Unset):
+            p90_seconds = UNSET
+        else:
+            p90_seconds = self.p90_seconds
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "key": key,
+            "label": label,
+            "total": total,
+            "approved": approved,
+            "rejected": rejected,
+            "expired": expired,
+            "auto_count": auto_count,
+            "manual_count": manual_count,
+        })
+        if avg_ttar_seconds is not UNSET:
+            field_dict["avg_ttar_seconds"] = avg_ttar_seconds
+        if p90_seconds is not UNSET:
+            field_dict["p90_seconds"] = p90_seconds
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        key = d.pop("key")
+
+        label = d.pop("label")
+
+        total = d.pop("total")
+
+        approved = d.pop("approved")
+
+        rejected = d.pop("rejected")
+
+        expired = d.pop("expired")
+
+        auto_count = d.pop("auto_count")
+
+        manual_count = d.pop("manual_count")
+
+        def _parse_avg_ttar_seconds(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        avg_ttar_seconds = _parse_avg_ttar_seconds(d.pop("avg_ttar_seconds", UNSET))
+
+
+        def _parse_p90_seconds(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        p90_seconds = _parse_p90_seconds(d.pop("p90_seconds", UNSET))
+
+
+        approval_analytics_group = cls(
+            key=key,
+            label=label,
+            total=total,
+            approved=approved,
+            rejected=rejected,
+            expired=expired,
+            auto_count=auto_count,
+            manual_count=manual_count,
+            avg_ttar_seconds=avg_ttar_seconds,
+            p90_seconds=p90_seconds,
+        )
+
+
+        approval_analytics_group.additional_properties = d
+        return approval_analytics_group
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_response.py
@@ -1,0 +1,125 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.approval_analytics_response_window import ApprovalAnalyticsResponseWindow
+  from ..models.approval_analytics_group import ApprovalAnalyticsGroup
+  from ..models.approval_analytics_summary import ApprovalAnalyticsSummary
+
+
+
+
+
+T = TypeVar("T", bound="ApprovalAnalyticsResponse")
+
+
+@_attrs_define
+class ApprovalAnalyticsResponse:
+    """ 
+        Attributes:
+            window (ApprovalAnalyticsResponseWindow):
+            summary (ApprovalAnalyticsSummary):
+            groups (Union[Unset, List['ApprovalAnalyticsGroup']]):
+     """
+
+    window: 'ApprovalAnalyticsResponseWindow'
+    summary: 'ApprovalAnalyticsSummary'
+    groups: Union[Unset, List['ApprovalAnalyticsGroup']] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.approval_analytics_response_window import ApprovalAnalyticsResponseWindow
+        from ..models.approval_analytics_group import ApprovalAnalyticsGroup
+        from ..models.approval_analytics_summary import ApprovalAnalyticsSummary
+        window = self.window.to_dict()
+
+        summary = self.summary.to_dict()
+
+        groups: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.groups, Unset):
+            groups = []
+            for groups_item_data in self.groups:
+                groups_item = groups_item_data.to_dict()
+                groups.append(groups_item)
+
+
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "window": window,
+            "summary": summary,
+        })
+        if groups is not UNSET:
+            field_dict["groups"] = groups
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.approval_analytics_response_window import ApprovalAnalyticsResponseWindow
+        from ..models.approval_analytics_group import ApprovalAnalyticsGroup
+        from ..models.approval_analytics_summary import ApprovalAnalyticsSummary
+        d = src_dict.copy()
+        window = ApprovalAnalyticsResponseWindow.from_dict(d.pop("window"))
+
+
+
+
+        summary = ApprovalAnalyticsSummary.from_dict(d.pop("summary"))
+
+
+
+
+        groups = []
+        _groups = d.pop("groups", UNSET)
+        for groups_item_data in (_groups or []):
+            groups_item = ApprovalAnalyticsGroup.from_dict(groups_item_data)
+
+
+
+            groups.append(groups_item)
+
+
+        approval_analytics_response = cls(
+            window=window,
+            summary=summary,
+            groups=groups,
+        )
+
+
+        approval_analytics_response.additional_properties = d
+        return approval_analytics_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_response_window.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_response_window.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="ApprovalAnalyticsResponseWindow")
+
+
+@_attrs_define
+class ApprovalAnalyticsResponseWindow:
+    """ 
+        Attributes:
+            since (datetime.datetime):
+            until (datetime.datetime):
+     """
+
+    since: datetime.datetime
+    until: datetime.datetime
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        since = self.since.isoformat()
+
+        until = self.until.isoformat()
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "since": since,
+            "until": until,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        since = isoparse(d.pop("since"))
+
+
+
+
+        until = isoparse(d.pop("until"))
+
+
+
+
+        approval_analytics_response_window = cls(
+            since=since,
+            until=until,
+        )
+
+
+        approval_analytics_response_window.additional_properties = d
+        return approval_analytics_response_window
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_summary.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/approval_analytics_summary.py
@@ -1,0 +1,200 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast, Union
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="ApprovalAnalyticsSummary")
+
+
+@_attrs_define
+class ApprovalAnalyticsSummary:
+    """ 
+        Attributes:
+            total (int): Total decisions with verdict=require_approval in the window (includes still-pending).
+            approved (int):
+            rejected (int):
+            expired (int):
+            auto_resolved (int): Resolutions driven by lifecycle events (expire/invalidate/repair), not human decision.
+            manual_resolved (int): Resolutions where a human approver entered approve or reject.
+            avg_time_to_approve_seconds (Union[None, Unset, float]): Null when no approvals resolved in the window —
+                distinguishes "no data" from "all resolved in 0 s".
+            p50 (Union[None, Unset, float]):
+            p90 (Union[None, Unset, float]):
+            p99 (Union[None, Unset, float]):
+     """
+
+    total: int
+    approved: int
+    rejected: int
+    expired: int
+    auto_resolved: int
+    manual_resolved: int
+    avg_time_to_approve_seconds: Union[None, Unset, float] = UNSET
+    p50: Union[None, Unset, float] = UNSET
+    p90: Union[None, Unset, float] = UNSET
+    p99: Union[None, Unset, float] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        total = self.total
+
+        approved = self.approved
+
+        rejected = self.rejected
+
+        expired = self.expired
+
+        auto_resolved = self.auto_resolved
+
+        manual_resolved = self.manual_resolved
+
+        avg_time_to_approve_seconds: Union[None, Unset, float]
+        if isinstance(self.avg_time_to_approve_seconds, Unset):
+            avg_time_to_approve_seconds = UNSET
+        else:
+            avg_time_to_approve_seconds = self.avg_time_to_approve_seconds
+
+        p50: Union[None, Unset, float]
+        if isinstance(self.p50, Unset):
+            p50 = UNSET
+        else:
+            p50 = self.p50
+
+        p90: Union[None, Unset, float]
+        if isinstance(self.p90, Unset):
+            p90 = UNSET
+        else:
+            p90 = self.p90
+
+        p99: Union[None, Unset, float]
+        if isinstance(self.p99, Unset):
+            p99 = UNSET
+        else:
+            p99 = self.p99
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "total": total,
+            "approved": approved,
+            "rejected": rejected,
+            "expired": expired,
+            "auto_resolved": auto_resolved,
+            "manual_resolved": manual_resolved,
+        })
+        if avg_time_to_approve_seconds is not UNSET:
+            field_dict["avg_time_to_approve_seconds"] = avg_time_to_approve_seconds
+        if p50 is not UNSET:
+            field_dict["p50"] = p50
+        if p90 is not UNSET:
+            field_dict["p90"] = p90
+        if p99 is not UNSET:
+            field_dict["p99"] = p99
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        total = d.pop("total")
+
+        approved = d.pop("approved")
+
+        rejected = d.pop("rejected")
+
+        expired = d.pop("expired")
+
+        auto_resolved = d.pop("auto_resolved")
+
+        manual_resolved = d.pop("manual_resolved")
+
+        def _parse_avg_time_to_approve_seconds(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        avg_time_to_approve_seconds = _parse_avg_time_to_approve_seconds(d.pop("avg_time_to_approve_seconds", UNSET))
+
+
+        def _parse_p50(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        p50 = _parse_p50(d.pop("p50", UNSET))
+
+
+        def _parse_p90(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        p90 = _parse_p90(d.pop("p90", UNSET))
+
+
+        def _parse_p99(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        p99 = _parse_p99(d.pop("p99", UNSET))
+
+
+        approval_analytics_summary = cls(
+            total=total,
+            approved=approved,
+            rejected=rejected,
+            expired=expired,
+            auto_resolved=auto_resolved,
+            manual_resolved=manual_resolved,
+            avg_time_to_approve_seconds=avg_time_to_approve_seconds,
+            p50=p50,
+            p90=p90,
+            p99=p99,
+        )
+
+
+        approval_analytics_summary.additional_properties = d
+        return approval_analytics_summary
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/approval_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/approval_item.py
@@ -18,8 +18,8 @@ from typing import Union
 import datetime
 
 if TYPE_CHECKING:
-  from ..models.job_summary import JobSummary
   from ..models.approval_item_constraints_type_0 import ApprovalItemConstraintsType0
+  from ..models.job_summary import JobSummary
 
 
 
@@ -58,8 +58,8 @@ class ApprovalItem:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.job_summary import JobSummary
         from ..models.approval_item_constraints_type_0 import ApprovalItemConstraintsType0
+        from ..models.job_summary import JobSummary
         job: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.job, Unset):
             job = self.job.to_dict()
@@ -147,8 +147,8 @@ class ApprovalItem:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.job_summary import JobSummary
         from ..models.approval_item_constraints_type_0 import ApprovalItemConstraintsType0
+        from ..models.job_summary import JobSummary
         d = src_dict.copy()
         _job = d.pop("job", UNSET)
         job: Union[Unset, JobSummary]

--- a/sdk/python/src/cordum_sdk/_generated/models/approve_mcp_approval_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/approve_mcp_approval_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ApproveMcpApprovalResponse200")
+
+
+@_attrs_define
+class ApproveMcpApprovalResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        approve_mcp_approval_response_200 = cls(
+        )
+
+
+        approve_mcp_approval_response_200.additional_properties = d
+        return approve_mcp_approval_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_agent_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_agent_body.py
@@ -8,6 +8,9 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
+from ..types import UNSET, Unset
+from typing import cast, List
+from typing import Union
 
 
 
@@ -20,15 +23,85 @@ T = TypeVar("T", bound="CreateAgentBody")
 @_attrs_define
 class CreateAgentBody:
     """ 
+        Attributes:
+            name (str):
+            owner (str):
+            risk_tier (str):
+            description (Union[Unset, str]):
+            team (Union[Unset, str]):
+            allowed_topics (Union[Unset, List[str]]):
+            allowed_pools (Union[Unset, List[str]]):
+            allowed_tools (Union[Unset, List[str]]):
+            data_classifications (Union[Unset, List[str]]):
      """
 
+    name: str
+    owner: str
+    risk_tier: str
+    description: Union[Unset, str] = UNSET
+    team: Union[Unset, str] = UNSET
+    allowed_topics: Union[Unset, List[str]] = UNSET
+    allowed_pools: Union[Unset, List[str]] = UNSET
+    allowed_tools: Union[Unset, List[str]] = UNSET
+    data_classifications: Union[Unset, List[str]] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
 
     def to_dict(self) -> Dict[str, Any]:
-        
+        name = self.name
+
+        owner = self.owner
+
+        risk_tier = self.risk_tier
+
+        description = self.description
+
+        team = self.team
+
+        allowed_topics: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_topics, Unset):
+            allowed_topics = self.allowed_topics
+
+
+
+        allowed_pools: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_pools, Unset):
+            allowed_pools = self.allowed_pools
+
+
+
+        allowed_tools: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_tools, Unset):
+            allowed_tools = self.allowed_tools
+
+
+
+        data_classifications: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.data_classifications, Unset):
+            data_classifications = self.data_classifications
+
+
+
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
+        field_dict.update({
+            "name": name,
+            "owner": owner,
+            "risk_tier": risk_tier,
+        })
+        if description is not UNSET:
+            field_dict["description"] = description
+        if team is not UNSET:
+            field_dict["team"] = team
+        if allowed_topics is not UNSET:
+            field_dict["allowed_topics"] = allowed_topics
+        if allowed_pools is not UNSET:
+            field_dict["allowed_pools"] = allowed_pools
+        if allowed_tools is not UNSET:
+            field_dict["allowed_tools"] = allowed_tools
+        if data_classifications is not UNSET:
+            field_dict["data_classifications"] = data_classifications
 
         return field_dict
 
@@ -37,7 +110,38 @@ class CreateAgentBody:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
+        name = d.pop("name")
+
+        owner = d.pop("owner")
+
+        risk_tier = d.pop("risk_tier")
+
+        description = d.pop("description", UNSET)
+
+        team = d.pop("team", UNSET)
+
+        allowed_topics = cast(List[str], d.pop("allowed_topics", UNSET))
+
+
+        allowed_pools = cast(List[str], d.pop("allowed_pools", UNSET))
+
+
+        allowed_tools = cast(List[str], d.pop("allowed_tools", UNSET))
+
+
+        data_classifications = cast(List[str], d.pop("data_classifications", UNSET))
+
+
         create_agent_body = cls(
+            name=name,
+            owner=owner,
+            risk_tier=risk_tier,
+            description=description,
+            team=team,
+            allowed_topics=allowed_topics,
+            allowed_pools=allowed_pools,
+            allowed_tools=allowed_tools,
+            data_classifications=data_classifications,
         )
 
 

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body.py
@@ -1,0 +1,119 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.create_eval_dataset_body_entries_item import CreateEvalDatasetBodyEntriesItem
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetBody")
+
+
+@_attrs_define
+class CreateEvalDatasetBody:
+    """ 
+        Attributes:
+            name (str):
+            version (int):
+            entries (List['CreateEvalDatasetBodyEntriesItem']):
+            description (Union[Unset, str]):
+     """
+
+    name: str
+    version: int
+    entries: List['CreateEvalDatasetBodyEntriesItem']
+    description: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.create_eval_dataset_body_entries_item import CreateEvalDatasetBodyEntriesItem
+        name = self.name
+
+        version = self.version
+
+        entries = []
+        for entries_item_data in self.entries:
+            entries_item = entries_item_data.to_dict()
+            entries.append(entries_item)
+
+
+
+        description = self.description
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "name": name,
+            "version": version,
+            "entries": entries,
+        })
+        if description is not UNSET:
+            field_dict["description"] = description
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.create_eval_dataset_body_entries_item import CreateEvalDatasetBodyEntriesItem
+        d = src_dict.copy()
+        name = d.pop("name")
+
+        version = d.pop("version")
+
+        entries = []
+        _entries = d.pop("entries")
+        for entries_item_data in (_entries):
+            entries_item = CreateEvalDatasetBodyEntriesItem.from_dict(entries_item_data)
+
+
+
+            entries.append(entries_item)
+
+
+        description = d.pop("description", UNSET)
+
+        create_eval_dataset_body = cls(
+            name=name,
+            version=version,
+            entries=entries,
+            description=description,
+        )
+
+
+        create_eval_dataset_body.additional_properties = d
+        return create_eval_dataset_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item.py
@@ -14,8 +14,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
   from ..models.create_eval_dataset_body_entries_item_metadata import CreateEvalDatasetBodyEntriesItemMetadata
+  from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
 
 
 
@@ -50,8 +50,8 @@ class CreateEvalDatasetBodyEntriesItem:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
         from ..models.create_eval_dataset_body_entries_item_metadata import CreateEvalDatasetBodyEntriesItemMetadata
+        from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
         id = self.id
 
         input_: Union[Unset, Dict[str, Any]] = UNSET
@@ -100,8 +100,8 @@ class CreateEvalDatasetBodyEntriesItem:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
         from ..models.create_eval_dataset_body_entries_item_metadata import CreateEvalDatasetBodyEntriesItemMetadata
+        from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
         d = src_dict.copy()
         id = d.pop("id", UNSET)
 

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item.py
@@ -1,0 +1,167 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
+  from ..models.create_eval_dataset_body_entries_item_metadata import CreateEvalDatasetBodyEntriesItemMetadata
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetBodyEntriesItem")
+
+
+@_attrs_define
+class CreateEvalDatasetBodyEntriesItem:
+    """ 
+        Attributes:
+            id (Union[Unset, str]):
+            input_ (Union[Unset, CreateEvalDatasetBodyEntriesItemInput]):
+            expected_decision (Union[Unset, str]):
+            rule_id (Union[Unset, str]):
+            metadata (Union[Unset, CreateEvalDatasetBodyEntriesItemMetadata]):
+            source (Union[Unset, str]):
+            source_ref (Union[Unset, str]):
+            notes (Union[Unset, str]):
+     """
+
+    id: Union[Unset, str] = UNSET
+    input_: Union[Unset, 'CreateEvalDatasetBodyEntriesItemInput'] = UNSET
+    expected_decision: Union[Unset, str] = UNSET
+    rule_id: Union[Unset, str] = UNSET
+    metadata: Union[Unset, 'CreateEvalDatasetBodyEntriesItemMetadata'] = UNSET
+    source: Union[Unset, str] = UNSET
+    source_ref: Union[Unset, str] = UNSET
+    notes: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
+        from ..models.create_eval_dataset_body_entries_item_metadata import CreateEvalDatasetBodyEntriesItemMetadata
+        id = self.id
+
+        input_: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.input_, Unset):
+            input_ = self.input_.to_dict()
+
+        expected_decision = self.expected_decision
+
+        rule_id = self.rule_id
+
+        metadata: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        source = self.source
+
+        source_ref = self.source_ref
+
+        notes = self.notes
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if id is not UNSET:
+            field_dict["id"] = id
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+        if expected_decision is not UNSET:
+            field_dict["expected_decision"] = expected_decision
+        if rule_id is not UNSET:
+            field_dict["rule_id"] = rule_id
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if source is not UNSET:
+            field_dict["source"] = source
+        if source_ref is not UNSET:
+            field_dict["source_ref"] = source_ref
+        if notes is not UNSET:
+            field_dict["notes"] = notes
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.create_eval_dataset_body_entries_item_input import CreateEvalDatasetBodyEntriesItemInput
+        from ..models.create_eval_dataset_body_entries_item_metadata import CreateEvalDatasetBodyEntriesItemMetadata
+        d = src_dict.copy()
+        id = d.pop("id", UNSET)
+
+        _input_ = d.pop("input", UNSET)
+        input_: Union[Unset, CreateEvalDatasetBodyEntriesItemInput]
+        if isinstance(_input_,  Unset):
+            input_ = UNSET
+        else:
+            input_ = CreateEvalDatasetBodyEntriesItemInput.from_dict(_input_)
+
+
+
+
+        expected_decision = d.pop("expected_decision", UNSET)
+
+        rule_id = d.pop("rule_id", UNSET)
+
+        _metadata = d.pop("metadata", UNSET)
+        metadata: Union[Unset, CreateEvalDatasetBodyEntriesItemMetadata]
+        if isinstance(_metadata,  Unset):
+            metadata = UNSET
+        else:
+            metadata = CreateEvalDatasetBodyEntriesItemMetadata.from_dict(_metadata)
+
+
+
+
+        source = d.pop("source", UNSET)
+
+        source_ref = d.pop("source_ref", UNSET)
+
+        notes = d.pop("notes", UNSET)
+
+        create_eval_dataset_body_entries_item = cls(
+            id=id,
+            input_=input_,
+            expected_decision=expected_decision,
+            rule_id=rule_id,
+            metadata=metadata,
+            source=source,
+            source_ref=source_ref,
+            notes=notes,
+        )
+
+
+        create_eval_dataset_body_entries_item.additional_properties = d
+        return create_eval_dataset_body_entries_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item_input.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item_input.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetBodyEntriesItemInput")
+
+
+@_attrs_define
+class CreateEvalDatasetBodyEntriesItemInput:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        create_eval_dataset_body_entries_item_input = cls(
+        )
+
+
+        create_eval_dataset_body_entries_item_input.additional_properties = d
+        return create_eval_dataset_body_entries_item_input
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item_metadata.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_body_entries_item_metadata.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetBodyEntriesItemMetadata")
+
+
+@_attrs_define
+class CreateEvalDatasetBodyEntriesItemMetadata:
+    """ 
+     """
+
+    additional_properties: Dict[str, str] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        create_eval_dataset_body_entries_item_metadata = cls(
+        )
+
+
+        create_eval_dataset_body_entries_item_metadata.additional_properties = d
+        return create_eval_dataset_body_entries_item_metadata
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_from_incidents_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_from_incidents_body.py
@@ -1,0 +1,170 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast, List
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetFromIncidentsBody")
+
+
+@_attrs_define
+class CreateEvalDatasetFromIncidentsBody:
+    """ 
+        Attributes:
+            name (str):
+            tenant (Union[Unset, str]):
+            since (Union[Unset, str]):
+            until (Union[Unset, str]):
+            topic (Union[Unset, str]):
+            rule_id (Union[Unset, str]):
+            verdicts (Union[Unset, List[str]]):
+            agent_id (Union[Unset, str]):
+            max_entries (Union[Unset, int]):
+            description (Union[Unset, str]):
+            dry_run (Union[Unset, bool]):
+     """
+
+    name: str
+    tenant: Union[Unset, str] = UNSET
+    since: Union[Unset, str] = UNSET
+    until: Union[Unset, str] = UNSET
+    topic: Union[Unset, str] = UNSET
+    rule_id: Union[Unset, str] = UNSET
+    verdicts: Union[Unset, List[str]] = UNSET
+    agent_id: Union[Unset, str] = UNSET
+    max_entries: Union[Unset, int] = UNSET
+    description: Union[Unset, str] = UNSET
+    dry_run: Union[Unset, bool] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+
+        tenant = self.tenant
+
+        since = self.since
+
+        until = self.until
+
+        topic = self.topic
+
+        rule_id = self.rule_id
+
+        verdicts: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.verdicts, Unset):
+            verdicts = self.verdicts
+
+
+
+        agent_id = self.agent_id
+
+        max_entries = self.max_entries
+
+        description = self.description
+
+        dry_run = self.dry_run
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "name": name,
+        })
+        if tenant is not UNSET:
+            field_dict["tenant"] = tenant
+        if since is not UNSET:
+            field_dict["since"] = since
+        if until is not UNSET:
+            field_dict["until"] = until
+        if topic is not UNSET:
+            field_dict["topic"] = topic
+        if rule_id is not UNSET:
+            field_dict["rule_id"] = rule_id
+        if verdicts is not UNSET:
+            field_dict["verdicts"] = verdicts
+        if agent_id is not UNSET:
+            field_dict["agent_id"] = agent_id
+        if max_entries is not UNSET:
+            field_dict["max_entries"] = max_entries
+        if description is not UNSET:
+            field_dict["description"] = description
+        if dry_run is not UNSET:
+            field_dict["dry_run"] = dry_run
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name")
+
+        tenant = d.pop("tenant", UNSET)
+
+        since = d.pop("since", UNSET)
+
+        until = d.pop("until", UNSET)
+
+        topic = d.pop("topic", UNSET)
+
+        rule_id = d.pop("rule_id", UNSET)
+
+        verdicts = cast(List[str], d.pop("verdicts", UNSET))
+
+
+        agent_id = d.pop("agent_id", UNSET)
+
+        max_entries = d.pop("max_entries", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        dry_run = d.pop("dry_run", UNSET)
+
+        create_eval_dataset_from_incidents_body = cls(
+            name=name,
+            tenant=tenant,
+            since=since,
+            until=until,
+            topic=topic,
+            rule_id=rule_id,
+            verdicts=verdicts,
+            agent_id=agent_id,
+            max_entries=max_entries,
+            description=description,
+            dry_run=dry_run,
+        )
+
+
+        create_eval_dataset_from_incidents_body.additional_properties = d
+        return create_eval_dataset_from_incidents_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_from_incidents_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_from_incidents_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetFromIncidentsResponse200")
+
+
+@_attrs_define
+class CreateEvalDatasetFromIncidentsResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        create_eval_dataset_from_incidents_response_200 = cls(
+        )
+
+
+        create_eval_dataset_from_incidents_response_200.additional_properties = d
+        return create_eval_dataset_from_incidents_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_from_incidents_response_201.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_from_incidents_response_201.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetFromIncidentsResponse201")
+
+
+@_attrs_define
+class CreateEvalDatasetFromIncidentsResponse201:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        create_eval_dataset_from_incidents_response_201 = cls(
+        )
+
+
+        create_eval_dataset_from_incidents_response_201.additional_properties = d
+        return create_eval_dataset_from_incidents_response_201
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_response_201.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_response_201.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetResponse201")
+
+
+@_attrs_define
+class CreateEvalDatasetResponse201:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        create_eval_dataset_response_201 = cls(
+        )
+
+
+        create_eval_dataset_response_201.additional_properties = d
+        return create_eval_dataset_response_201
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_successor_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_successor_body.py
@@ -1,0 +1,115 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.create_eval_dataset_successor_body_entries_item import CreateEvalDatasetSuccessorBodyEntriesItem
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetSuccessorBody")
+
+
+@_attrs_define
+class CreateEvalDatasetSuccessorBody:
+    """ 
+        Attributes:
+            version (Union[Unset, int]):
+            description (Union[Unset, str]):
+            entries (Union[Unset, List['CreateEvalDatasetSuccessorBodyEntriesItem']]):
+     """
+
+    version: Union[Unset, int] = UNSET
+    description: Union[Unset, str] = UNSET
+    entries: Union[Unset, List['CreateEvalDatasetSuccessorBodyEntriesItem']] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.create_eval_dataset_successor_body_entries_item import CreateEvalDatasetSuccessorBodyEntriesItem
+        version = self.version
+
+        description = self.description
+
+        entries: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.entries, Unset):
+            entries = []
+            for entries_item_data in self.entries:
+                entries_item = entries_item_data.to_dict()
+                entries.append(entries_item)
+
+
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if version is not UNSET:
+            field_dict["version"] = version
+        if description is not UNSET:
+            field_dict["description"] = description
+        if entries is not UNSET:
+            field_dict["entries"] = entries
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.create_eval_dataset_successor_body_entries_item import CreateEvalDatasetSuccessorBodyEntriesItem
+        d = src_dict.copy()
+        version = d.pop("version", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        entries = []
+        _entries = d.pop("entries", UNSET)
+        for entries_item_data in (_entries or []):
+            entries_item = CreateEvalDatasetSuccessorBodyEntriesItem.from_dict(entries_item_data)
+
+
+
+            entries.append(entries_item)
+
+
+        create_eval_dataset_successor_body = cls(
+            version=version,
+            description=description,
+            entries=entries,
+        )
+
+
+        create_eval_dataset_successor_body.additional_properties = d
+        return create_eval_dataset_successor_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_successor_body_entries_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_successor_body_entries_item.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetSuccessorBodyEntriesItem")
+
+
+@_attrs_define
+class CreateEvalDatasetSuccessorBodyEntriesItem:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        create_eval_dataset_successor_body_entries_item = cls(
+        )
+
+
+        create_eval_dataset_successor_body_entries_item.additional_properties = d
+        return create_eval_dataset_successor_body_entries_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_successor_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/create_eval_dataset_successor_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="CreateEvalDatasetSuccessorResponse200")
+
+
+@_attrs_define
+class CreateEvalDatasetSuccessorResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        create_eval_dataset_successor_response_200 = cls(
+        )
+
+
+        create_eval_dataset_successor_response_200.additional_properties = d
+        return create_eval_dataset_successor_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/delegation_chain_link.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/delegation_chain_link.py
@@ -1,0 +1,137 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import cast, Union
+from typing import Union
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="DelegationChainLink")
+
+
+@_attrs_define
+class DelegationChainLink:
+    """ 
+        Attributes:
+            agent_id (str):
+            issued_at (datetime.datetime):
+            expires_at (datetime.datetime):
+            jti (str):
+            issued_by (str):
+            parent_jti (Union[None, Unset, str]):
+     """
+
+    agent_id: str
+    issued_at: datetime.datetime
+    expires_at: datetime.datetime
+    jti: str
+    issued_by: str
+    parent_jti: Union[None, Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        agent_id = self.agent_id
+
+        issued_at = self.issued_at.isoformat()
+
+        expires_at = self.expires_at.isoformat()
+
+        jti = self.jti
+
+        issued_by = self.issued_by
+
+        parent_jti: Union[None, Unset, str]
+        if isinstance(self.parent_jti, Unset):
+            parent_jti = UNSET
+        else:
+            parent_jti = self.parent_jti
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "agent_id": agent_id,
+            "issued_at": issued_at,
+            "expires_at": expires_at,
+            "jti": jti,
+            "issued_by": issued_by,
+        })
+        if parent_jti is not UNSET:
+            field_dict["parent_jti"] = parent_jti
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        agent_id = d.pop("agent_id")
+
+        issued_at = isoparse(d.pop("issued_at"))
+
+
+
+
+        expires_at = isoparse(d.pop("expires_at"))
+
+
+
+
+        jti = d.pop("jti")
+
+        issued_by = d.pop("issued_by")
+
+        def _parse_parent_jti(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        parent_jti = _parse_parent_jti(d.pop("parent_jti", UNSET))
+
+
+        delegation_chain_link = cls(
+            agent_id=agent_id,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            jti=jti,
+            issued_by=issued_by,
+            parent_jti=parent_jti,
+        )
+
+
+        delegation_chain_link.additional_properties = d
+        return delegation_chain_link
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/delegation_lineage_chain_link.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/delegation_lineage_chain_link.py
@@ -1,0 +1,134 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import Union
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="DelegationLineageChainLink")
+
+
+@_attrs_define
+class DelegationLineageChainLink:
+    """ 
+        Attributes:
+            agent_id (Union[Unset, str]):
+            issued_at (Union[Unset, datetime.datetime]):
+            expires_at (Union[Unset, datetime.datetime]):
+            jti (Union[Unset, str]):
+            parent_jti (Union[Unset, str]):
+     """
+
+    agent_id: Union[Unset, str] = UNSET
+    issued_at: Union[Unset, datetime.datetime] = UNSET
+    expires_at: Union[Unset, datetime.datetime] = UNSET
+    jti: Union[Unset, str] = UNSET
+    parent_jti: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        agent_id = self.agent_id
+
+        issued_at: Union[Unset, str] = UNSET
+        if not isinstance(self.issued_at, Unset):
+            issued_at = self.issued_at.isoformat()
+
+        expires_at: Union[Unset, str] = UNSET
+        if not isinstance(self.expires_at, Unset):
+            expires_at = self.expires_at.isoformat()
+
+        jti = self.jti
+
+        parent_jti = self.parent_jti
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if agent_id is not UNSET:
+            field_dict["agent_id"] = agent_id
+        if issued_at is not UNSET:
+            field_dict["issued_at"] = issued_at
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if jti is not UNSET:
+            field_dict["jti"] = jti
+        if parent_jti is not UNSET:
+            field_dict["parent_jti"] = parent_jti
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        agent_id = d.pop("agent_id", UNSET)
+
+        _issued_at = d.pop("issued_at", UNSET)
+        issued_at: Union[Unset, datetime.datetime]
+        if isinstance(_issued_at,  Unset):
+            issued_at = UNSET
+        else:
+            issued_at = isoparse(_issued_at)
+
+
+
+
+        _expires_at = d.pop("expires_at", UNSET)
+        expires_at: Union[Unset, datetime.datetime]
+        if isinstance(_expires_at,  Unset):
+            expires_at = UNSET
+        else:
+            expires_at = isoparse(_expires_at)
+
+
+
+
+        jti = d.pop("jti", UNSET)
+
+        parent_jti = d.pop("parent_jti", UNSET)
+
+        delegation_lineage_chain_link = cls(
+            agent_id=agent_id,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            jti=jti,
+            parent_jti=parent_jti,
+        )
+
+
+        delegation_lineage_chain_link.additional_properties = d
+        return delegation_lineage_chain_link
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/delegation_lineage_view.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/delegation_lineage_view.py
@@ -1,0 +1,195 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.delegation_lineage_chain_link import DelegationLineageChainLink
+
+
+
+
+
+T = TypeVar("T", bound="DelegationLineageView")
+
+
+@_attrs_define
+class DelegationLineageView:
+    """ 
+        Attributes:
+            jti (Union[Unset, str]):
+            audience (Union[Unset, str]):
+            root_issuer (Union[Unset, str]):
+            parent_issuer (Union[Unset, str]):
+            chain_depth (Union[Unset, int]):
+            chain (Union[Unset, List['DelegationLineageChainLink']]):
+            scope (Union[Unset, List[str]]):
+            expires_at (Union[Unset, datetime.datetime]):
+            verified_at (Union[Unset, int]):
+            reverified_at_dispatch (Union[Unset, bool]):
+     """
+
+    jti: Union[Unset, str] = UNSET
+    audience: Union[Unset, str] = UNSET
+    root_issuer: Union[Unset, str] = UNSET
+    parent_issuer: Union[Unset, str] = UNSET
+    chain_depth: Union[Unset, int] = UNSET
+    chain: Union[Unset, List['DelegationLineageChainLink']] = UNSET
+    scope: Union[Unset, List[str]] = UNSET
+    expires_at: Union[Unset, datetime.datetime] = UNSET
+    verified_at: Union[Unset, int] = UNSET
+    reverified_at_dispatch: Union[Unset, bool] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.delegation_lineage_chain_link import DelegationLineageChainLink
+        jti = self.jti
+
+        audience = self.audience
+
+        root_issuer = self.root_issuer
+
+        parent_issuer = self.parent_issuer
+
+        chain_depth = self.chain_depth
+
+        chain: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.chain, Unset):
+            chain = []
+            for chain_item_data in self.chain:
+                chain_item = chain_item_data.to_dict()
+                chain.append(chain_item)
+
+
+
+        scope: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.scope, Unset):
+            scope = self.scope
+
+
+
+        expires_at: Union[Unset, str] = UNSET
+        if not isinstance(self.expires_at, Unset):
+            expires_at = self.expires_at.isoformat()
+
+        verified_at = self.verified_at
+
+        reverified_at_dispatch = self.reverified_at_dispatch
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if jti is not UNSET:
+            field_dict["jti"] = jti
+        if audience is not UNSET:
+            field_dict["audience"] = audience
+        if root_issuer is not UNSET:
+            field_dict["root_issuer"] = root_issuer
+        if parent_issuer is not UNSET:
+            field_dict["parent_issuer"] = parent_issuer
+        if chain_depth is not UNSET:
+            field_dict["chain_depth"] = chain_depth
+        if chain is not UNSET:
+            field_dict["chain"] = chain
+        if scope is not UNSET:
+            field_dict["scope"] = scope
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if verified_at is not UNSET:
+            field_dict["verified_at"] = verified_at
+        if reverified_at_dispatch is not UNSET:
+            field_dict["reverified_at_dispatch"] = reverified_at_dispatch
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.delegation_lineage_chain_link import DelegationLineageChainLink
+        d = src_dict.copy()
+        jti = d.pop("jti", UNSET)
+
+        audience = d.pop("audience", UNSET)
+
+        root_issuer = d.pop("root_issuer", UNSET)
+
+        parent_issuer = d.pop("parent_issuer", UNSET)
+
+        chain_depth = d.pop("chain_depth", UNSET)
+
+        chain = []
+        _chain = d.pop("chain", UNSET)
+        for chain_item_data in (_chain or []):
+            chain_item = DelegationLineageChainLink.from_dict(chain_item_data)
+
+
+
+            chain.append(chain_item)
+
+
+        scope = cast(List[str], d.pop("scope", UNSET))
+
+
+        _expires_at = d.pop("expires_at", UNSET)
+        expires_at: Union[Unset, datetime.datetime]
+        if isinstance(_expires_at,  Unset):
+            expires_at = UNSET
+        else:
+            expires_at = isoparse(_expires_at)
+
+
+
+
+        verified_at = d.pop("verified_at", UNSET)
+
+        reverified_at_dispatch = d.pop("reverified_at_dispatch", UNSET)
+
+        delegation_lineage_view = cls(
+            jti=jti,
+            audience=audience,
+            root_issuer=root_issuer,
+            parent_issuer=parent_issuer,
+            chain_depth=chain_depth,
+            chain=chain,
+            scope=scope,
+            expires_at=expires_at,
+            verified_at=verified_at,
+            reverified_at_dispatch=reverified_at_dispatch,
+        )
+
+
+        delegation_lineage_view.additional_properties = d
+        return delegation_lineage_view
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/delegation_list_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/delegation_list_response.py
@@ -1,0 +1,116 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import cast, Union
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.delegation_view import DelegationView
+
+
+
+
+
+T = TypeVar("T", bound="DelegationListResponse")
+
+
+@_attrs_define
+class DelegationListResponse:
+    """ 
+        Attributes:
+            items (List['DelegationView']):
+            next_cursor (Union[None, Unset, str]):
+     """
+
+    items: List['DelegationView']
+    next_cursor: Union[None, Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.delegation_view import DelegationView
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+
+
+        next_cursor: Union[None, Unset, str]
+        if isinstance(self.next_cursor, Unset):
+            next_cursor = UNSET
+        else:
+            next_cursor = self.next_cursor
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "items": items,
+        })
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.delegation_view import DelegationView
+        d = src_dict.copy()
+        items = []
+        _items = d.pop("items")
+        for items_item_data in (_items):
+            items_item = DelegationView.from_dict(items_item_data)
+
+
+
+            items.append(items_item)
+
+
+        def _parse_next_cursor(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        next_cursor = _parse_next_cursor(d.pop("next_cursor", UNSET))
+
+
+        delegation_list_response = cls(
+            items=items,
+            next_cursor=next_cursor,
+        )
+
+
+        delegation_list_response.additional_properties = d
+        return delegation_list_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/delegation_view.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/delegation_view.py
@@ -1,0 +1,252 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import cast, List
+from typing import cast, Union
+from typing import Dict
+from typing import Union
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.delegation_chain_link import DelegationChainLink
+
+
+
+
+
+T = TypeVar("T", bound="DelegationView")
+
+
+@_attrs_define
+class DelegationView:
+    """ 
+        Attributes:
+            jti (str):
+            issuer (str): Root issuer for the delegation chain.
+            subject (str): Agent that issued the token.
+            audience (str): Target agent the token was minted for.
+            chain_depth (int):
+            issued_at (datetime.datetime):
+            expires_at (datetime.datetime):
+            revoked (bool):
+            allowed_actions (Union[Unset, List[str]]):
+            allowed_topics (Union[Unset, List[str]]):
+            chain (Union[Unset, List['DelegationChainLink']]):
+            revoked_at (Union[None, Unset, datetime.datetime]):
+            revoked_reason (Union[None, Unset, str]):
+     """
+
+    jti: str
+    issuer: str
+    subject: str
+    audience: str
+    chain_depth: int
+    issued_at: datetime.datetime
+    expires_at: datetime.datetime
+    revoked: bool
+    allowed_actions: Union[Unset, List[str]] = UNSET
+    allowed_topics: Union[Unset, List[str]] = UNSET
+    chain: Union[Unset, List['DelegationChainLink']] = UNSET
+    revoked_at: Union[None, Unset, datetime.datetime] = UNSET
+    revoked_reason: Union[None, Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.delegation_chain_link import DelegationChainLink
+        jti = self.jti
+
+        issuer = self.issuer
+
+        subject = self.subject
+
+        audience = self.audience
+
+        chain_depth = self.chain_depth
+
+        issued_at = self.issued_at.isoformat()
+
+        expires_at = self.expires_at.isoformat()
+
+        revoked = self.revoked
+
+        allowed_actions: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_actions, Unset):
+            allowed_actions = self.allowed_actions
+
+
+
+        allowed_topics: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_topics, Unset):
+            allowed_topics = self.allowed_topics
+
+
+
+        chain: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.chain, Unset):
+            chain = []
+            for chain_item_data in self.chain:
+                chain_item = chain_item_data.to_dict()
+                chain.append(chain_item)
+
+
+
+        revoked_at: Union[None, Unset, str]
+        if isinstance(self.revoked_at, Unset):
+            revoked_at = UNSET
+        elif isinstance(self.revoked_at, datetime.datetime):
+            revoked_at = self.revoked_at.isoformat()
+        else:
+            revoked_at = self.revoked_at
+
+        revoked_reason: Union[None, Unset, str]
+        if isinstance(self.revoked_reason, Unset):
+            revoked_reason = UNSET
+        else:
+            revoked_reason = self.revoked_reason
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "jti": jti,
+            "issuer": issuer,
+            "subject": subject,
+            "audience": audience,
+            "chain_depth": chain_depth,
+            "issued_at": issued_at,
+            "expires_at": expires_at,
+            "revoked": revoked,
+        })
+        if allowed_actions is not UNSET:
+            field_dict["allowed_actions"] = allowed_actions
+        if allowed_topics is not UNSET:
+            field_dict["allowed_topics"] = allowed_topics
+        if chain is not UNSET:
+            field_dict["chain"] = chain
+        if revoked_at is not UNSET:
+            field_dict["revoked_at"] = revoked_at
+        if revoked_reason is not UNSET:
+            field_dict["revoked_reason"] = revoked_reason
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.delegation_chain_link import DelegationChainLink
+        d = src_dict.copy()
+        jti = d.pop("jti")
+
+        issuer = d.pop("issuer")
+
+        subject = d.pop("subject")
+
+        audience = d.pop("audience")
+
+        chain_depth = d.pop("chain_depth")
+
+        issued_at = isoparse(d.pop("issued_at"))
+
+
+
+
+        expires_at = isoparse(d.pop("expires_at"))
+
+
+
+
+        revoked = d.pop("revoked")
+
+        allowed_actions = cast(List[str], d.pop("allowed_actions", UNSET))
+
+
+        allowed_topics = cast(List[str], d.pop("allowed_topics", UNSET))
+
+
+        chain = []
+        _chain = d.pop("chain", UNSET)
+        for chain_item_data in (_chain or []):
+            chain_item = DelegationChainLink.from_dict(chain_item_data)
+
+
+
+            chain.append(chain_item)
+
+
+        def _parse_revoked_at(data: object) -> Union[None, Unset, datetime.datetime]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                revoked_at_type_0 = isoparse(data)
+
+
+
+                return revoked_at_type_0
+            except: # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.datetime], data)
+
+        revoked_at = _parse_revoked_at(d.pop("revoked_at", UNSET))
+
+
+        def _parse_revoked_reason(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        revoked_reason = _parse_revoked_reason(d.pop("revoked_reason", UNSET))
+
+
+        delegation_view = cls(
+            jti=jti,
+            issuer=issuer,
+            subject=subject,
+            audience=audience,
+            chain_depth=chain_depth,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            revoked=revoked,
+            allowed_actions=allowed_actions,
+            allowed_topics=allowed_topics,
+            chain=chain,
+            revoked_at=revoked_at,
+            revoked_reason=revoked_reason,
+        )
+
+
+        delegation_view.additional_properties = d
+        return delegation_view
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/dry_run_workflow_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/dry_run_workflow_body.py
@@ -14,8 +14,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.dry_run_workflow_body_environment import DryRunWorkflowBodyEnvironment
   from ..models.dry_run_workflow_body_input import DryRunWorkflowBodyInput
+  from ..models.dry_run_workflow_body_environment import DryRunWorkflowBodyEnvironment
 
 
 
@@ -38,8 +38,8 @@ class DryRunWorkflowBody:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.dry_run_workflow_body_environment import DryRunWorkflowBodyEnvironment
         from ..models.dry_run_workflow_body_input import DryRunWorkflowBodyInput
+        from ..models.dry_run_workflow_body_environment import DryRunWorkflowBodyEnvironment
         input_: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.input_, Unset):
             input_ = self.input_.to_dict()
@@ -64,8 +64,8 @@ class DryRunWorkflowBody:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.dry_run_workflow_body_environment import DryRunWorkflowBodyEnvironment
         from ..models.dry_run_workflow_body_input import DryRunWorkflowBodyInput
+        from ..models.dry_run_workflow_body_environment import DryRunWorkflowBodyEnvironment
         d = src_dict.copy()
         _input_ = d.pop("input", UNSET)
         input_: Union[Unset, DryRunWorkflowBodyInput]

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result.py
@@ -1,0 +1,169 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..models.eval_entry_result_drift_direction import EvalEntryResultDriftDirection
+from ..models.eval_entry_result_status import EvalEntryResultStatus
+from ..types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.eval_entry_result_input import EvalEntryResultInput
+
+
+
+
+
+T = TypeVar("T", bound="EvalEntryResult")
+
+
+@_attrs_define
+class EvalEntryResult:
+    """ 
+        Attributes:
+            entry_id (str):
+            status (EvalEntryResultStatus): regression = expected was deny/require_approval/throttle/allow_with_constraints
+                AND actual is allow
+            drift_direction (EvalEntryResultDriftDirection):
+            input_ (Union[Unset, EvalEntryResultInput]):
+            expected_decision (Union[Unset, str]):
+            actual_decision (Union[Unset, str]):
+            rule_id (Union[Unset, str]):
+            reason (Union[Unset, str]):
+            error (Union[Unset, str]):
+     """
+
+    entry_id: str
+    status: EvalEntryResultStatus
+    drift_direction: EvalEntryResultDriftDirection
+    input_: Union[Unset, 'EvalEntryResultInput'] = UNSET
+    expected_decision: Union[Unset, str] = UNSET
+    actual_decision: Union[Unset, str] = UNSET
+    rule_id: Union[Unset, str] = UNSET
+    reason: Union[Unset, str] = UNSET
+    error: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.eval_entry_result_input import EvalEntryResultInput
+        entry_id = self.entry_id
+
+        status = self.status.value
+
+        drift_direction = self.drift_direction.value
+
+        input_: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.input_, Unset):
+            input_ = self.input_.to_dict()
+
+        expected_decision = self.expected_decision
+
+        actual_decision = self.actual_decision
+
+        rule_id = self.rule_id
+
+        reason = self.reason
+
+        error = self.error
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "entry_id": entry_id,
+            "status": status,
+            "drift_direction": drift_direction,
+        })
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+        if expected_decision is not UNSET:
+            field_dict["expected_decision"] = expected_decision
+        if actual_decision is not UNSET:
+            field_dict["actual_decision"] = actual_decision
+        if rule_id is not UNSET:
+            field_dict["rule_id"] = rule_id
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+        if error is not UNSET:
+            field_dict["error"] = error
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.eval_entry_result_input import EvalEntryResultInput
+        d = src_dict.copy()
+        entry_id = d.pop("entry_id")
+
+        status = EvalEntryResultStatus(d.pop("status"))
+
+
+
+
+        drift_direction = EvalEntryResultDriftDirection(d.pop("drift_direction"))
+
+
+
+
+        _input_ = d.pop("input", UNSET)
+        input_: Union[Unset, EvalEntryResultInput]
+        if isinstance(_input_,  Unset):
+            input_ = UNSET
+        else:
+            input_ = EvalEntryResultInput.from_dict(_input_)
+
+
+
+
+        expected_decision = d.pop("expected_decision", UNSET)
+
+        actual_decision = d.pop("actual_decision", UNSET)
+
+        rule_id = d.pop("rule_id", UNSET)
+
+        reason = d.pop("reason", UNSET)
+
+        error = d.pop("error", UNSET)
+
+        eval_entry_result = cls(
+            entry_id=entry_id,
+            status=status,
+            drift_direction=drift_direction,
+            input_=input_,
+            expected_decision=expected_decision,
+            actual_decision=actual_decision,
+            rule_id=rule_id,
+            reason=reason,
+            error=error,
+        )
+
+
+        eval_entry_result.additional_properties = d
+        return eval_entry_result
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result_drift_direction.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result_drift_direction.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class EvalEntryResultDriftDirection(str, Enum):
+    ESCALATED = "escalated"
+    RELAXED = "relaxed"
+    UNCHANGED = "unchanged"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result_input.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result_input.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="EvalEntryResultInput")
+
+
+@_attrs_define
+class EvalEntryResultInput:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        eval_entry_result_input = cls(
+        )
+
+
+        eval_entry_result_input.additional_properties = d
+        return eval_entry_result_input
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result_status.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_entry_result_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class EvalEntryResultStatus(str, Enum):
+    ERROR = "error"
+    FAIL = "fail"
+    PASS = "pass"
+    REGRESSION = "regression"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_run_accepted_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_run_accepted_response.py
@@ -1,0 +1,194 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..models.eval_run_accepted_response_status import EvalRunAcceptedResponseStatus
+from ..types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import Union
+from uuid import UUID
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="EvalRunAcceptedResponse")
+
+
+@_attrs_define
+class EvalRunAcceptedResponse:
+    """ 
+        Attributes:
+            run_id (UUID):
+            status (EvalRunAcceptedResponseStatus):
+            poll_url (Union[Unset, str]):
+            dataset_id (Union[Unset, str]):
+            dataset_name (Union[Unset, str]):
+            dataset_version (Union[Unset, int]):
+            tenant (Union[Unset, str]):
+            started_at (Union[Unset, datetime.datetime]):
+            completed_at (Union[Unset, datetime.datetime]):
+            policy_snapshot (Union[Unset, str]):
+            error (Union[Unset, str]):
+     """
+
+    run_id: UUID
+    status: EvalRunAcceptedResponseStatus
+    poll_url: Union[Unset, str] = UNSET
+    dataset_id: Union[Unset, str] = UNSET
+    dataset_name: Union[Unset, str] = UNSET
+    dataset_version: Union[Unset, int] = UNSET
+    tenant: Union[Unset, str] = UNSET
+    started_at: Union[Unset, datetime.datetime] = UNSET
+    completed_at: Union[Unset, datetime.datetime] = UNSET
+    policy_snapshot: Union[Unset, str] = UNSET
+    error: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        run_id = str(self.run_id)
+
+        status = self.status.value
+
+        poll_url = self.poll_url
+
+        dataset_id = self.dataset_id
+
+        dataset_name = self.dataset_name
+
+        dataset_version = self.dataset_version
+
+        tenant = self.tenant
+
+        started_at: Union[Unset, str] = UNSET
+        if not isinstance(self.started_at, Unset):
+            started_at = self.started_at.isoformat()
+
+        completed_at: Union[Unset, str] = UNSET
+        if not isinstance(self.completed_at, Unset):
+            completed_at = self.completed_at.isoformat()
+
+        policy_snapshot = self.policy_snapshot
+
+        error = self.error
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "run_id": run_id,
+            "status": status,
+        })
+        if poll_url is not UNSET:
+            field_dict["poll_url"] = poll_url
+        if dataset_id is not UNSET:
+            field_dict["dataset_id"] = dataset_id
+        if dataset_name is not UNSET:
+            field_dict["dataset_name"] = dataset_name
+        if dataset_version is not UNSET:
+            field_dict["dataset_version"] = dataset_version
+        if tenant is not UNSET:
+            field_dict["tenant"] = tenant
+        if started_at is not UNSET:
+            field_dict["started_at"] = started_at
+        if completed_at is not UNSET:
+            field_dict["completed_at"] = completed_at
+        if policy_snapshot is not UNSET:
+            field_dict["policy_snapshot"] = policy_snapshot
+        if error is not UNSET:
+            field_dict["error"] = error
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        run_id = UUID(d.pop("run_id"))
+
+
+
+
+        status = EvalRunAcceptedResponseStatus(d.pop("status"))
+
+
+
+
+        poll_url = d.pop("poll_url", UNSET)
+
+        dataset_id = d.pop("dataset_id", UNSET)
+
+        dataset_name = d.pop("dataset_name", UNSET)
+
+        dataset_version = d.pop("dataset_version", UNSET)
+
+        tenant = d.pop("tenant", UNSET)
+
+        _started_at = d.pop("started_at", UNSET)
+        started_at: Union[Unset, datetime.datetime]
+        if isinstance(_started_at,  Unset):
+            started_at = UNSET
+        else:
+            started_at = isoparse(_started_at)
+
+
+
+
+        _completed_at = d.pop("completed_at", UNSET)
+        completed_at: Union[Unset, datetime.datetime]
+        if isinstance(_completed_at,  Unset):
+            completed_at = UNSET
+        else:
+            completed_at = isoparse(_completed_at)
+
+
+
+
+        policy_snapshot = d.pop("policy_snapshot", UNSET)
+
+        error = d.pop("error", UNSET)
+
+        eval_run_accepted_response = cls(
+            run_id=run_id,
+            status=status,
+            poll_url=poll_url,
+            dataset_id=dataset_id,
+            dataset_name=dataset_name,
+            dataset_version=dataset_version,
+            tenant=tenant,
+            started_at=started_at,
+            completed_at=completed_at,
+            policy_snapshot=policy_snapshot,
+            error=error,
+        )
+
+
+        eval_run_accepted_response.additional_properties = d
+        return eval_run_accepted_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_run_accepted_response_status.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_run_accepted_response_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class EvalRunAcceptedResponseStatus(str, Enum):
+    FAILED = "failed"
+    PENDING = "pending"
+    RUNNING = "running"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_run_request.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_run_request.py
@@ -1,0 +1,102 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="EvalRunRequest")
+
+
+@_attrs_define
+class EvalRunRequest:
+    """ 
+        Attributes:
+            use_current_policy (Union[Unset, bool]):
+            candidate_bundle_id (Union[Unset, str]):
+            candidate_content (Union[Unset, str]):
+            max_entries (Union[Unset, int]):
+     """
+
+    use_current_policy: Union[Unset, bool] = UNSET
+    candidate_bundle_id: Union[Unset, str] = UNSET
+    candidate_content: Union[Unset, str] = UNSET
+    max_entries: Union[Unset, int] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        use_current_policy = self.use_current_policy
+
+        candidate_bundle_id = self.candidate_bundle_id
+
+        candidate_content = self.candidate_content
+
+        max_entries = self.max_entries
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if use_current_policy is not UNSET:
+            field_dict["use_current_policy"] = use_current_policy
+        if candidate_bundle_id is not UNSET:
+            field_dict["candidate_bundle_id"] = candidate_bundle_id
+        if candidate_content is not UNSET:
+            field_dict["candidate_content"] = candidate_content
+        if max_entries is not UNSET:
+            field_dict["max_entries"] = max_entries
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        use_current_policy = d.pop("use_current_policy", UNSET)
+
+        candidate_bundle_id = d.pop("candidate_bundle_id", UNSET)
+
+        candidate_content = d.pop("candidate_content", UNSET)
+
+        max_entries = d.pop("max_entries", UNSET)
+
+        eval_run_request = cls(
+            use_current_policy=use_current_policy,
+            candidate_bundle_id=candidate_bundle_id,
+            candidate_content=candidate_content,
+            max_entries=max_entries,
+        )
+
+
+        eval_run_request.additional_properties = d
+        return eval_run_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_run_result.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_run_result.py
@@ -16,8 +16,8 @@ from uuid import UUID
 import datetime
 
 if TYPE_CHECKING:
-  from ..models.eval_run_summary import EvalRunSummary
   from ..models.eval_entry_result import EvalEntryResult
+  from ..models.eval_run_summary import EvalRunSummary
 
 
 
@@ -56,8 +56,8 @@ class EvalRunResult:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.eval_run_summary import EvalRunSummary
         from ..models.eval_entry_result import EvalEntryResult
+        from ..models.eval_run_summary import EvalRunSummary
         run_id = str(self.run_id)
 
         dataset_id = self.dataset_id
@@ -105,8 +105,8 @@ class EvalRunResult:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.eval_run_summary import EvalRunSummary
         from ..models.eval_entry_result import EvalEntryResult
+        from ..models.eval_run_summary import EvalRunSummary
         d = src_dict.copy()
         run_id = UUID(d.pop("run_id"))
 

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_run_result.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_run_result.py
@@ -1,0 +1,182 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from uuid import UUID
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.eval_run_summary import EvalRunSummary
+  from ..models.eval_entry_result import EvalEntryResult
+
+
+
+
+
+T = TypeVar("T", bound="EvalRunResult")
+
+
+@_attrs_define
+class EvalRunResult:
+    """ 
+        Attributes:
+            run_id (UUID):
+            dataset_id (str):
+            dataset_name (str):
+            dataset_version (int):
+            tenant (str):
+            policy_snapshot (str):
+            started_at (datetime.datetime):
+            completed_at (datetime.datetime):
+            summary (EvalRunSummary):
+            entries (List['EvalEntryResult']):
+     """
+
+    run_id: UUID
+    dataset_id: str
+    dataset_name: str
+    dataset_version: int
+    tenant: str
+    policy_snapshot: str
+    started_at: datetime.datetime
+    completed_at: datetime.datetime
+    summary: 'EvalRunSummary'
+    entries: List['EvalEntryResult']
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.eval_run_summary import EvalRunSummary
+        from ..models.eval_entry_result import EvalEntryResult
+        run_id = str(self.run_id)
+
+        dataset_id = self.dataset_id
+
+        dataset_name = self.dataset_name
+
+        dataset_version = self.dataset_version
+
+        tenant = self.tenant
+
+        policy_snapshot = self.policy_snapshot
+
+        started_at = self.started_at.isoformat()
+
+        completed_at = self.completed_at.isoformat()
+
+        summary = self.summary.to_dict()
+
+        entries = []
+        for entries_item_data in self.entries:
+            entries_item = entries_item_data.to_dict()
+            entries.append(entries_item)
+
+
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "run_id": run_id,
+            "dataset_id": dataset_id,
+            "dataset_name": dataset_name,
+            "dataset_version": dataset_version,
+            "tenant": tenant,
+            "policy_snapshot": policy_snapshot,
+            "started_at": started_at,
+            "completed_at": completed_at,
+            "summary": summary,
+            "entries": entries,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.eval_run_summary import EvalRunSummary
+        from ..models.eval_entry_result import EvalEntryResult
+        d = src_dict.copy()
+        run_id = UUID(d.pop("run_id"))
+
+
+
+
+        dataset_id = d.pop("dataset_id")
+
+        dataset_name = d.pop("dataset_name")
+
+        dataset_version = d.pop("dataset_version")
+
+        tenant = d.pop("tenant")
+
+        policy_snapshot = d.pop("policy_snapshot")
+
+        started_at = isoparse(d.pop("started_at"))
+
+
+
+
+        completed_at = isoparse(d.pop("completed_at"))
+
+
+
+
+        summary = EvalRunSummary.from_dict(d.pop("summary"))
+
+
+
+
+        entries = []
+        _entries = d.pop("entries")
+        for entries_item_data in (_entries):
+            entries_item = EvalEntryResult.from_dict(entries_item_data)
+
+
+
+            entries.append(entries_item)
+
+
+        eval_run_result = cls(
+            run_id=run_id,
+            dataset_id=dataset_id,
+            dataset_name=dataset_name,
+            dataset_version=dataset_version,
+            tenant=tenant,
+            policy_snapshot=policy_snapshot,
+            started_at=started_at,
+            completed_at=completed_at,
+            summary=summary,
+            entries=entries,
+        )
+
+
+        eval_run_result.additional_properties = d
+        return eval_run_result
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_run_summary.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_run_summary.py
@@ -1,0 +1,128 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast, Union
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="EvalRunSummary")
+
+
+@_attrs_define
+class EvalRunSummary:
+    """ 
+        Attributes:
+            total (int):
+            passed (int):
+            failed (int):
+            regressions (int):
+            errored (int):
+            score_percent (Union[None, Unset, float]):
+     """
+
+    total: int
+    passed: int
+    failed: int
+    regressions: int
+    errored: int
+    score_percent: Union[None, Unset, float] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        total = self.total
+
+        passed = self.passed
+
+        failed = self.failed
+
+        regressions = self.regressions
+
+        errored = self.errored
+
+        score_percent: Union[None, Unset, float]
+        if isinstance(self.score_percent, Unset):
+            score_percent = UNSET
+        else:
+            score_percent = self.score_percent
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "total": total,
+            "passed": passed,
+            "failed": failed,
+            "regressions": regressions,
+            "errored": errored,
+        })
+        if score_percent is not UNSET:
+            field_dict["score_percent"] = score_percent
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        total = d.pop("total")
+
+        passed = d.pop("passed")
+
+        failed = d.pop("failed")
+
+        regressions = d.pop("regressions")
+
+        errored = d.pop("errored")
+
+        def _parse_score_percent(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        score_percent = _parse_score_percent(d.pop("score_percent", UNSET))
+
+
+        eval_run_summary = cls(
+            total=total,
+            passed=passed,
+            failed=failed,
+            regressions=regressions,
+            errored=errored,
+            score_percent=score_percent,
+        )
+
+
+        eval_run_summary.additional_properties = d
+        return eval_run_summary
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/eval_runs_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/eval_runs_response.py
@@ -1,0 +1,103 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.eval_run_result import EvalRunResult
+
+
+
+
+
+T = TypeVar("T", bound="EvalRunsResponse")
+
+
+@_attrs_define
+class EvalRunsResponse:
+    """ 
+        Attributes:
+            items (List['EvalRunResult']):
+            next_cursor (Union[Unset, str]):
+     """
+
+    items: List['EvalRunResult']
+    next_cursor: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.eval_run_result import EvalRunResult
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+
+
+        next_cursor = self.next_cursor
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "items": items,
+        })
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.eval_run_result import EvalRunResult
+        d = src_dict.copy()
+        items = []
+        _items = d.pop("items")
+        for items_item_data in (_items):
+            items_item = EvalRunResult.from_dict(items_item_data)
+
+
+
+            items.append(items_item)
+
+
+        next_cursor = d.pop("next_cursor", UNSET)
+
+        eval_runs_response = cls(
+            items=items,
+            next_cursor=next_cursor,
+        )
+
+
+        eval_runs_response.additional_properties = d
+        return eval_runs_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/get_agent_denied_events_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_agent_denied_events_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="GetAgentDeniedEventsResponse200")
+
+
+@_attrs_define
+class GetAgentDeniedEventsResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        get_agent_denied_events_response_200 = cls(
+        )
+
+
+        get_agent_denied_events_response_200.additional_properties = d
+        return get_agent_denied_events_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/get_agent_tool_visibility_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_agent_tool_visibility_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="GetAgentToolVisibilityResponse200")
+
+
+@_attrs_define
+class GetAgentToolVisibilityResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        get_agent_tool_visibility_response_200 = cls(
+        )
+
+
+        get_agent_tool_visibility_response_200.additional_properties = d
+        return get_agent_tool_visibility_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/get_approval_analytics_group_by.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_approval_analytics_group_by.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class GetApprovalAnalyticsGroupBy(str, Enum):
+    AGENT = "agent"
+    OVERALL = "overall"
+    RULE = "rule"
+    TOPIC = "topic"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/get_approval_analytics_window.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_approval_analytics_window.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class GetApprovalAnalyticsWindow(str, Enum):
+    VALUE_0 = "24h"
+    VALUE_1 = "7d"
+    VALUE_2 = "30d"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/get_approval_context_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_approval_context_response_200.py
@@ -16,11 +16,11 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
-  from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
   from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
-  from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+  from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
   from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
+  from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+  from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
 
 
 
@@ -55,11 +55,11 @@ class GetApprovalContextResponse200:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
-        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
         from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
-        from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
         from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
+        from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+        from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
         approval: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.approval, Unset):
             approval = self.approval.to_dict()
@@ -123,11 +123,11 @@ class GetApprovalContextResponse200:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
-        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
         from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
-        from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
         from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
+        from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+        from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
         d = src_dict.copy()
         _approval = d.pop("approval", UNSET)
         approval: Union[Unset, GetApprovalContextResponse200Approval]

--- a/sdk/python/src/cordum_sdk/_generated/models/get_approval_context_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_approval_context_response_200.py
@@ -16,11 +16,11 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
-  from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
-  from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
   from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
+  from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
+  from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
   from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+  from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
 
 
 
@@ -55,11 +55,11 @@ class GetApprovalContextResponse200:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
-        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
-        from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
         from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
+        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
+        from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
         from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+        from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
         approval: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.approval, Unset):
             approval = self.approval.to_dict()
@@ -123,11 +123,11 @@ class GetApprovalContextResponse200:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
-        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
-        from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
         from ..models.get_approval_context_response_200_policy_snapshot_summary import GetApprovalContextResponse200PolicySnapshotSummary
+        from ..models.get_approval_context_response_200_prior_approvals_item import GetApprovalContextResponse200PriorApprovalsItem
+        from ..models.get_approval_context_response_200_blast_radius import GetApprovalContextResponse200BlastRadius
         from ..models.get_approval_context_response_200_approval import GetApprovalContextResponse200Approval
+        from ..models.get_approval_context_response_200_constraints_type_0 import GetApprovalContextResponse200ConstraintsType0
         d = src_dict.copy()
         _approval = d.pop("approval", UNSET)
         approval: Union[Unset, GetApprovalContextResponse200Approval]

--- a/sdk/python/src/cordum_sdk/_generated/models/get_eval_dataset_by_name_version_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_eval_dataset_by_name_version_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="GetEvalDatasetByNameVersionResponse200")
+
+
+@_attrs_define
+class GetEvalDatasetByNameVersionResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        get_eval_dataset_by_name_version_response_200 = cls(
+        )
+
+
+        get_eval_dataset_by_name_version_response_200.additional_properties = d
+        return get_eval_dataset_by_name_version_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/get_eval_dataset_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_eval_dataset_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="GetEvalDatasetResponse200")
+
+
+@_attrs_define
+class GetEvalDatasetResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        get_eval_dataset_response_200 = cls(
+        )
+
+
+        get_eval_dataset_response_200.additional_properties = d
+        return get_eval_dataset_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/get_mcp_approval_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_mcp_approval_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="GetMcpApprovalResponse200")
+
+
+@_attrs_define
+class GetMcpApprovalResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        get_mcp_approval_response_200 = cls(
+        )
+
+
+        get_mcp_approval_response_200.additional_properties = d
+        return get_mcp_approval_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/get_mcp_usage_group_by.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_mcp_usage_group_by.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class GetMcpUsageGroupBy(str, Enum):
+    METHOD = "method"
+    SUBJECT = "subject"
+    TOOL = "tool"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/get_mcp_usage_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/get_mcp_usage_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="GetMcpUsageResponse200")
+
+
+@_attrs_define
+class GetMcpUsageResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        get_mcp_usage_response_200 = cls(
+        )
+
+
+        get_mcp_usage_response_200.additional_properties = d
+        return get_mcp_usage_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/installed_pack_verification.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/installed_pack_verification.py
@@ -1,0 +1,179 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..models.installed_pack_verification_signature_algorithm import InstalledPackVerificationSignatureAlgorithm
+from ..types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import cast, List
+from typing import Union
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="InstalledPackVerification")
+
+
+@_attrs_define
+class InstalledPackVerification:
+    """ Pack-signature verification outcome computed by the gateway at
+    install time. Never client-supplied — the gateway discards any
+    `verification` field on the install payload and computes its own.
+    Pre-existing installs default to {signed: false} when this object
+    is absent.
+
+        Attributes:
+            signed (bool): True when the gateway successfully verified the pack against
+                a trusted publisher key at install time.
+            publisher_id (Union[Unset, str]): Publisher identifier derived from the trusted key's metadata.
+            kid (Union[Unset, str]): Key id of the Ed25519 public key that verified the pack.
+            verified_at (Union[Unset, datetime.datetime]): RFC3339 timestamp of the server-side verification.
+            has_cordum_counter_sig (Union[Unset, bool]): True when a valid Cordum counter-signature envelope
+                (pack.yaml.sig.cordum) is present and verified against the
+                embedded Cordum counter-signing key.
+            signature_algorithm (Union[Unset, InstalledPackVerificationSignatureAlgorithm]): Algorithm advertised by the
+                verified envelope. Always ed25519 today.
+            pack_signature_version (Union[Unset, int]): Canonical manifest version that was signed.
+            warnings (Union[Unset, List[str]]): Non-fatal warnings the gateway wants to surface alongside the
+                verification outcome (for example, "pack accepted unsigned —
+                gateway strict mode disabled").
+     """
+
+    signed: bool
+    publisher_id: Union[Unset, str] = UNSET
+    kid: Union[Unset, str] = UNSET
+    verified_at: Union[Unset, datetime.datetime] = UNSET
+    has_cordum_counter_sig: Union[Unset, bool] = UNSET
+    signature_algorithm: Union[Unset, InstalledPackVerificationSignatureAlgorithm] = UNSET
+    pack_signature_version: Union[Unset, int] = UNSET
+    warnings: Union[Unset, List[str]] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        signed = self.signed
+
+        publisher_id = self.publisher_id
+
+        kid = self.kid
+
+        verified_at: Union[Unset, str] = UNSET
+        if not isinstance(self.verified_at, Unset):
+            verified_at = self.verified_at.isoformat()
+
+        has_cordum_counter_sig = self.has_cordum_counter_sig
+
+        signature_algorithm: Union[Unset, str] = UNSET
+        if not isinstance(self.signature_algorithm, Unset):
+            signature_algorithm = self.signature_algorithm.value
+
+
+        pack_signature_version = self.pack_signature_version
+
+        warnings: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.warnings, Unset):
+            warnings = self.warnings
+
+
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "signed": signed,
+        })
+        if publisher_id is not UNSET:
+            field_dict["publisher_id"] = publisher_id
+        if kid is not UNSET:
+            field_dict["kid"] = kid
+        if verified_at is not UNSET:
+            field_dict["verified_at"] = verified_at
+        if has_cordum_counter_sig is not UNSET:
+            field_dict["has_cordum_counter_sig"] = has_cordum_counter_sig
+        if signature_algorithm is not UNSET:
+            field_dict["signature_algorithm"] = signature_algorithm
+        if pack_signature_version is not UNSET:
+            field_dict["pack_signature_version"] = pack_signature_version
+        if warnings is not UNSET:
+            field_dict["warnings"] = warnings
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        signed = d.pop("signed")
+
+        publisher_id = d.pop("publisher_id", UNSET)
+
+        kid = d.pop("kid", UNSET)
+
+        _verified_at = d.pop("verified_at", UNSET)
+        verified_at: Union[Unset, datetime.datetime]
+        if isinstance(_verified_at,  Unset):
+            verified_at = UNSET
+        else:
+            verified_at = isoparse(_verified_at)
+
+
+
+
+        has_cordum_counter_sig = d.pop("has_cordum_counter_sig", UNSET)
+
+        _signature_algorithm = d.pop("signature_algorithm", UNSET)
+        signature_algorithm: Union[Unset, InstalledPackVerificationSignatureAlgorithm]
+        if isinstance(_signature_algorithm,  Unset):
+            signature_algorithm = UNSET
+        else:
+            signature_algorithm = InstalledPackVerificationSignatureAlgorithm(_signature_algorithm)
+
+
+
+
+        pack_signature_version = d.pop("pack_signature_version", UNSET)
+
+        warnings = cast(List[str], d.pop("warnings", UNSET))
+
+
+        installed_pack_verification = cls(
+            signed=signed,
+            publisher_id=publisher_id,
+            kid=kid,
+            verified_at=verified_at,
+            has_cordum_counter_sig=has_cordum_counter_sig,
+            signature_algorithm=signature_algorithm,
+            pack_signature_version=pack_signature_version,
+            warnings=warnings,
+        )
+
+
+        installed_pack_verification.additional_properties = d
+        return installed_pack_verification
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/installed_pack_verification_signature_algorithm.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/installed_pack_verification_signature_algorithm.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+class InstalledPackVerificationSignatureAlgorithm(str, Enum):
+    ED25519 = "ed25519"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/issue_delegation_token_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/issue_delegation_token_body.py
@@ -1,0 +1,121 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast, List
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="IssueDelegationTokenBody")
+
+
+@_attrs_define
+class IssueDelegationTokenBody:
+    """ 
+        Attributes:
+            target_agent_id (str):
+            allowed_actions (Union[Unset, List[str]]):
+            allowed_topics (Union[Unset, List[str]]):
+            ttl_seconds (Union[Unset, int]):
+            parent_token (Union[Unset, str]):
+     """
+
+    target_agent_id: str
+    allowed_actions: Union[Unset, List[str]] = UNSET
+    allowed_topics: Union[Unset, List[str]] = UNSET
+    ttl_seconds: Union[Unset, int] = UNSET
+    parent_token: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        target_agent_id = self.target_agent_id
+
+        allowed_actions: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_actions, Unset):
+            allowed_actions = self.allowed_actions
+
+
+
+        allowed_topics: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_topics, Unset):
+            allowed_topics = self.allowed_topics
+
+
+
+        ttl_seconds = self.ttl_seconds
+
+        parent_token = self.parent_token
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "target_agent_id": target_agent_id,
+        })
+        if allowed_actions is not UNSET:
+            field_dict["allowed_actions"] = allowed_actions
+        if allowed_topics is not UNSET:
+            field_dict["allowed_topics"] = allowed_topics
+        if ttl_seconds is not UNSET:
+            field_dict["ttl_seconds"] = ttl_seconds
+        if parent_token is not UNSET:
+            field_dict["parent_token"] = parent_token
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        target_agent_id = d.pop("target_agent_id")
+
+        allowed_actions = cast(List[str], d.pop("allowed_actions", UNSET))
+
+
+        allowed_topics = cast(List[str], d.pop("allowed_topics", UNSET))
+
+
+        ttl_seconds = d.pop("ttl_seconds", UNSET)
+
+        parent_token = d.pop("parent_token", UNSET)
+
+        issue_delegation_token_body = cls(
+            target_agent_id=target_agent_id,
+            allowed_actions=allowed_actions,
+            allowed_topics=allowed_topics,
+            ttl_seconds=ttl_seconds,
+            parent_token=parent_token,
+        )
+
+
+        issue_delegation_token_body.additional_properties = d
+        return issue_delegation_token_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/issue_delegation_token_response_201.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/issue_delegation_token_response_201.py
@@ -1,0 +1,111 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="IssueDelegationTokenResponse201")
+
+
+@_attrs_define
+class IssueDelegationTokenResponse201:
+    """ 
+        Attributes:
+            token (Union[Unset, str]):
+            kid (Union[Unset, str]):
+            expires_at (Union[Unset, str]):
+            chain_depth (Union[Unset, int]):
+            jti (Union[Unset, str]):
+     """
+
+    token: Union[Unset, str] = UNSET
+    kid: Union[Unset, str] = UNSET
+    expires_at: Union[Unset, str] = UNSET
+    chain_depth: Union[Unset, int] = UNSET
+    jti: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        token = self.token
+
+        kid = self.kid
+
+        expires_at = self.expires_at
+
+        chain_depth = self.chain_depth
+
+        jti = self.jti
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if token is not UNSET:
+            field_dict["token"] = token
+        if kid is not UNSET:
+            field_dict["kid"] = kid
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if chain_depth is not UNSET:
+            field_dict["chain_depth"] = chain_depth
+        if jti is not UNSET:
+            field_dict["jti"] = jti
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        token = d.pop("token", UNSET)
+
+        kid = d.pop("kid", UNSET)
+
+        expires_at = d.pop("expires_at", UNSET)
+
+        chain_depth = d.pop("chain_depth", UNSET)
+
+        jti = d.pop("jti", UNSET)
+
+        issue_delegation_token_response_201 = cls(
+            token=token,
+            kid=kid,
+            expires_at=expires_at,
+            chain_depth=chain_depth,
+            jti=jti,
+        )
+
+
+        issue_delegation_token_response_201.additional_properties = d
+        return issue_delegation_token_response_201
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/job_detail.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/job_detail.py
@@ -18,10 +18,10 @@ from typing import Union
 import datetime
 
 if TYPE_CHECKING:
-  from ..models.delegation_lineage_view import DelegationLineageView
+  from ..models.job_detail_result_type_0 import JobDetailResultType0
   from ..models.safety_decision import SafetyDecision
   from ..models.job_detail_labels import JobDetailLabels
-  from ..models.job_detail_result_type_0 import JobDetailResultType0
+  from ..models.delegation_lineage_view import DelegationLineageView
 
 
 
@@ -84,10 +84,10 @@ class JobDetail:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.delegation_lineage_view import DelegationLineageView
+        from ..models.job_detail_result_type_0 import JobDetailResultType0
         from ..models.safety_decision import SafetyDecision
         from ..models.job_detail_labels import JobDetailLabels
-        from ..models.job_detail_result_type_0 import JobDetailResultType0
+        from ..models.delegation_lineage_view import DelegationLineageView
         id = self.id
 
         state = self.state
@@ -241,10 +241,10 @@ class JobDetail:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.delegation_lineage_view import DelegationLineageView
+        from ..models.job_detail_result_type_0 import JobDetailResultType0
         from ..models.safety_decision import SafetyDecision
         from ..models.job_detail_labels import JobDetailLabels
-        from ..models.job_detail_result_type_0 import JobDetailResultType0
+        from ..models.delegation_lineage_view import DelegationLineageView
         d = src_dict.copy()
         id = d.pop("id", UNSET)
 

--- a/sdk/python/src/cordum_sdk/_generated/models/job_detail.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/job_detail.py
@@ -18,6 +18,7 @@ from typing import Union
 import datetime
 
 if TYPE_CHECKING:
+  from ..models.delegation_lineage_view import DelegationLineageView
   from ..models.safety_decision import SafetyDecision
   from ..models.job_detail_labels import JobDetailLabels
   from ..models.job_detail_result_type_0 import JobDetailResultType0
@@ -54,6 +55,7 @@ class JobDetail:
             error (Union[None, Unset, str]):
             retry_count (Union[Unset, int]):
             decisions (Union[List['SafetyDecision'], None, Unset]):
+            delegation (Union[Unset, DelegationLineageView]):
      """
 
     id: Union[Unset, str] = UNSET
@@ -77,10 +79,12 @@ class JobDetail:
     error: Union[None, Unset, str] = UNSET
     retry_count: Union[Unset, int] = UNSET
     decisions: Union[List['SafetyDecision'], None, Unset] = UNSET
+    delegation: Union[Unset, 'DelegationLineageView'] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
 
     def to_dict(self) -> Dict[str, Any]:
+        from ..models.delegation_lineage_view import DelegationLineageView
         from ..models.safety_decision import SafetyDecision
         from ..models.job_detail_labels import JobDetailLabels
         from ..models.job_detail_result_type_0 import JobDetailResultType0
@@ -177,6 +181,10 @@ class JobDetail:
         else:
             decisions = self.decisions
 
+        delegation: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.delegation, Unset):
+            delegation = self.delegation.to_dict()
+
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -224,6 +232,8 @@ class JobDetail:
             field_dict["retry_count"] = retry_count
         if decisions is not UNSET:
             field_dict["decisions"] = decisions
+        if delegation is not UNSET:
+            field_dict["delegation"] = delegation
 
         return field_dict
 
@@ -231,6 +241,7 @@ class JobDetail:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.delegation_lineage_view import DelegationLineageView
         from ..models.safety_decision import SafetyDecision
         from ..models.job_detail_labels import JobDetailLabels
         from ..models.job_detail_result_type_0 import JobDetailResultType0
@@ -403,6 +414,16 @@ class JobDetail:
         decisions = _parse_decisions(d.pop("decisions", UNSET))
 
 
+        _delegation = d.pop("delegation", UNSET)
+        delegation: Union[Unset, DelegationLineageView]
+        if isinstance(_delegation,  Unset):
+            delegation = UNSET
+        else:
+            delegation = DelegationLineageView.from_dict(_delegation)
+
+
+
+
         job_detail = cls(
             id=id,
             state=state,
@@ -425,6 +446,7 @@ class JobDetail:
             error=error,
             retry_count=retry_count,
             decisions=decisions,
+            delegation=delegation,
         )
 
 

--- a/sdk/python/src/cordum_sdk/_generated/models/json_rpc_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/json_rpc_response.py
@@ -16,8 +16,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
   from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
+  from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
 
 
 
@@ -44,8 +44,8 @@ class JsonRpcResponse:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
         from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
+        from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
         jsonrpc: Union[Unset, str] = UNSET
         if not isinstance(self.jsonrpc, Unset):
             jsonrpc = self.jsonrpc.value
@@ -93,8 +93,8 @@ class JsonRpcResponse:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
         from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
+        from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
         d = src_dict.copy()
         _jsonrpc = d.pop("jsonrpc", UNSET)
         jsonrpc: Union[Unset, JsonRpcResponseJsonrpc]

--- a/sdk/python/src/cordum_sdk/_generated/models/json_rpc_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/json_rpc_response.py
@@ -16,8 +16,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
   from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
+  from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
 
 
 
@@ -44,8 +44,8 @@ class JsonRpcResponse:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
         from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
+        from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
         jsonrpc: Union[Unset, str] = UNSET
         if not isinstance(self.jsonrpc, Unset):
             jsonrpc = self.jsonrpc.value
@@ -93,8 +93,8 @@ class JsonRpcResponse:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
         from ..models.json_rpc_response_result_type_0 import JsonRpcResponseResultType0
+        from ..models.json_rpc_response_error_type_0 import JsonRpcResponseErrorType0
         d = src_dict.copy()
         _jsonrpc = d.pop("jsonrpc", UNSET)
         jsonrpc: Union[Unset, JsonRpcResponseJsonrpc]

--- a/sdk/python/src/cordum_sdk/_generated/models/list_agents_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_agents_response_200.py
@@ -8,7 +8,14 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
 
+if TYPE_CHECKING:
+  from ..models.list_agents_response_200_items_item import ListAgentsResponse200ItemsItem
 
 
 
@@ -20,15 +27,38 @@ T = TypeVar("T", bound="ListAgentsResponse200")
 @_attrs_define
 class ListAgentsResponse200:
     """ 
+        Attributes:
+            items (Union[Unset, List['ListAgentsResponse200ItemsItem']]):
+            cursor (Union[Unset, str]):
      """
 
+    items: Union[Unset, List['ListAgentsResponse200ItemsItem']] = UNSET
+    cursor: Union[Unset, str] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
 
     def to_dict(self) -> Dict[str, Any]:
-        
+        from ..models.list_agents_response_200_items_item import ListAgentsResponse200ItemsItem
+        items: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.items, Unset):
+            items = []
+            for items_item_data in self.items:
+                items_item = items_item_data.to_dict()
+                items.append(items_item)
+
+
+
+        cursor = self.cursor
+
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if items is not UNSET:
+            field_dict["items"] = items
+        if cursor is not UNSET:
+            field_dict["cursor"] = cursor
 
         return field_dict
 
@@ -36,8 +66,23 @@ class ListAgentsResponse200:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.list_agents_response_200_items_item import ListAgentsResponse200ItemsItem
         d = src_dict.copy()
+        items = []
+        _items = d.pop("items", UNSET)
+        for items_item_data in (_items or []):
+            items_item = ListAgentsResponse200ItemsItem.from_dict(items_item_data)
+
+
+
+            items.append(items_item)
+
+
+        cursor = d.pop("cursor", UNSET)
+
         list_agents_response_200 = cls(
+            items=items,
+            cursor=cursor,
         )
 
 

--- a/sdk/python/src/cordum_sdk/_generated/models/list_agents_response_200_items_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_agents_response_200_items_item.py
@@ -1,0 +1,213 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast, List
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="ListAgentsResponse200ItemsItem")
+
+
+@_attrs_define
+class ListAgentsResponse200ItemsItem:
+    """ 
+        Attributes:
+            id (Union[Unset, str]):
+            name (Union[Unset, str]):
+            description (Union[Unset, str]):
+            owner (Union[Unset, str]):
+            team (Union[Unset, str]):
+            risk_tier (Union[Unset, str]):
+            allowed_topics (Union[Unset, List[str]]):
+            allowed_pools (Union[Unset, List[str]]):
+            allowed_tools (Union[Unset, List[str]]):
+            data_classifications (Union[Unset, List[str]]):
+            status (Union[Unset, str]):
+            created_at (Union[Unset, str]):
+            updated_at (Union[Unset, str]):
+            last_active (Union[Unset, int]):
+     """
+
+    id: Union[Unset, str] = UNSET
+    name: Union[Unset, str] = UNSET
+    description: Union[Unset, str] = UNSET
+    owner: Union[Unset, str] = UNSET
+    team: Union[Unset, str] = UNSET
+    risk_tier: Union[Unset, str] = UNSET
+    allowed_topics: Union[Unset, List[str]] = UNSET
+    allowed_pools: Union[Unset, List[str]] = UNSET
+    allowed_tools: Union[Unset, List[str]] = UNSET
+    data_classifications: Union[Unset, List[str]] = UNSET
+    status: Union[Unset, str] = UNSET
+    created_at: Union[Unset, str] = UNSET
+    updated_at: Union[Unset, str] = UNSET
+    last_active: Union[Unset, int] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+
+        name = self.name
+
+        description = self.description
+
+        owner = self.owner
+
+        team = self.team
+
+        risk_tier = self.risk_tier
+
+        allowed_topics: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_topics, Unset):
+            allowed_topics = self.allowed_topics
+
+
+
+        allowed_pools: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_pools, Unset):
+            allowed_pools = self.allowed_pools
+
+
+
+        allowed_tools: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_tools, Unset):
+            allowed_tools = self.allowed_tools
+
+
+
+        data_classifications: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.data_classifications, Unset):
+            data_classifications = self.data_classifications
+
+
+
+        status = self.status
+
+        created_at = self.created_at
+
+        updated_at = self.updated_at
+
+        last_active = self.last_active
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if id is not UNSET:
+            field_dict["id"] = id
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if owner is not UNSET:
+            field_dict["owner"] = owner
+        if team is not UNSET:
+            field_dict["team"] = team
+        if risk_tier is not UNSET:
+            field_dict["risk_tier"] = risk_tier
+        if allowed_topics is not UNSET:
+            field_dict["allowed_topics"] = allowed_topics
+        if allowed_pools is not UNSET:
+            field_dict["allowed_pools"] = allowed_pools
+        if allowed_tools is not UNSET:
+            field_dict["allowed_tools"] = allowed_tools
+        if data_classifications is not UNSET:
+            field_dict["data_classifications"] = data_classifications
+        if status is not UNSET:
+            field_dict["status"] = status
+        if created_at is not UNSET:
+            field_dict["created_at"] = created_at
+        if updated_at is not UNSET:
+            field_dict["updated_at"] = updated_at
+        if last_active is not UNSET:
+            field_dict["last_active"] = last_active
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        id = d.pop("id", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        owner = d.pop("owner", UNSET)
+
+        team = d.pop("team", UNSET)
+
+        risk_tier = d.pop("risk_tier", UNSET)
+
+        allowed_topics = cast(List[str], d.pop("allowed_topics", UNSET))
+
+
+        allowed_pools = cast(List[str], d.pop("allowed_pools", UNSET))
+
+
+        allowed_tools = cast(List[str], d.pop("allowed_tools", UNSET))
+
+
+        data_classifications = cast(List[str], d.pop("data_classifications", UNSET))
+
+
+        status = d.pop("status", UNSET)
+
+        created_at = d.pop("created_at", UNSET)
+
+        updated_at = d.pop("updated_at", UNSET)
+
+        last_active = d.pop("last_active", UNSET)
+
+        list_agents_response_200_items_item = cls(
+            id=id,
+            name=name,
+            description=description,
+            owner=owner,
+            team=team,
+            risk_tier=risk_tier,
+            allowed_topics=allowed_topics,
+            allowed_pools=allowed_pools,
+            allowed_tools=allowed_tools,
+            data_classifications=data_classifications,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+            last_active=last_active,
+        )
+
+
+        list_agents_response_200_items_item.additional_properties = d
+        return list_agents_response_200_items_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_delegations_for_agent_status.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_delegations_for_agent_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class ListDelegationsForAgentStatus(str, Enum):
+    ACTIVE = "active"
+    ALL = "all"
+    EXPIRED = "expired"
+    REVOKED = "revoked"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/list_delegations_status.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_delegations_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class ListDelegationsStatus(str, Enum):
+    ACTIVE = "active"
+    ALL = "all"
+    EXPIRED = "expired"
+    REVOKED = "revoked"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/list_eval_dataset_versions_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_eval_dataset_versions_response_200.py
@@ -1,0 +1,97 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.list_eval_dataset_versions_response_200_items_item import ListEvalDatasetVersionsResponse200ItemsItem
+
+
+
+
+
+T = TypeVar("T", bound="ListEvalDatasetVersionsResponse200")
+
+
+@_attrs_define
+class ListEvalDatasetVersionsResponse200:
+    """ 
+        Attributes:
+            items (Union[Unset, List['ListEvalDatasetVersionsResponse200ItemsItem']]):
+     """
+
+    items: Union[Unset, List['ListEvalDatasetVersionsResponse200ItemsItem']] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.list_eval_dataset_versions_response_200_items_item import ListEvalDatasetVersionsResponse200ItemsItem
+        items: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.items, Unset):
+            items = []
+            for items_item_data in self.items:
+                items_item = items_item_data.to_dict()
+                items.append(items_item)
+
+
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if items is not UNSET:
+            field_dict["items"] = items
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.list_eval_dataset_versions_response_200_items_item import ListEvalDatasetVersionsResponse200ItemsItem
+        d = src_dict.copy()
+        items = []
+        _items = d.pop("items", UNSET)
+        for items_item_data in (_items or []):
+            items_item = ListEvalDatasetVersionsResponse200ItemsItem.from_dict(items_item_data)
+
+
+
+            items.append(items_item)
+
+
+        list_eval_dataset_versions_response_200 = cls(
+            items=items,
+        )
+
+
+        list_eval_dataset_versions_response_200.additional_properties = d
+        return list_eval_dataset_versions_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_eval_dataset_versions_response_200_items_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_eval_dataset_versions_response_200_items_item.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ListEvalDatasetVersionsResponse200ItemsItem")
+
+
+@_attrs_define
+class ListEvalDatasetVersionsResponse200ItemsItem:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        list_eval_dataset_versions_response_200_items_item = cls(
+        )
+
+
+        list_eval_dataset_versions_response_200_items_item.additional_properties = d
+        return list_eval_dataset_versions_response_200_items_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_eval_datasets_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_eval_datasets_response_200.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.list_eval_datasets_response_200_items_item import ListEvalDatasetsResponse200ItemsItem
+
+
+
+
+
+T = TypeVar("T", bound="ListEvalDatasetsResponse200")
+
+
+@_attrs_define
+class ListEvalDatasetsResponse200:
+    """ 
+        Attributes:
+            items (Union[Unset, List['ListEvalDatasetsResponse200ItemsItem']]):
+            next_cursor (Union[Unset, str]):
+     """
+
+    items: Union[Unset, List['ListEvalDatasetsResponse200ItemsItem']] = UNSET
+    next_cursor: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.list_eval_datasets_response_200_items_item import ListEvalDatasetsResponse200ItemsItem
+        items: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.items, Unset):
+            items = []
+            for items_item_data in self.items:
+                items_item = items_item_data.to_dict()
+                items.append(items_item)
+
+
+
+        next_cursor = self.next_cursor
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if items is not UNSET:
+            field_dict["items"] = items
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.list_eval_datasets_response_200_items_item import ListEvalDatasetsResponse200ItemsItem
+        d = src_dict.copy()
+        items = []
+        _items = d.pop("items", UNSET)
+        for items_item_data in (_items or []):
+            items_item = ListEvalDatasetsResponse200ItemsItem.from_dict(items_item_data)
+
+
+
+            items.append(items_item)
+
+
+        next_cursor = d.pop("next_cursor", UNSET)
+
+        list_eval_datasets_response_200 = cls(
+            items=items,
+            next_cursor=next_cursor,
+        )
+
+
+        list_eval_datasets_response_200.additional_properties = d
+        return list_eval_datasets_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_eval_datasets_response_200_items_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_eval_datasets_response_200_items_item.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ListEvalDatasetsResponse200ItemsItem")
+
+
+@_attrs_define
+class ListEvalDatasetsResponse200ItemsItem:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        list_eval_datasets_response_200_items_item = cls(
+        )
+
+
+        list_eval_datasets_response_200_items_item.additional_properties = d
+        return list_eval_datasets_response_200_items_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_governance_decisions_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_governance_decisions_response_200.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.list_governance_decisions_response_200_items_item import ListGovernanceDecisionsResponse200ItemsItem
+
+
+
+
+
+T = TypeVar("T", bound="ListGovernanceDecisionsResponse200")
+
+
+@_attrs_define
+class ListGovernanceDecisionsResponse200:
+    """ 
+        Attributes:
+            items (Union[Unset, List['ListGovernanceDecisionsResponse200ItemsItem']]):
+            next_cursor (Union[Unset, str]):
+     """
+
+    items: Union[Unset, List['ListGovernanceDecisionsResponse200ItemsItem']] = UNSET
+    next_cursor: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.list_governance_decisions_response_200_items_item import ListGovernanceDecisionsResponse200ItemsItem
+        items: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.items, Unset):
+            items = []
+            for items_item_data in self.items:
+                items_item = items_item_data.to_dict()
+                items.append(items_item)
+
+
+
+        next_cursor = self.next_cursor
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if items is not UNSET:
+            field_dict["items"] = items
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.list_governance_decisions_response_200_items_item import ListGovernanceDecisionsResponse200ItemsItem
+        d = src_dict.copy()
+        items = []
+        _items = d.pop("items", UNSET)
+        for items_item_data in (_items or []):
+            items_item = ListGovernanceDecisionsResponse200ItemsItem.from_dict(items_item_data)
+
+
+
+            items.append(items_item)
+
+
+        next_cursor = d.pop("next_cursor", UNSET)
+
+        list_governance_decisions_response_200 = cls(
+            items=items,
+            next_cursor=next_cursor,
+        )
+
+
+        list_governance_decisions_response_200.additional_properties = d
+        return list_governance_decisions_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_governance_decisions_response_200_items_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_governance_decisions_response_200_items_item.py
@@ -1,0 +1,181 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.list_governance_decisions_response_200_items_item_constraints import ListGovernanceDecisionsResponse200ItemsItemConstraints
+
+
+
+
+
+T = TypeVar("T", bound="ListGovernanceDecisionsResponse200ItemsItem")
+
+
+@_attrs_define
+class ListGovernanceDecisionsResponse200ItemsItem:
+    """ 
+        Attributes:
+            job_id (Union[Unset, str]):
+            topic (Union[Unset, str]):
+            matched_rule (Union[Unset, str]):
+            verdict (Union[Unset, str]):
+            reason (Union[Unset, str]):
+            constraints (Union[Unset, ListGovernanceDecisionsResponse200ItemsItemConstraints]):
+            approval_status (Union[Unset, str]):
+            approval_decision (Union[Unset, str]):
+            agent_id (Union[Unset, str]):
+            policy_version (Union[Unset, str]):
+            timestamp (Union[Unset, str]):
+     """
+
+    job_id: Union[Unset, str] = UNSET
+    topic: Union[Unset, str] = UNSET
+    matched_rule: Union[Unset, str] = UNSET
+    verdict: Union[Unset, str] = UNSET
+    reason: Union[Unset, str] = UNSET
+    constraints: Union[Unset, 'ListGovernanceDecisionsResponse200ItemsItemConstraints'] = UNSET
+    approval_status: Union[Unset, str] = UNSET
+    approval_decision: Union[Unset, str] = UNSET
+    agent_id: Union[Unset, str] = UNSET
+    policy_version: Union[Unset, str] = UNSET
+    timestamp: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.list_governance_decisions_response_200_items_item_constraints import ListGovernanceDecisionsResponse200ItemsItemConstraints
+        job_id = self.job_id
+
+        topic = self.topic
+
+        matched_rule = self.matched_rule
+
+        verdict = self.verdict
+
+        reason = self.reason
+
+        constraints: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.constraints, Unset):
+            constraints = self.constraints.to_dict()
+
+        approval_status = self.approval_status
+
+        approval_decision = self.approval_decision
+
+        agent_id = self.agent_id
+
+        policy_version = self.policy_version
+
+        timestamp = self.timestamp
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if job_id is not UNSET:
+            field_dict["job_id"] = job_id
+        if topic is not UNSET:
+            field_dict["topic"] = topic
+        if matched_rule is not UNSET:
+            field_dict["matched_rule"] = matched_rule
+        if verdict is not UNSET:
+            field_dict["verdict"] = verdict
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+        if constraints is not UNSET:
+            field_dict["constraints"] = constraints
+        if approval_status is not UNSET:
+            field_dict["approval_status"] = approval_status
+        if approval_decision is not UNSET:
+            field_dict["approval_decision"] = approval_decision
+        if agent_id is not UNSET:
+            field_dict["agent_id"] = agent_id
+        if policy_version is not UNSET:
+            field_dict["policy_version"] = policy_version
+        if timestamp is not UNSET:
+            field_dict["timestamp"] = timestamp
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.list_governance_decisions_response_200_items_item_constraints import ListGovernanceDecisionsResponse200ItemsItemConstraints
+        d = src_dict.copy()
+        job_id = d.pop("job_id", UNSET)
+
+        topic = d.pop("topic", UNSET)
+
+        matched_rule = d.pop("matched_rule", UNSET)
+
+        verdict = d.pop("verdict", UNSET)
+
+        reason = d.pop("reason", UNSET)
+
+        _constraints = d.pop("constraints", UNSET)
+        constraints: Union[Unset, ListGovernanceDecisionsResponse200ItemsItemConstraints]
+        if isinstance(_constraints,  Unset):
+            constraints = UNSET
+        else:
+            constraints = ListGovernanceDecisionsResponse200ItemsItemConstraints.from_dict(_constraints)
+
+
+
+
+        approval_status = d.pop("approval_status", UNSET)
+
+        approval_decision = d.pop("approval_decision", UNSET)
+
+        agent_id = d.pop("agent_id", UNSET)
+
+        policy_version = d.pop("policy_version", UNSET)
+
+        timestamp = d.pop("timestamp", UNSET)
+
+        list_governance_decisions_response_200_items_item = cls(
+            job_id=job_id,
+            topic=topic,
+            matched_rule=matched_rule,
+            verdict=verdict,
+            reason=reason,
+            constraints=constraints,
+            approval_status=approval_status,
+            approval_decision=approval_decision,
+            agent_id=agent_id,
+            policy_version=policy_version,
+            timestamp=timestamp,
+        )
+
+
+        list_governance_decisions_response_200_items_item.additional_properties = d
+        return list_governance_decisions_response_200_items_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_governance_decisions_response_200_items_item_constraints.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_governance_decisions_response_200_items_item_constraints.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ListGovernanceDecisionsResponse200ItemsItemConstraints")
+
+
+@_attrs_define
+class ListGovernanceDecisionsResponse200ItemsItemConstraints:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        list_governance_decisions_response_200_items_item_constraints = cls(
+        )
+
+
+        list_governance_decisions_response_200_items_item_constraints.additional_properties = d
+        return list_governance_decisions_response_200_items_item_constraints
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_mcp_approvals_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_mcp_approvals_response_200.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.list_mcp_approvals_response_200_items_item import ListMcpApprovalsResponse200ItemsItem
+
+
+
+
+
+T = TypeVar("T", bound="ListMcpApprovalsResponse200")
+
+
+@_attrs_define
+class ListMcpApprovalsResponse200:
+    """ 
+        Attributes:
+            items (Union[Unset, List['ListMcpApprovalsResponse200ItemsItem']]):
+            next_cursor (Union[Unset, int]):
+     """
+
+    items: Union[Unset, List['ListMcpApprovalsResponse200ItemsItem']] = UNSET
+    next_cursor: Union[Unset, int] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.list_mcp_approvals_response_200_items_item import ListMcpApprovalsResponse200ItemsItem
+        items: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.items, Unset):
+            items = []
+            for items_item_data in self.items:
+                items_item = items_item_data.to_dict()
+                items.append(items_item)
+
+
+
+        next_cursor = self.next_cursor
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if items is not UNSET:
+            field_dict["items"] = items
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.list_mcp_approvals_response_200_items_item import ListMcpApprovalsResponse200ItemsItem
+        d = src_dict.copy()
+        items = []
+        _items = d.pop("items", UNSET)
+        for items_item_data in (_items or []):
+            items_item = ListMcpApprovalsResponse200ItemsItem.from_dict(items_item_data)
+
+
+
+            items.append(items_item)
+
+
+        next_cursor = d.pop("next_cursor", UNSET)
+
+        list_mcp_approvals_response_200 = cls(
+            items=items,
+            next_cursor=next_cursor,
+        )
+
+
+        list_mcp_approvals_response_200.additional_properties = d
+        return list_mcp_approvals_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_mcp_approvals_response_200_items_item.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_mcp_approvals_response_200_items_item.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ListMcpApprovalsResponse200ItemsItem")
+
+
+@_attrs_define
+class ListMcpApprovalsResponse200ItemsItem:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        list_mcp_approvals_response_200_items_item = cls(
+        )
+
+
+        list_mcp_approvals_response_200_items_item.additional_properties = d
+        return list_mcp_approvals_response_200_items_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_mcp_outbound_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_mcp_outbound_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ListMcpOutboundResponse200")
+
+
+@_attrs_define
+class ListMcpOutboundResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        list_mcp_outbound_response_200 = cls(
+        )
+
+
+        list_mcp_outbound_response_200.additional_properties = d
+        return list_mcp_outbound_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/list_mcp_tools_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/list_mcp_tools_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ListMcpToolsResponse200")
+
+
+@_attrs_define
+class ListMcpToolsResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        list_mcp_tools_response_200 = cls(
+        )
+
+
+        list_mcp_tools_response_200.additional_properties = d
+        return list_mcp_tools_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/pack_record.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/pack_record.py
@@ -13,9 +13,12 @@ from ..types import UNSET, Unset
 from dateutil.parser import isoparse
 from typing import cast
 from typing import cast, Union
+from typing import Dict
 from typing import Union
 import datetime
 
+if TYPE_CHECKING:
+  from ..models.installed_pack_verification import InstalledPackVerification
 
 
 
@@ -36,6 +39,12 @@ class PackRecord:
             author (Union[None, Unset, str]):
             installed_at (Union[Unset, datetime.datetime]):
             updated_at (Union[Unset, datetime.datetime]):
+            verification (Union[Unset, InstalledPackVerification]): Pack-signature verification outcome computed by the
+                gateway at
+                install time. Never client-supplied — the gateway discards any
+                `verification` field on the install payload and computes its own.
+                Pre-existing installs default to {signed: false} when this object
+                is absent.
      """
 
     id: Union[Unset, str] = UNSET
@@ -46,10 +55,12 @@ class PackRecord:
     author: Union[None, Unset, str] = UNSET
     installed_at: Union[Unset, datetime.datetime] = UNSET
     updated_at: Union[Unset, datetime.datetime] = UNSET
+    verification: Union[Unset, 'InstalledPackVerification'] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
 
     def to_dict(self) -> Dict[str, Any]:
+        from ..models.installed_pack_verification import InstalledPackVerification
         id = self.id
 
         name = self.name
@@ -81,6 +92,10 @@ class PackRecord:
         if not isinstance(self.updated_at, Unset):
             updated_at = self.updated_at.isoformat()
 
+        verification: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.verification, Unset):
+            verification = self.verification.to_dict()
+
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -102,6 +117,8 @@ class PackRecord:
             field_dict["installed_at"] = installed_at
         if updated_at is not UNSET:
             field_dict["updated_at"] = updated_at
+        if verification is not UNSET:
+            field_dict["verification"] = verification
 
         return field_dict
 
@@ -109,6 +126,7 @@ class PackRecord:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.installed_pack_verification import InstalledPackVerification
         d = src_dict.copy()
         id = d.pop("id", UNSET)
 
@@ -166,6 +184,16 @@ class PackRecord:
 
 
 
+        _verification = d.pop("verification", UNSET)
+        verification: Union[Unset, InstalledPackVerification]
+        if isinstance(_verification,  Unset):
+            verification = UNSET
+        else:
+            verification = InstalledPackVerification.from_dict(_verification)
+
+
+
+
         pack_record = cls(
             id=id,
             name=name,
@@ -175,6 +203,7 @@ class PackRecord:
             author=author,
             installed_at=installed_at,
             updated_at=updated_at,
+            verification=verification,
         )
 
 

--- a/sdk/python/src/cordum_sdk/_generated/models/policy_analytics_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/policy_analytics_response_200.py
@@ -15,9 +15,9 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
   from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
   from ..models.policy_analytics_response_200_rules_item import PolicyAnalyticsResponse200RulesItem
+  from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
 
 
 
@@ -42,9 +42,9 @@ class PolicyAnalyticsResponse200:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
         from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
         from ..models.policy_analytics_response_200_rules_item import PolicyAnalyticsResponse200RulesItem
+        from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
         time_range: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.time_range, Unset):
             time_range = self.time_range.to_dict()
@@ -80,9 +80,9 @@ class PolicyAnalyticsResponse200:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
         from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
         from ..models.policy_analytics_response_200_rules_item import PolicyAnalyticsResponse200RulesItem
+        from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
         d = src_dict.copy()
         _time_range = d.pop("time_range", UNSET)
         time_range: Union[Unset, PolicyAnalyticsResponse200TimeRange]

--- a/sdk/python/src/cordum_sdk/_generated/models/policy_analytics_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/policy_analytics_response_200.py
@@ -15,8 +15,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
   from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
+  from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
   from ..models.policy_analytics_response_200_rules_item import PolicyAnalyticsResponse200RulesItem
 
 
@@ -42,8 +42,8 @@ class PolicyAnalyticsResponse200:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
         from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
+        from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
         from ..models.policy_analytics_response_200_rules_item import PolicyAnalyticsResponse200RulesItem
         time_range: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.time_range, Unset):
@@ -80,8 +80,8 @@ class PolicyAnalyticsResponse200:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
         from ..models.policy_analytics_response_200_summary import PolicyAnalyticsResponse200Summary
+        from ..models.policy_analytics_response_200_time_range import PolicyAnalyticsResponse200TimeRange
         from ..models.policy_analytics_response_200_rules_item import PolicyAnalyticsResponse200RulesItem
         d = src_dict.copy()
         _time_range = d.pop("time_range", UNSET)

--- a/sdk/python/src/cordum_sdk/_generated/models/policy_check_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/policy_check_response.py
@@ -17,8 +17,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.policy_check_response_constraints_type_0 import PolicyCheckResponseConstraintsType0
   from ..models.safety_decision import SafetyDecision
+  from ..models.policy_check_response_constraints_type_0 import PolicyCheckResponseConstraintsType0
 
 
 
@@ -47,8 +47,8 @@ class PolicyCheckResponse:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.policy_check_response_constraints_type_0 import PolicyCheckResponseConstraintsType0
         from ..models.safety_decision import SafetyDecision
+        from ..models.policy_check_response_constraints_type_0 import PolicyCheckResponseConstraintsType0
         decision: Union[Unset, str] = UNSET
         if not isinstance(self.decision, Unset):
             decision = self.decision.value
@@ -105,8 +105,8 @@ class PolicyCheckResponse:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.policy_check_response_constraints_type_0 import PolicyCheckResponseConstraintsType0
         from ..models.safety_decision import SafetyDecision
+        from ..models.policy_check_response_constraints_type_0 import PolicyCheckResponseConstraintsType0
         d = src_dict.copy()
         _decision = d.pop("decision", UNSET)
         decision: Union[Unset, PolicyCheckResponseDecision]

--- a/sdk/python/src/cordum_sdk/_generated/models/policy_replay_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/policy_replay_response.py
@@ -16,10 +16,10 @@ from typing import Union
 from uuid import UUID
 
 if TYPE_CHECKING:
-  from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
-  from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
-  from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
   from ..models.policy_replay_response_rule_hits_item import PolicyReplayResponseRuleHitsItem
+  from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
+  from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
+  from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
 
 
 
@@ -54,10 +54,10 @@ class PolicyReplayResponse:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
-        from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
-        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
         from ..models.policy_replay_response_rule_hits_item import PolicyReplayResponseRuleHitsItem
+        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
+        from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
+        from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
         replay_id = str(self.replay_id)
 
         policy_snapshot = self.policy_snapshot
@@ -114,10 +114,10 @@ class PolicyReplayResponse:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
-        from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
-        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
         from ..models.policy_replay_response_rule_hits_item import PolicyReplayResponseRuleHitsItem
+        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
+        from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
+        from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
         d = src_dict.copy()
         replay_id = UUID(d.pop("replay_id"))
 

--- a/sdk/python/src/cordum_sdk/_generated/models/policy_replay_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/policy_replay_response.py
@@ -17,8 +17,8 @@ from uuid import UUID
 
 if TYPE_CHECKING:
   from ..models.policy_replay_response_rule_hits_item import PolicyReplayResponseRuleHitsItem
-  from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
   from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
+  from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
   from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
 
 
@@ -55,8 +55,8 @@ class PolicyReplayResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         from ..models.policy_replay_response_rule_hits_item import PolicyReplayResponseRuleHitsItem
-        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
         from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
+        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
         from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
         replay_id = str(self.replay_id)
 
@@ -115,8 +115,8 @@ class PolicyReplayResponse:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         from ..models.policy_replay_response_rule_hits_item import PolicyReplayResponseRuleHitsItem
-        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
         from ..models.policy_replay_response_summary import PolicyReplayResponseSummary
+        from ..models.policy_replay_response_changes_item import PolicyReplayResponseChangesItem
         from ..models.policy_replay_response_time_range import PolicyReplayResponseTimeRange
         d = src_dict.copy()
         replay_id = UUID(d.pop("replay_id"))

--- a/sdk/python/src/cordum_sdk/_generated/models/reject_mcp_approval_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/reject_mcp_approval_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="RejectMcpApprovalResponse200")
+
+
+@_attrs_define
+class RejectMcpApprovalResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        reject_mcp_approval_response_200 = cls(
+        )
+
+
+        reject_mcp_approval_response_200.additional_properties = d
+        return reject_mcp_approval_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/revoke_delegation_token_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/revoke_delegation_token_body.py
@@ -1,0 +1,92 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="RevokeDelegationTokenBody")
+
+
+@_attrs_define
+class RevokeDelegationTokenBody:
+    """ 
+        Attributes:
+            jti (str):
+            reason (Union[Unset, str]):
+            cascade (Union[Unset, bool]): When true, revoke downstream delegations that extended this token. Default: True.
+     """
+
+    jti: str
+    reason: Union[Unset, str] = UNSET
+    cascade: Union[Unset, bool] = True
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        jti = self.jti
+
+        reason = self.reason
+
+        cascade = self.cascade
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "jti": jti,
+        })
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+        if cascade is not UNSET:
+            field_dict["cascade"] = cascade
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        jti = d.pop("jti")
+
+        reason = d.pop("reason", UNSET)
+
+        cascade = d.pop("cascade", UNSET)
+
+        revoke_delegation_token_body = cls(
+            jti=jti,
+            reason=reason,
+            cascade=cascade,
+        )
+
+
+        revoke_delegation_token_body.additional_properties = d
+        return revoke_delegation_token_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/revoke_delegation_token_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/revoke_delegation_token_response_200.py
@@ -1,0 +1,80 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="RevokeDelegationTokenResponse200")
+
+
+@_attrs_define
+class RevokeDelegationTokenResponse200:
+    """ 
+        Attributes:
+            jti (str):
+            cascaded_count (int): Number of downstream delegations revoked in addition to the root token.
+     """
+
+    jti: str
+    cascaded_count: int
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        jti = self.jti
+
+        cascaded_count = self.cascaded_count
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "jti": jti,
+            "cascaded_count": cascaded_count,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        jti = d.pop("jti")
+
+        cascaded_count = d.pop("cascaded_count")
+
+        revoke_delegation_token_response_200 = cls(
+            jti=jti,
+            cascaded_count=cascaded_count,
+        )
+
+
+        revoke_delegation_token_response_200.additional_properties = d
+        return revoke_delegation_token_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/run_detail.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/run_detail.py
@@ -18,10 +18,10 @@ from typing import Union
 import datetime
 
 if TYPE_CHECKING:
-  from ..models.run_detail_input import RunDetailInput
-  from ..models.run_detail_steps import RunDetailSteps
   from ..models.run_detail_output_type_0 import RunDetailOutputType0
   from ..models.run_summary_error_type_0 import RunSummaryErrorType0
+  from ..models.run_detail_input import RunDetailInput
+  from ..models.run_detail_steps import RunDetailSteps
 
 
 
@@ -62,10 +62,10 @@ class RunDetail:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.run_detail_input import RunDetailInput
-        from ..models.run_detail_steps import RunDetailSteps
         from ..models.run_detail_output_type_0 import RunDetailOutputType0
         from ..models.run_summary_error_type_0 import RunSummaryErrorType0
+        from ..models.run_detail_input import RunDetailInput
+        from ..models.run_detail_steps import RunDetailSteps
         id = self.id
 
         workflow_id = self.workflow_id
@@ -149,10 +149,10 @@ class RunDetail:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.run_detail_input import RunDetailInput
-        from ..models.run_detail_steps import RunDetailSteps
         from ..models.run_detail_output_type_0 import RunDetailOutputType0
         from ..models.run_summary_error_type_0 import RunSummaryErrorType0
+        from ..models.run_detail_input import RunDetailInput
+        from ..models.run_detail_steps import RunDetailSteps
         d = src_dict.copy()
         id = d.pop("id", UNSET)
 

--- a/sdk/python/src/cordum_sdk/_generated/models/run_detail.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/run_detail.py
@@ -18,9 +18,9 @@ from typing import Union
 import datetime
 
 if TYPE_CHECKING:
+  from ..models.run_detail_input import RunDetailInput
   from ..models.run_detail_output_type_0 import RunDetailOutputType0
   from ..models.run_summary_error_type_0 import RunSummaryErrorType0
-  from ..models.run_detail_input import RunDetailInput
   from ..models.run_detail_steps import RunDetailSteps
 
 
@@ -62,9 +62,9 @@ class RunDetail:
 
 
     def to_dict(self) -> Dict[str, Any]:
+        from ..models.run_detail_input import RunDetailInput
         from ..models.run_detail_output_type_0 import RunDetailOutputType0
         from ..models.run_summary_error_type_0 import RunSummaryErrorType0
-        from ..models.run_detail_input import RunDetailInput
         from ..models.run_detail_steps import RunDetailSteps
         id = self.id
 
@@ -149,9 +149,9 @@ class RunDetail:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.run_detail_input import RunDetailInput
         from ..models.run_detail_output_type_0 import RunDetailOutputType0
         from ..models.run_summary_error_type_0 import RunSummaryErrorType0
-        from ..models.run_detail_input import RunDetailInput
         from ..models.run_detail_steps import RunDetailSteps
         d = src_dict.copy()
         id = d.pop("id", UNSET)

--- a/sdk/python/src/cordum_sdk/_generated/models/status_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/status_response.py
@@ -18,9 +18,9 @@ import datetime
 
 if TYPE_CHECKING:
   from ..models.status_response_nats import StatusResponseNats
+  from ..models.status_response_redis import StatusResponseRedis
   from ..models.status_response_build import StatusResponseBuild
   from ..models.status_response_license_type_0 import StatusResponseLicenseType0
-  from ..models.status_response_redis import StatusResponseRedis
 
 
 
@@ -54,9 +54,9 @@ class StatusResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         from ..models.status_response_nats import StatusResponseNats
+        from ..models.status_response_redis import StatusResponseRedis
         from ..models.status_response_build import StatusResponseBuild
         from ..models.status_response_license_type_0 import StatusResponseLicenseType0
-        from ..models.status_response_redis import StatusResponseRedis
         time: Union[Unset, str] = UNSET
         if not isinstance(self.time, Unset):
             time = self.time.isoformat()
@@ -112,9 +112,9 @@ class StatusResponse:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         from ..models.status_response_nats import StatusResponseNats
+        from ..models.status_response_redis import StatusResponseRedis
         from ..models.status_response_build import StatusResponseBuild
         from ..models.status_response_license_type_0 import StatusResponseLicenseType0
-        from ..models.status_response_redis import StatusResponseRedis
         d = src_dict.copy()
         _time = d.pop("time", UNSET)
         time: Union[Unset, datetime.datetime]

--- a/sdk/python/src/cordum_sdk/_generated/models/status_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/status_response.py
@@ -17,10 +17,10 @@ from typing import Union
 import datetime
 
 if TYPE_CHECKING:
-  from ..models.status_response_redis import StatusResponseRedis
-  from ..models.status_response_build import StatusResponseBuild
   from ..models.status_response_nats import StatusResponseNats
+  from ..models.status_response_build import StatusResponseBuild
   from ..models.status_response_license_type_0 import StatusResponseLicenseType0
+  from ..models.status_response_redis import StatusResponseRedis
 
 
 
@@ -53,10 +53,10 @@ class StatusResponse:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.status_response_redis import StatusResponseRedis
-        from ..models.status_response_build import StatusResponseBuild
         from ..models.status_response_nats import StatusResponseNats
+        from ..models.status_response_build import StatusResponseBuild
         from ..models.status_response_license_type_0 import StatusResponseLicenseType0
+        from ..models.status_response_redis import StatusResponseRedis
         time: Union[Unset, str] = UNSET
         if not isinstance(self.time, Unset):
             time = self.time.isoformat()
@@ -111,10 +111,10 @@ class StatusResponse:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.status_response_redis import StatusResponseRedis
-        from ..models.status_response_build import StatusResponseBuild
         from ..models.status_response_nats import StatusResponseNats
+        from ..models.status_response_build import StatusResponseBuild
         from ..models.status_response_license_type_0 import StatusResponseLicenseType0
+        from ..models.status_response_redis import StatusResponseRedis
         d = src_dict.copy()
         _time = d.pop("time", UNSET)
         time: Union[Unset, datetime.datetime]

--- a/sdk/python/src/cordum_sdk/_generated/models/submit_job_request.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/submit_job_request.py
@@ -16,8 +16,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.submit_job_request_labels import SubmitJobRequestLabels
   from ..models.submit_job_request_context import SubmitJobRequestContext
+  from ..models.submit_job_request_labels import SubmitJobRequestLabels
 
 
 
@@ -91,8 +91,8 @@ class SubmitJobRequest:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.submit_job_request_labels import SubmitJobRequestLabels
         from ..models.submit_job_request_context import SubmitJobRequestContext
+        from ..models.submit_job_request_labels import SubmitJobRequestLabels
         prompt = self.prompt
 
         topic = self.topic
@@ -230,8 +230,8 @@ class SubmitJobRequest:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.submit_job_request_labels import SubmitJobRequestLabels
         from ..models.submit_job_request_context import SubmitJobRequestContext
+        from ..models.submit_job_request_labels import SubmitJobRequestLabels
         d = src_dict.copy()
         prompt = d.pop("prompt")
 

--- a/sdk/python/src/cordum_sdk/_generated/models/update_agent_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/update_agent_body.py
@@ -8,6 +8,9 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
+from ..types import UNSET, Unset
+from typing import cast, List
+from typing import Union
 
 
 
@@ -20,15 +23,94 @@ T = TypeVar("T", bound="UpdateAgentBody")
 @_attrs_define
 class UpdateAgentBody:
     """ 
+        Attributes:
+            name (Union[Unset, str]):
+            description (Union[Unset, str]):
+            owner (Union[Unset, str]):
+            team (Union[Unset, str]):
+            risk_tier (Union[Unset, str]):
+            status (Union[Unset, str]):
+            allowed_topics (Union[Unset, List[str]]):
+            allowed_pools (Union[Unset, List[str]]):
+            allowed_tools (Union[Unset, List[str]]):
+            data_classifications (Union[Unset, List[str]]):
      """
 
+    name: Union[Unset, str] = UNSET
+    description: Union[Unset, str] = UNSET
+    owner: Union[Unset, str] = UNSET
+    team: Union[Unset, str] = UNSET
+    risk_tier: Union[Unset, str] = UNSET
+    status: Union[Unset, str] = UNSET
+    allowed_topics: Union[Unset, List[str]] = UNSET
+    allowed_pools: Union[Unset, List[str]] = UNSET
+    allowed_tools: Union[Unset, List[str]] = UNSET
+    data_classifications: Union[Unset, List[str]] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
 
     def to_dict(self) -> Dict[str, Any]:
-        
+        name = self.name
+
+        description = self.description
+
+        owner = self.owner
+
+        team = self.team
+
+        risk_tier = self.risk_tier
+
+        status = self.status
+
+        allowed_topics: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_topics, Unset):
+            allowed_topics = self.allowed_topics
+
+
+
+        allowed_pools: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_pools, Unset):
+            allowed_pools = self.allowed_pools
+
+
+
+        allowed_tools: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_tools, Unset):
+            allowed_tools = self.allowed_tools
+
+
+
+        data_classifications: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.data_classifications, Unset):
+            data_classifications = self.data_classifications
+
+
+
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if owner is not UNSET:
+            field_dict["owner"] = owner
+        if team is not UNSET:
+            field_dict["team"] = team
+        if risk_tier is not UNSET:
+            field_dict["risk_tier"] = risk_tier
+        if status is not UNSET:
+            field_dict["status"] = status
+        if allowed_topics is not UNSET:
+            field_dict["allowed_topics"] = allowed_topics
+        if allowed_pools is not UNSET:
+            field_dict["allowed_pools"] = allowed_pools
+        if allowed_tools is not UNSET:
+            field_dict["allowed_tools"] = allowed_tools
+        if data_classifications is not UNSET:
+            field_dict["data_classifications"] = data_classifications
 
         return field_dict
 
@@ -37,7 +119,41 @@ class UpdateAgentBody:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        owner = d.pop("owner", UNSET)
+
+        team = d.pop("team", UNSET)
+
+        risk_tier = d.pop("risk_tier", UNSET)
+
+        status = d.pop("status", UNSET)
+
+        allowed_topics = cast(List[str], d.pop("allowed_topics", UNSET))
+
+
+        allowed_pools = cast(List[str], d.pop("allowed_pools", UNSET))
+
+
+        allowed_tools = cast(List[str], d.pop("allowed_tools", UNSET))
+
+
+        data_classifications = cast(List[str], d.pop("data_classifications", UNSET))
+
+
         update_agent_body = cls(
+            name=name,
+            description=description,
+            owner=owner,
+            team=team,
+            risk_tier=risk_tier,
+            status=status,
+            allowed_topics=allowed_topics,
+            allowed_pools=allowed_pools,
+            allowed_tools=allowed_tools,
+            data_classifications=data_classifications,
         )
 
 

--- a/sdk/python/src/cordum_sdk/_generated/models/verify_delegation_token_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/verify_delegation_token_body.py
@@ -1,0 +1,83 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="VerifyDelegationTokenBody")
+
+
+@_attrs_define
+class VerifyDelegationTokenBody:
+    """ 
+        Attributes:
+            token (str):
+            expected_audience (Union[Unset, str]):
+     """
+
+    token: str
+    expected_audience: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        token = self.token
+
+        expected_audience = self.expected_audience
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "token": token,
+        })
+        if expected_audience is not UNSET:
+            field_dict["expected_audience"] = expected_audience
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        token = d.pop("token")
+
+        expected_audience = d.pop("expected_audience", UNSET)
+
+        verify_delegation_token_body = cls(
+            token=token,
+            expected_audience=expected_audience,
+        )
+
+
+        verify_delegation_token_body.additional_properties = d
+        return verify_delegation_token_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/verify_delegation_token_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/verify_delegation_token_response_200.py
@@ -1,0 +1,170 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.delegation_chain_link import DelegationChainLink
+
+
+
+
+
+T = TypeVar("T", bound="VerifyDelegationTokenResponse200")
+
+
+@_attrs_define
+class VerifyDelegationTokenResponse200:
+    """ 
+        Attributes:
+            valid (Union[Unset, bool]):
+            sub (Union[Unset, str]):
+            aud (Union[Unset, str]):
+            allowed_actions (Union[Unset, List[str]]):
+            allowed_topics (Union[Unset, List[str]]):
+            chain_depth (Union[Unset, int]):
+            delegation_chain (Union[Unset, List['DelegationChainLink']]):
+            error_code (Union[Unset, str]):
+     """
+
+    valid: Union[Unset, bool] = UNSET
+    sub: Union[Unset, str] = UNSET
+    aud: Union[Unset, str] = UNSET
+    allowed_actions: Union[Unset, List[str]] = UNSET
+    allowed_topics: Union[Unset, List[str]] = UNSET
+    chain_depth: Union[Unset, int] = UNSET
+    delegation_chain: Union[Unset, List['DelegationChainLink']] = UNSET
+    error_code: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.delegation_chain_link import DelegationChainLink
+        valid = self.valid
+
+        sub = self.sub
+
+        aud = self.aud
+
+        allowed_actions: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_actions, Unset):
+            allowed_actions = self.allowed_actions
+
+
+
+        allowed_topics: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.allowed_topics, Unset):
+            allowed_topics = self.allowed_topics
+
+
+
+        chain_depth = self.chain_depth
+
+        delegation_chain: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.delegation_chain, Unset):
+            delegation_chain = []
+            for delegation_chain_item_data in self.delegation_chain:
+                delegation_chain_item = delegation_chain_item_data.to_dict()
+                delegation_chain.append(delegation_chain_item)
+
+
+
+        error_code = self.error_code
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if valid is not UNSET:
+            field_dict["valid"] = valid
+        if sub is not UNSET:
+            field_dict["sub"] = sub
+        if aud is not UNSET:
+            field_dict["aud"] = aud
+        if allowed_actions is not UNSET:
+            field_dict["allowed_actions"] = allowed_actions
+        if allowed_topics is not UNSET:
+            field_dict["allowed_topics"] = allowed_topics
+        if chain_depth is not UNSET:
+            field_dict["chain_depth"] = chain_depth
+        if delegation_chain is not UNSET:
+            field_dict["delegation_chain"] = delegation_chain
+        if error_code is not UNSET:
+            field_dict["error_code"] = error_code
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.delegation_chain_link import DelegationChainLink
+        d = src_dict.copy()
+        valid = d.pop("valid", UNSET)
+
+        sub = d.pop("sub", UNSET)
+
+        aud = d.pop("aud", UNSET)
+
+        allowed_actions = cast(List[str], d.pop("allowed_actions", UNSET))
+
+
+        allowed_topics = cast(List[str], d.pop("allowed_topics", UNSET))
+
+
+        chain_depth = d.pop("chain_depth", UNSET)
+
+        delegation_chain = []
+        _delegation_chain = d.pop("delegation_chain", UNSET)
+        for delegation_chain_item_data in (_delegation_chain or []):
+            delegation_chain_item = DelegationChainLink.from_dict(delegation_chain_item_data)
+
+
+
+            delegation_chain.append(delegation_chain_item)
+
+
+        error_code = d.pop("error_code", UNSET)
+
+        verify_delegation_token_response_200 = cls(
+            valid=valid,
+            sub=sub,
+            aud=aud,
+            allowed_actions=allowed_actions,
+            allowed_topics=allowed_topics,
+            chain_depth=chain_depth,
+            delegation_chain=delegation_chain,
+            error_code=error_code,
+        )
+
+
+        verify_delegation_token_response_200.additional_properties = d
+        return verify_delegation_token_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/verify_mcp_signature_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/verify_mcp_signature_body.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="VerifyMcpSignatureBody")
+
+
+@_attrs_define
+class VerifyMcpSignatureBody:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        verify_mcp_signature_body = cls(
+        )
+
+
+        verify_mcp_signature_body.additional_properties = d
+        return verify_mcp_signature_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/verify_mcp_signature_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/verify_mcp_signature_response_200.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="VerifyMcpSignatureResponse200")
+
+
+@_attrs_define
+class VerifyMcpSignatureResponse200:
+    """ 
+     """
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        verify_mcp_signature_response_200 = cls(
+        )
+
+
+        verify_mcp_signature_response_200.additional_properties = d
+        return verify_mcp_signature_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/workflow_definition.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/workflow_definition.py
@@ -14,8 +14,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.workflow_definition_config import WorkflowDefinitionConfig
   from ..models.workflow_definition_steps import WorkflowDefinitionSteps
+  from ..models.workflow_definition_config import WorkflowDefinitionConfig
 
 
 
@@ -52,8 +52,8 @@ class WorkflowDefinition:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.workflow_definition_config import WorkflowDefinitionConfig
         from ..models.workflow_definition_steps import WorkflowDefinitionSteps
+        from ..models.workflow_definition_config import WorkflowDefinitionConfig
         id = self.id
 
         name = self.name
@@ -101,8 +101,8 @@ class WorkflowDefinition:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.workflow_definition_config import WorkflowDefinitionConfig
         from ..models.workflow_definition_steps import WorkflowDefinitionSteps
+        from ..models.workflow_definition_config import WorkflowDefinitionConfig
         d = src_dict.copy()
         id = d.pop("id")
 

--- a/sdk/python/src/cordum_sdk/_generated/models/workflow_definition.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/workflow_definition.py
@@ -14,8 +14,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.workflow_definition_steps import WorkflowDefinitionSteps
   from ..models.workflow_definition_config import WorkflowDefinitionConfig
+  from ..models.workflow_definition_steps import WorkflowDefinitionSteps
 
 
 
@@ -52,8 +52,8 @@ class WorkflowDefinition:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.workflow_definition_steps import WorkflowDefinitionSteps
         from ..models.workflow_definition_config import WorkflowDefinitionConfig
+        from ..models.workflow_definition_steps import WorkflowDefinitionSteps
         id = self.id
 
         name = self.name
@@ -101,8 +101,8 @@ class WorkflowDefinition:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.workflow_definition_steps import WorkflowDefinitionSteps
         from ..models.workflow_definition_config import WorkflowDefinitionConfig
+        from ..models.workflow_definition_steps import WorkflowDefinitionSteps
         d = src_dict.copy()
         id = d.pop("id")
 

--- a/sdk/python/src/cordum_sdk/_generated/models/workflow_step.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/workflow_step.py
@@ -15,8 +15,8 @@ from typing import Dict
 from typing import Union
 
 if TYPE_CHECKING:
-  from ..models.workflow_step_retry import WorkflowStepRetry
   from ..models.workflow_step_config import WorkflowStepConfig
+  from ..models.workflow_step_retry import WorkflowStepRetry
 
 
 
@@ -49,8 +49,8 @@ class WorkflowStep:
 
 
     def to_dict(self) -> Dict[str, Any]:
-        from ..models.workflow_step_retry import WorkflowStepRetry
         from ..models.workflow_step_config import WorkflowStepConfig
+        from ..models.workflow_step_retry import WorkflowStepRetry
         id = self.id
 
         type = self.type
@@ -97,8 +97,8 @@ class WorkflowStep:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.workflow_step_retry import WorkflowStepRetry
         from ..models.workflow_step_config import WorkflowStepConfig
+        from ..models.workflow_step_retry import WorkflowStepRetry
         d = src_dict.copy()
         id = d.pop("id")
 

--- a/sdk/typescript/src/_generated/schema.d.ts
+++ b/sdk/typescript/src/_generated/schema.d.ts
@@ -42,13 +42,16 @@ export interface paths {
     "/api/v1/agents/{id}": {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
             path: {
                 id: string;
             };
             cookie?: never;
         };
-        /** Get an agent identity */
+        /** Get one agent identity */
         get: operations["getAgent"];
         /** Update an agent identity */
         put: operations["updateAgent"];
@@ -60,19 +63,88 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{id}/delegate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Issue a delegation token from one agent to another */
+        post: operations["issueDelegationToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/{id}/delegations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List delegation tokens issued by a specific agent */
+        get: operations["listDelegationsForAgent"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{id}/stats": {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                id: string;
-            };
+            path?: never;
             cookie?: never;
         };
-        /** Get per-agent statistics */
+        /** Get per-agent runtime statistics */
         get: operations["getAgentStats"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/revoke-delegation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Revoke a delegation token by JTI
+         * @description By default revoking a token cascades to every downstream delegation that extended it. Set `cascade=false` for narrow-scoped revocation.
+         */
+        post: operations["revokeDelegationToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/verify-delegation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Verify a delegation token for an expected audience */
+        post: operations["verifyDelegationToken"];
         delete?: never;
         options?: never;
         head?: never;
@@ -519,6 +591,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/delegations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List delegation tokens for the current tenant */
+        get: operations["listDelegations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/dlq": {
         parameters: {
             query?: never;
@@ -579,6 +668,206 @@ export interface paths {
         };
         /** List DLQ entries (paginated) */
         get: operations["listDLQPaginated"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/datasets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List eval datasets */
+        get: operations["listEvalDatasets"];
+        put?: never;
+        /** Create a curated eval dataset */
+        post: operations["createEvalDataset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/datasets/{id}": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** Get one eval dataset */
+        get: operations["getEvalDataset"];
+        /** Create a successor version from an existing dataset */
+        put: operations["createEvalDatasetSuccessor"];
+        post?: never;
+        /** Delete an eval dataset */
+        delete: operations["deleteEvalDataset"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/datasets/{id}/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run an eval dataset against the active or candidate policy
+         * @description Synchronous for ≤500 entries (returns 200 with full result), asynchronous for larger datasets (returns 202 with run_id; poll GET /evals/runs/{runId}).
+         */
+        post: operations["runEvalDataset"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/datasets/{id}/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List historical runs for one eval dataset */
+        get: operations["listEvalRuns"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/datasets/by-name/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List versions for an eval dataset family */
+        get: operations["listEvalDatasetVersions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/datasets/by-name/{name}/versions/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a dataset by name and version */
+        get: operations["getEvalDatasetByNameVersion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/datasets/from-incidents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Derive an eval dataset from governance incidents */
+        post: operations["createEvalDatasetFromIncidents"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/evals/runs/{run_id}": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        /** Get one eval run */
+        get: operations["getEvalRun"];
+        put?: never;
+        post?: never;
+        /** Delete a historical eval run */
+        delete: operations["deleteEvalRun"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/governance/approvals/analytics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Approval analytics (time-to-approve, auto vs manual, bottlenecks)
+         * @description Aggregated approval KPIs for the requested window. Consumes the
+         *     Policy Decision Log as the source of truth, pairs each
+         *     require_approval verdict with its ApprovalRecord, and computes
+         *     per-group breakdowns sorted with the slowest approvers first so
+         *     bottlenecks surface at the top.
+         *
+         *     Requires the `governance.read` permission.
+         *
+         *     Responses are memoised per `(tenant, window, group_by, limit)`
+         *     tuple for 30 seconds so dashboards can poll without thrashing
+         *     the decision-log index.
+         */
+        get: operations["getApprovalAnalytics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/governance/decisions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Query the governance decision log */
+        get: operations["listGovernanceDecisions"];
         put?: never;
         post?: never;
         delete?: never;
@@ -864,6 +1153,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/mcp/approvals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List MCP tool-call approvals */
+        get: operations["listMcpApprovals"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp/approvals/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one MCP approval record */
+        get: operations["getMcpApproval"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp/approvals/{id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Approve an MCP tool-call approval request */
+        post: operations["approveMcpApproval"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp/approvals/{id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reject an MCP tool-call approval request */
+        post: operations["rejectMcpApproval"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/mcp/message": {
         parameters: {
             query?: never;
@@ -875,6 +1232,26 @@ export interface paths {
         put?: never;
         /** Send a JSON-RPC 2.0 message to MCP server */
         post: operations["mcpMessageV1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp/outbound": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List outbound MCP signed-call events
+         * @description Walks the tenant's audit chain stream and returns observed outbound MCP calls, filtered by time range + subject. Admin-only.
+         */
+        get: operations["listMcpOutbound"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -913,6 +1290,46 @@ export interface paths {
         get: operations["mcpStatusV1"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Outbound MCP usage buckets from the audit chain
+         * @description Walks the tenant's audit chain and buckets outbound MCP calls by subject, method, and tool for usage analytics. Admin-only.
+         */
+        get: operations["getMcpUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp/verify-signature": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Verify an outbound MCP signature (admin-gated)
+         * @description Verify an ECDSA signature over an MCP request against the trusted-key store. Admin-only. See docs/mcp/outbound-signing.md.
+         */
+        post: operations["verifyMcpSignature"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2167,6 +2584,45 @@ export interface components {
             scopes?: string[];
             usageCount?: number;
         };
+        ApprovalAnalyticsGroup: {
+            approved: number;
+            auto_count: number;
+            avg_ttar_seconds?: number | null;
+            expired: number;
+            /** @description Group identifier (rule id, agent id, or topic string). */
+            key: string;
+            label: string;
+            manual_count: number;
+            p90_seconds?: number | null;
+            rejected: number;
+            total: number;
+        };
+        ApprovalAnalyticsResponse: {
+            groups?: components["schemas"]["ApprovalAnalyticsGroup"][];
+            summary: components["schemas"]["ApprovalAnalyticsSummary"];
+            window: {
+                /** Format: date-time */
+                since: string;
+                /** Format: date-time */
+                until: string;
+            };
+        };
+        ApprovalAnalyticsSummary: {
+            approved: number;
+            /** @description Resolutions driven by lifecycle events (expire/invalidate/repair), not human decision. */
+            auto_resolved: number;
+            /** @description Null when no approvals resolved in the window — distinguishes "no data" from "all resolved in 0 s". */
+            avg_time_to_approve_seconds?: number | null;
+            expired: number;
+            /** @description Resolutions where a human approver entered approve or reject. */
+            manual_resolved: number;
+            p50?: number | null;
+            p90?: number | null;
+            p99?: number | null;
+            rejected: number;
+            /** @description Total decisions with verdict=require_approval in the window (includes still-pending). */
+            total: number;
+        };
         ApprovalDecisionRequest: {
             note?: string;
             reason: string;
@@ -2299,6 +2755,64 @@ export interface components {
             tenant?: string;
             username: string;
         };
+        DelegationChainLink: {
+            agent_id: string;
+            /** Format: date-time */
+            expires_at: string;
+            /** Format: date-time */
+            issued_at: string;
+            issued_by: string;
+            jti: string;
+            parent_jti?: string | null;
+        };
+        DelegationLineageChainLink: {
+            agent_id?: string;
+            /** Format: date-time */
+            expires_at?: string;
+            /** Format: date-time */
+            issued_at?: string;
+            jti?: string;
+            parent_jti?: string;
+        };
+        DelegationLineageView: {
+            audience?: string;
+            chain?: components["schemas"]["DelegationLineageChainLink"][];
+            chain_depth?: number;
+            /** Format: date-time */
+            expires_at?: string;
+            jti?: string;
+            parent_issuer?: string;
+            reverified_at_dispatch?: boolean;
+            root_issuer?: string;
+            scope?: string[];
+            /** Format: int64 */
+            verified_at?: number;
+        };
+        DelegationListResponse: {
+            items: components["schemas"]["DelegationView"][];
+            next_cursor?: string | null;
+        };
+        DelegationView: {
+            allowed_actions?: string[];
+            allowed_topics?: string[];
+            /** @description Target agent the token was minted for. */
+            audience: string;
+            chain?: components["schemas"]["DelegationChainLink"][];
+            chain_depth: number;
+            /** Format: date-time */
+            expires_at: string;
+            /** Format: date-time */
+            issued_at: string;
+            /** @description Root issuer for the delegation chain. */
+            issuer: string;
+            jti: string;
+            revoked: boolean;
+            /** Format: date-time */
+            revoked_at?: string | null;
+            revoked_reason?: string | null;
+            /** @description Agent that issued the token. */
+            subject: string;
+        };
         DLQEntry: {
             error?: string;
             /** Format: date-time */
@@ -2320,8 +2834,119 @@ export interface components {
             /** @description HTTP status code */
             status: number;
         };
+        EvalEntryResult: {
+            actual_decision?: string;
+            /** @enum {string} */
+            drift_direction: "escalated" | "relaxed" | "unchanged";
+            entry_id: string;
+            error?: string;
+            expected_decision?: string;
+            input?: {
+                [key: string]: unknown;
+            };
+            reason?: string;
+            rule_id?: string;
+            /**
+             * @description regression = expected was deny/require_approval/throttle/allow_with_constraints AND actual is allow
+             * @enum {string}
+             */
+            status: "pass" | "fail" | "regression" | "error";
+        };
+        EvalRunAcceptedResponse: {
+            /** Format: date-time */
+            completed_at?: string;
+            dataset_id?: string;
+            dataset_name?: string;
+            dataset_version?: number;
+            error?: string;
+            policy_snapshot?: string;
+            poll_url?: string;
+            /** Format: uuid */
+            run_id: string;
+            /** Format: date-time */
+            started_at?: string;
+            /** @enum {string} */
+            status: "pending" | "running" | "failed";
+            tenant?: string;
+        };
+        EvalRunRequest: {
+            candidate_bundle_id?: string;
+            candidate_content?: string;
+            max_entries?: number;
+            use_current_policy?: boolean;
+        };
+        EvalRunResult: {
+            /** Format: date-time */
+            completed_at: string;
+            dataset_id: string;
+            dataset_name: string;
+            dataset_version: number;
+            entries: components["schemas"]["EvalEntryResult"][];
+            policy_snapshot: string;
+            /** Format: uuid */
+            run_id: string;
+            /** Format: date-time */
+            started_at: string;
+            summary: components["schemas"]["EvalRunSummary"];
+            tenant: string;
+        };
+        EvalRunsResponse: {
+            items: components["schemas"]["EvalRunResult"][];
+            next_cursor?: string;
+        };
+        EvalRunSummary: {
+            errored: number;
+            failed: number;
+            passed: number;
+            regressions: number;
+            /** Format: float */
+            score_percent?: number | null;
+            total: number;
+        };
         GenericObject: {
             [key: string]: unknown;
+        };
+        /**
+         * @description Pack-signature verification outcome computed by the gateway at
+         *     install time. Never client-supplied — the gateway discards any
+         *     `verification` field on the install payload and computes its own.
+         *     Pre-existing installs default to {signed: false} when this object
+         *     is absent.
+         */
+        InstalledPackVerification: {
+            /**
+             * @description True when a valid Cordum counter-signature envelope
+             *     (pack.yaml.sig.cordum) is present and verified against the
+             *     embedded Cordum counter-signing key.
+             */
+            has_cordum_counter_sig?: boolean;
+            /** @description Key id of the Ed25519 public key that verified the pack. */
+            kid?: string;
+            /** @description Canonical manifest version that was signed. */
+            pack_signature_version?: number;
+            /** @description Publisher identifier derived from the trusted key's metadata. */
+            publisher_id?: string;
+            /**
+             * @description Algorithm advertised by the verified envelope. Always ed25519 today.
+             * @enum {string}
+             */
+            signature_algorithm?: "ed25519";
+            /**
+             * @description True when the gateway successfully verified the pack against
+             *     a trusted publisher key at install time.
+             */
+            signed: boolean;
+            /**
+             * Format: date-time
+             * @description RFC3339 timestamp of the server-side verification.
+             */
+            verified_at?: string;
+            /**
+             * @description Non-fatal warnings the gateway wants to surface alongside the
+             *     verification outcome (for example, "pack accepted unsigned —
+             *     gateway strict mode disabled").
+             */
+            warnings?: string[];
         };
         JobDetail: components["schemas"]["JobSummary"] & {
             adapter_id?: string;
@@ -2332,6 +2957,7 @@ export interface components {
             /** Format: date-time */
             created_at?: string;
             decisions?: components["schemas"]["SafetyDecision"][] | null;
+            delegation?: components["schemas"]["DelegationLineageView"];
             error?: string | null;
             labels?: {
                 [key: string]: string;
@@ -2517,6 +3143,12 @@ export interface components {
             status?: "ACTIVE" | "INACTIVE" | "UNINSTALLED" | "ERROR";
             /** Format: date-time */
             updated_at?: string;
+            /**
+             * @description Server-verified pack signature state. Pre-existing installs
+             *     from before signature verification shipped read as absent;
+             *     clients SHOULD render an absent value as {signed: false}.
+             */
+            verification?: components["schemas"]["InstalledPackVerification"];
             version?: string;
         };
         PackVerification: {
@@ -3194,44 +3826,82 @@ export interface operations {
     };
     listAgents: {
         parameters: {
-            query?: never;
-            header?: never;
+            query?: {
+                cursor?: string;
+                limit?: number;
+                risk_tier?: string;
+                status?: string;
+                team?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Agents */
+            /** @description Agent identity page */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": {
-                        [key: string]: unknown;
+                        cursor?: string;
+                        items?: {
+                            allowed_pools?: string[];
+                            allowed_tools?: string[];
+                            allowed_topics?: string[];
+                            created_at?: string;
+                            data_classifications?: string[];
+                            description?: string;
+                            id?: string;
+                            /** Format: int64 */
+                            last_active?: number;
+                            name?: string;
+                            owner?: string;
+                            risk_tier?: string;
+                            status?: string;
+                            team?: string;
+                            updated_at?: string;
+                        }[];
                     };
                 };
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     createAgent: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
             path?: never;
             cookie?: never;
         };
         requestBody: {
             content: {
                 "application/json": {
-                    [key: string]: unknown;
+                    allowed_pools?: string[];
+                    allowed_tools?: string[];
+                    allowed_topics?: string[];
+                    data_classifications?: string[];
+                    description?: string;
+                    name: string;
+                    owner: string;
+                    risk_tier: string;
+                    team?: string;
                 };
             };
         };
         responses: {
-            /** @description Created */
+            /** @description Agent identity created */
             201: {
                 headers: {
                     [name: string]: unknown;
@@ -3245,12 +3915,17 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            409: components["responses"]["Conflict"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     getAgent: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
             path: {
                 id: string;
             };
@@ -3258,7 +3933,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Agent */
+            /** @description Agent identity */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -3272,12 +3947,16 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     updateAgent: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
             path: {
                 id: string;
             };
@@ -3286,12 +3965,21 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
-                    [key: string]: unknown;
+                    allowed_pools?: string[];
+                    allowed_tools?: string[];
+                    allowed_topics?: string[];
+                    data_classifications?: string[];
+                    description?: string;
+                    name?: string;
+                    owner?: string;
+                    risk_tier?: string;
+                    status?: string;
+                    team?: string;
                 };
             };
         };
         responses: {
-            /** @description Updated */
+            /** @description Agent identity updated */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -3306,12 +3994,16 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     deleteAgent: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
             path: {
                 id: string;
             };
@@ -3319,7 +4011,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Deleted */
+            /** @description Agent identity deleted */
             204: {
                 headers: {
                     [name: string]: unknown;
@@ -3329,12 +4021,73 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
-    getAgentStats: {
+    issueDelegationToken: {
         parameters: {
             query?: never;
-            header?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    allowed_actions?: string[];
+                    allowed_topics?: string[];
+                    parent_token?: string;
+                    target_agent_id: string;
+                    /** Format: int64 */
+                    ttl_seconds?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Delegation token issued */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        chain_depth?: number;
+                        expires_at?: string;
+                        jti?: string;
+                        kid?: string;
+                        token?: string;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            429: components["responses"]["RateLimited"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    listDelegationsForAgent: {
+        parameters: {
+            query?: {
+                before_expiry?: string;
+                cursor?: string;
+                limit?: number;
+                scope?: string;
+                since_issued?: string;
+                status?: "active" | "revoked" | "expired" | "all";
+                until_issued?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
             path: {
                 id: string;
             };
@@ -3342,7 +4095,36 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Stats */
+            /** @description Delegation token page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DelegationListResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getAgentStats: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Runtime statistics for the requested agent */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -3356,6 +4138,93 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    revokeDelegationToken: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description When true, revoke downstream delegations that extended this token.
+                     * @default true
+                     */
+                    cascade?: boolean;
+                    jti: string;
+                    reason?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Delegation token revoked */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Number of downstream delegations revoked in addition to the root token. */
+                        cascaded_count: number;
+                        jti: string;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    verifyDelegationToken: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    expected_audience?: string;
+                    token: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Delegation verification result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        allowed_actions?: string[];
+                        allowed_topics?: string[];
+                        aud?: string;
+                        chain_depth?: number;
+                        delegation_chain?: components["schemas"]["DelegationChainLink"][];
+                        error_code?: string;
+                        sub?: string;
+                        valid?: boolean;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     listApprovals: {
@@ -4255,6 +5124,41 @@ export interface operations {
             500: components["responses"]["InternalServerError"];
         };
     };
+    listDelegations: {
+        parameters: {
+            query?: {
+                before_expiry?: string;
+                cursor?: string;
+                limit?: number;
+                scope?: string;
+                since_issued?: string;
+                status?: "active" | "revoked" | "expired" | "all";
+                until_issued?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delegation token page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DelegationListResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
     listDLQ: {
         parameters: {
             query?: {
@@ -4370,6 +5274,578 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             500: components["responses"]["InternalServerError"];
+        };
+    };
+    listEvalDatasets: {
+        parameters: {
+            query?: {
+                created_after?: string;
+                created_before?: string;
+                cursor?: string;
+                limit?: number;
+                name_prefix?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Eval dataset page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items?: {
+                            [key: string]: unknown;
+                        }[];
+                        next_cursor?: string;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    createEvalDataset: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    description?: string;
+                    entries: {
+                        expected_decision?: string;
+                        id?: string;
+                        input?: {
+                            [key: string]: unknown;
+                        };
+                        metadata?: {
+                            [key: string]: string;
+                        };
+                        notes?: string;
+                        rule_id?: string;
+                        source?: string;
+                        source_ref?: string;
+                    }[];
+                    name: string;
+                    version: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Eval dataset created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            409: components["responses"]["Conflict"];
+            413: components["responses"]["PayloadTooLarge"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getEvalDataset: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Eval dataset */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    createEvalDatasetSuccessor: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    description?: string;
+                    entries?: {
+                        [key: string]: unknown;
+                    }[];
+                    version?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Successor dataset created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            413: components["responses"]["PayloadTooLarge"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    deleteEvalDataset: {
+        parameters: {
+            query?: {
+                force?: boolean;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Dataset deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    runEvalDataset: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["EvalRunRequest"];
+            };
+        };
+        responses: {
+            /** @description Run completed synchronously */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalRunResult"];
+                };
+            };
+            /** @description Run accepted for asynchronous processing */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalRunAcceptedResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            429: components["responses"]["RateLimited"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    listEvalRuns: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                has_regression?: boolean;
+                limit?: number;
+                min_score?: number;
+                since?: string;
+                until?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run history page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalRunsResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    listEvalDatasetVersions: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Dataset versions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items?: {
+                            [key: string]: unknown;
+                        }[];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getEvalDatasetByNameVersion: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                name: string;
+                version: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Eval dataset */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    createEvalDatasetFromIncidents: {
+        parameters: {
+            query?: {
+                dry_run?: boolean;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    agent_id?: string;
+                    description?: string;
+                    dry_run?: boolean;
+                    max_entries?: number;
+                    name: string;
+                    rule_id?: string;
+                    since?: string;
+                    tenant?: string;
+                    topic?: string;
+                    until?: string;
+                    verdicts?: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Dry-run extraction result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Eval dataset created from incidents */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            429: components["responses"]["RateLimited"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getEvalRun: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Completed run result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalRunResult"];
+                };
+            };
+            /** @description Run is still pending or running */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalRunAcceptedResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    deleteEvalRun: {
+        parameters: {
+            query?: {
+                force?: boolean;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Eval run deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getApprovalAnalytics: {
+        parameters: {
+            query?: {
+                /** @description Breakdown axis; `overall` returns only the window-wide summary. */
+                group_by?: "overall" | "rule" | "agent" | "topic";
+                /** @description Top-N rows per group (bounded at 50). Ignored when `group_by=overall`. */
+                limit?: number;
+                /** @description Inclusive lower bound (RFC3339 or unix milliseconds). Defaults to 24h before `until`. */
+                since?: string;
+                /** @description Exclusive upper bound (RFC3339 or unix milliseconds). Defaults to now. */
+                until?: string;
+                /** @description Shorthand for `since`/`until` (wins when supplied). One of `24h`, `7d`, `30d`. */
+                window?: "24h" | "7d" | "30d";
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Approval analytics response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApprovalAnalyticsResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description Decision log store unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listGovernanceDecisions: {
+        parameters: {
+            query?: {
+                agent_id?: string;
+                cursor?: string;
+                limit?: number;
+                rule_id?: string;
+                since?: string;
+                topic?: string;
+                until?: string;
+                verdict?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Governance decision page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items?: {
+                            agent_id?: string;
+                            approval_decision?: string;
+                            approval_status?: string;
+                            constraints?: {
+                                [key: string]: unknown;
+                            };
+                            job_id?: string;
+                            matched_rule?: string;
+                            policy_version?: string;
+                            reason?: string;
+                            timestamp?: string;
+                            topic?: string;
+                            verdict?: string;
+                        }[];
+                        next_cursor?: string;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     healthCheckV1: {
@@ -4885,6 +6361,145 @@ export interface operations {
             502: components["responses"]["BadGateway"];
         };
     };
+    listMcpApprovals: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                limit?: number;
+                status?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description MCP approval page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items?: {
+                            [key: string]: unknown;
+                        }[];
+                        /** Format: uint64 */
+                        next_cursor?: number;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getMcpApproval: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description MCP approval record */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    approveMcpApproval: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ApprovalDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description MCP approval resolved */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    rejectMcpApproval: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ApprovalDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description MCP approval resolved */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
     mcpMessageV1: {
         parameters: {
             query?: never;
@@ -4911,6 +6526,39 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    listMcpOutbound: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                limit?: number;
+                since?: string;
+                until?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Outbound MCP event page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             503: components["responses"]["ServiceUnavailable"];
@@ -4965,6 +6613,70 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    getMcpUsage: {
+        parameters: {
+            query?: {
+                group_by?: "subject" | "method" | "tool";
+                since?: string;
+                until?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Usage buckets */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    verifyMcpSignature: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Verification verdict */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     getMemory: {
@@ -7608,12 +9320,6 @@ export interface operations {
     };
 }
 export enum ApiPaths {
-    listAgents = "/api/v1/agents",
-    createAgent = "/api/v1/agents",
-    getAgent = "/api/v1/agents/{id}",
-    updateAgent = "/api/v1/agents/{id}",
-    deleteAgent = "/api/v1/agents/{id}",
-    getAgentStats = "/api/v1/agents/{id}/stats",
     getAuthConfig = "/api/v1/auth/config",
     login = "/api/v1/auth/login",
     getSession = "/api/v1/auth/session",
@@ -7752,5 +9458,37 @@ export enum ApiPaths {
     replayPolicyDecisions = "/api/v1/policy/replay",
     mcpSSEV1 = "/api/v1/mcp/sse",
     mcpMessageV1 = "/api/v1/mcp/message",
-    mcpStatusV1 = "/api/v1/mcp/status"
+    listAgents = "/api/v1/agents",
+    createAgent = "/api/v1/agents",
+    getAgent = "/api/v1/agents/{id}",
+    updateAgent = "/api/v1/agents/{id}",
+    deleteAgent = "/api/v1/agents/{id}",
+    getAgentStats = "/api/v1/agents/{id}/stats",
+    issueDelegationToken = "/api/v1/agents/{id}/delegate",
+    verifyDelegationToken = "/api/v1/agents/verify-delegation",
+    revokeDelegationToken = "/api/v1/agents/revoke-delegation",
+    listDelegationsForAgent = "/api/v1/agents/{id}/delegations",
+    listDelegations = "/api/v1/delegations",
+    listGovernanceDecisions = "/api/v1/governance/decisions",
+    listMcpApprovals = "/api/v1/mcp/approvals",
+    getMcpApproval = "/api/v1/mcp/approvals/{id}",
+    approveMcpApproval = "/api/v1/mcp/approvals/{id}/approve",
+    rejectMcpApproval = "/api/v1/mcp/approvals/{id}/reject",
+    verifyMcpSignature = "/api/v1/mcp/verify-signature",
+    listMcpOutbound = "/api/v1/mcp/outbound",
+    getMcpUsage = "/api/v1/mcp/usage",
+    createEvalDatasetFromIncidents = "/api/v1/evals/datasets/from-incidents",
+    listEvalDatasets = "/api/v1/evals/datasets",
+    createEvalDataset = "/api/v1/evals/datasets",
+    listEvalDatasetVersions = "/api/v1/evals/datasets/by-name/{name}",
+    getEvalDatasetByNameVersion = "/api/v1/evals/datasets/by-name/{name}/versions/{version}",
+    getEvalDataset = "/api/v1/evals/datasets/{id}",
+    createEvalDatasetSuccessor = "/api/v1/evals/datasets/{id}",
+    deleteEvalDataset = "/api/v1/evals/datasets/{id}",
+    runEvalDataset = "/api/v1/evals/datasets/{id}/run",
+    listEvalRuns = "/api/v1/evals/datasets/{id}/runs",
+    getEvalRun = "/api/v1/evals/runs/{run_id}",
+    deleteEvalRun = "/api/v1/evals/runs/{run_id}",
+    mcpStatusV1 = "/api/v1/mcp/status",
+    getApprovalAnalytics = "/api/v1/governance/approvals/analytics"
 }

--- a/sdk/typescript/src/_generated/schema.d.ts
+++ b/sdk/typescript/src/_generated/schema.d.ts
@@ -97,6 +97,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{id}/denied-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Recent mcp_tool_denied events for an agent identity
+         * @description Returns up to 50 of the most recent `mcp_tool_denied` audit events for the identity from the gateway's in-memory ring. Feeds the dashboard "recent denials" panel without requiring a SIEM pipeline.
+         */
+        get: operations["getAgentDeniedEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{id}/stats": {
         parameters: {
             query?: never;
@@ -106,6 +126,26 @@ export interface paths {
         };
         /** Get per-agent runtime statistics */
         get: operations["getAgentStats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/{id}/tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List MCP tools visible to a specific agent identity
+         * @description Returns the subset of the MCP tool catalogue this agent identity can call after applying the identity-aware filter (risk tier + data classification). A revoked or suspended identity returns an empty list with an advisory `note` field rather than failing.
+         */
+        get: operations["getAgentToolVisibility"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1288,6 +1328,26 @@ export interface paths {
         };
         /** Get MCP server status */
         get: operations["mcpStatusV1"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp/tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List MCP tools visible to an agent or the full catalogue
+         * @description Returns the MCP tool catalogue. Without an `agent_id` query parameter, returns the unfiltered admin view. With `agent_id`, returns the subset of tools the identity is entitled to call after applying the MCP risk- tier and data-classification filter.
+         */
+        get: operations["listMcpTools"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4110,6 +4170,35 @@ export interface operations {
             503: components["responses"]["ServiceUnavailable"];
         };
     };
+    getAgentDeniedEvents: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Most recent denial records for the agent */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
     getAgentStats: {
         parameters: {
             query?: never;
@@ -4125,6 +4214,37 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Runtime statistics for the requested agent */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getAgentToolVisibility: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Tool list filtered for the agent identity */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -6609,6 +6729,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["McpStatus"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    listMcpTools: {
+        parameters: {
+            query?: {
+                agent_id?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Tool list for the requested scope */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -9477,6 +9626,9 @@ export enum ApiPaths {
     verifyMcpSignature = "/api/v1/mcp/verify-signature",
     listMcpOutbound = "/api/v1/mcp/outbound",
     getMcpUsage = "/api/v1/mcp/usage",
+    listMcpTools = "/api/v1/mcp/tools",
+    getAgentToolVisibility = "/api/v1/agents/{id}/tools",
+    getAgentDeniedEvents = "/api/v1/agents/{id}/denied-events",
     createEvalDatasetFromIncidents = "/api/v1/evals/datasets/from-incidents",
     listEvalDatasets = "/api/v1/evals/datasets",
     createEvalDataset = "/api/v1/evals/datasets",


### PR DESCRIPTION
## Summary
Final split (7/7) from the original #198 squash. Re-opened after #204 auto-closed when its base branch \`split/platform\` was deleted post-merge. All review threads on #204 were already resolved before closure.

## What's in here
- **Blocker 2 fix (TOCTOU on stale snapshot)** — drift re-evaluation with original requester principal, full decision persistence, approval_snapshot label (handlers_approvals.go)
- **Scheduler fast-path binding** — approval fast-path now binds to current PolicySnapshot (engine.go)
- **Reconciler auto-invalidate** — scheduler reconciler provider wires back into approval store
- CodeRabbit residuals on drift re-evaluation (3 findings)
- Drop duplicate EventApprovalRevisionMismatch audit constant

## Commits
1. \`05795eaa\` split 6/7 of #198 — stale-snapshot recovery + reconciler auto-invalidate
2. \`e0814d66\` close blocker 2 from #198 review — TOCTOU on stale snapshot
3. \`977b9d0c\` bind scheduler approval fast-path to current PolicySnapshot (blocker 2 scheduler half)
4. \`36e06746\` address 3 CodeRabbit residuals on drift re-evaluation
5. \`0c1c32f1\` drop duplicate EventApprovalRevisionMismatch const

## Test plan
- [x] \`go test ./core/controlplane/gateway/... ./core/controlplane/scheduler/...\` (approval + dispatch paths)
- [x] \`go test ./core/audit/...\` (no duplicate const)
- [x] Full \`make build\` + \`make test\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Approvals now bind to policy snapshots and persist rotated safety snapshots for consistent admission decisions.
  * Granular authorization checks added for approval operations.
  * SIEM/audit events emitted on approval-revision mismatches.

* **New Features**
  * API endpoints to list MCP tools, view per-agent visible tools, and fetch recent denied-events.

* **New CLI**
  * cordumctl adds subcommands: auth, doctor, delegation, governance.

* **Tests**
  * Regression tests validating approval-snapshot binding and mismatch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->