### PR TITLE
fix(quickstart): share .env with shell so /status probe uses the same key as the gateway

### DIFF
--- a/tools/scripts/quickstart.sh
+++ b/tools/scripts/quickstart.sh
@@ -62,6 +62,30 @@ if ! docker info >/dev/null 2>&1; then
   die "cannot connect to the Docker daemon. Ensure Docker is running."
 fi
 
+# persist_env_var writes KEY=VALUE into .env, replacing any existing KEY line.
+# Keeps the shell (used for /status probe) and docker-compose (reads .env)
+# in agreement after auto-generation. Creates .env if absent.
+persist_env_var() {
+  local key="$1"
+  local value="$2"
+  local file=".env"
+  if [[ ! -f "${file}" ]]; then
+    echo "${key}=${value}" > "${file}"
+    return 0
+  fi
+  if grep -qE "^${key}=" "${file}"; then
+    # Replace existing line in place; awk avoids sed's escaping headache
+    # with hex secrets that can contain characters like / or &.
+    local tmp
+    tmp="$(mktemp)"
+    awk -v k="${key}" -v v="${value}" 'BEGIN{p=0} {
+      if ($0 ~ "^" k "=") { print k "=" v; p=1 } else { print $0 }
+    } END{ if (!p) print k "=" v }' "${file}" > "${tmp}" && mv "${tmp}" "${file}"
+  else
+    echo "${key}=${value}" >> "${file}"
+  fi
+}
+
 preflight_deploy() {
   local compose_files="$1"
   local allow_enterprise="$2"
@@ -83,13 +107,15 @@ preflight_deploy() {
   if [[ -z "${api_key}" ]]; then
     api_key="$(openssl rand -hex 32)"
     export CORDUM_API_KEY="${api_key}"
-    log "CORDUM_API_KEY: auto-generated (set CORDUM_API_KEY before running to override)"
+    persist_env_var CORDUM_API_KEY "${api_key}"
+    log "CORDUM_API_KEY: auto-generated and persisted to .env"
   fi
 
   if [[ -z "${REDIS_PASSWORD:-}" ]]; then
     REDIS_PASSWORD="$(openssl rand -hex 24)"
     export REDIS_PASSWORD
-    log "REDIS_PASSWORD: auto-generated (set REDIS_PASSWORD before running to override)"
+    persist_env_var REDIS_PASSWORD "${REDIS_PASSWORD}"
+    log "REDIS_PASSWORD: auto-generated and persisted to .env"
   fi
 
   # Optional auth vars become required only when user auth is enabled.
@@ -265,6 +291,33 @@ warn_port 4222 "nats client"
 warn_port 6379 "redis"
 
 # --- Env vars ---
+# If .env exists from a prior run, share its values with THIS shell so the
+# health probe uses the same API_KEY/REDIS_PASSWORD/admin creds that docker-
+# compose is feeding the containers. Without this the script would auto-
+# generate fresh secrets into its own shell env while the containers kept
+# using .env's existing values — the /status probe would then 401 for the
+# full health timeout. Only vars that aren't already set in the shell are
+# read; shell-exported overrides still win.
+load_from_env_file() {
+  local file="$1"
+  [[ -f "${file}" ]] || return 0
+  local var val
+  for var in CORDUM_API_KEY REDIS_PASSWORD CORDUM_ADMIN_PASSWORD \
+             CORDUM_ADMIN_EMAIL CORDUM_USER_AUTH_ENABLED \
+             CORDUM_TENANT_ID CORDUM_ORG_ID; do
+    if [[ -z "${!var:-}" ]]; then
+      # grep exits 1 when the var is absent from .env; with `set -e` +
+      # `pipefail` that aborts the script during `local x=$(...)`. Tolerate
+      # the missing-var case by catching the non-zero explicitly.
+      val="$(grep -E "^${var}=" "${file}" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+      if [[ -n "${val}" ]]; then
+        export "${var}=${val}"
+      fi
+    fi
+  done
+}
+load_from_env_file ".env"
+
 API_KEY=${CORDUM_API_KEY:-${API_KEY:-}}
 export CORDUM_API_KEY="${API_KEY}"
 REDIS_PASSWORD_VAL=${REDIS_PASSWORD:-}


### PR DESCRIPTION
## Summary
Fixes a 120 s health-check hang on fresh clones where `.env` already had `CORDUM_API_KEY` (from a prior run or pre-seed) but the shell didn't. Quickstart was auto-generating a fresh key in its own shell, then probing `/api/v1/status` with that new key — while the gateway container had been started with the .env key. Every probe 401'd until timeout.

## Root cause
- \`docker compose\` reads \`.env\` at runtime for container env vars.
- \`quickstart.sh\` read \`CORDUM_API_KEY\` / \`REDIS_PASSWORD\` only from the shell.
- When the two didn't agree, the gateway rejected every probe from the script.

## Fix
1. \`load_from_env_file\` at startup — parses \`.env\` and exports selected vars into the shell ONLY when they're unset. Shell-exported overrides still win.
2. \`persist_env_var\` on auto-generation — when quickstart generates a new secret, it writes it back to \`.env\` so the next container start and next run are in sync.
3. Tolerates missing-var \`grep\` returning 1 under \`set -e\` + \`pipefail\` with explicit \`|| true\`.

## Verification
With \`.env\` having \`CORDUM_USER_AUTH_ENABLED=true\` + matching admin password:
- Before: quickstart hangs 120 s on health probe → exit 1.
- After: quickstart completes cleanly; \`/api/v1/status\` returns 200 with \`nats.connected=true\`, \`redis.ok=true\`.

## Follow-up (Moe task incoming)
- Add a regression test in CI that runs quickstart against a pre-seeded .env
- Document the \`.env\` + quickstart contract in \`docs/deployment/\`
- Add a structured boot log on the gateway showing how many keys are loaded + from which source

🤖 Part of a full-system test pass; filed separately in Moe for docs/tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential synchronization issues by ensuring auto-generated secrets persist to configuration files and are properly loaded during startup, preventing mismatches between shell environment and containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->