### PR TITLE
fix(dashboard): label expired/invalidated prior approvals correctly

### DIFF
--- a/dashboard/src/pages/approvals/ApprovalDetailPage.test.tsx
+++ b/dashboard/src/pages/approvals/ApprovalDetailPage.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
 import type { BlastRadius, ApprovalContext, PriorApproval, ApprovalPolicySnapshot } from "@/api/types";
 import {
   formatTimeRemaining,
@@ -6,6 +7,7 @@ import {
   blastRadiusCount,
   isShortcutSuppressed,
   APPROVAL_SHORTCUTS,
+  PriorOutcomeBadge,
 } from "./ApprovalDetailPage";
 
 // ---------------------------------------------------------------------------
@@ -246,5 +248,46 @@ describe("ApprovalContext shape", () => {
     const rejected = makePriorApproval({ wasApproved: false, decision: "reject" });
     expect(approved.wasApproved).toBe(true);
     expect(rejected.wasApproved).toBe(false);
+  });
+});
+
+describe("PriorOutcomeBadge", () => {
+  function renderBadge(decision: string, wasApproved: boolean) {
+    return render(<PriorOutcomeBadge decision={decision} wasApproved={wasApproved} />)
+      .container.textContent?.trim() ?? "";
+  }
+
+  it.each([
+    ["approve", true, "Approved"],
+    ["approved", false, "Approved"],
+    ["reject", true, "Rejected"],
+    ["rejected", true, "Rejected"],
+    ["deny", true, "Rejected"],
+    ["expire", true, "Expired"],
+    ["expired", false, "Expired"],
+    ["invalidate", true, "Invalidated"],
+    ["invalidated", false, "Invalidated"],
+    ["repair", true, "Repaired"],
+    ["repaired", false, "Repaired"],
+  ])("decision %s is authoritative regardless of wasApproved=%s", (decision, wasApproved, expected) => {
+    expect(renderBadge(decision, wasApproved)).toBe(expected);
+  });
+
+  it("falls back to legacy boolean when decision is empty: approved", () => {
+    expect(renderBadge("", true)).toBe("Approved");
+  });
+
+  it("falls back to legacy boolean when decision is empty: rejected (not Unknown)", () => {
+    // Regression: previously the empty-decision + wasApproved=false branch
+    // showed "Unknown", losing the legacy "Rejected" outcome.
+    expect(renderBadge("", false)).toBe("Rejected");
+  });
+
+  it("renders unknown decision verbatim without overriding via wasApproved", () => {
+    // Regression: previously a non-empty unrecognized decision combined with
+    // wasApproved=true rendered as "Approved", letting the boolean override
+    // the authoritative decision string.
+    expect(renderBadge("frobnicate", true)).toBe("frobnicate");
+    expect(renderBadge("frobnicate", false)).toBe("frobnicate");
   });
 });

--- a/dashboard/src/pages/approvals/ApprovalDetailPage.tsx
+++ b/dashboard/src/pages/approvals/ApprovalDetailPage.tsx
@@ -428,6 +428,73 @@ export function formatTimeRemaining(ms: number): string {
 // Section: History (Prior Approvals)
 // ---------------------------------------------------------------------------
 
+// Renders the outcome of a prior approval. Older versions of this page used a
+// binary `wasApproved ? "Approved" : "Rejected"` ternary that mislabeled
+// expired/invalidated/repaired approvals as "Rejected" — confusing because
+// those are *not* human rejections; they are reconciler-driven lifecycle
+// transitions (e.g. workflow timeout, repair, replay invalidation).
+function PriorOutcomeBadge({
+  decision,
+  wasApproved,
+}: {
+  decision: string;
+  wasApproved: boolean;
+}) {
+  const d = (decision || "").toLowerCase();
+  if (d === "approve" || d === "approved" || (wasApproved && !d)) {
+    return (
+      <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+        <CheckCircle2 className="h-3 w-3" />
+        Approved
+      </span>
+    );
+  }
+  if (d === "reject" || d === "rejected" || d === "deny") {
+    return (
+      <span className="inline-flex items-center gap-1 text-red-500">
+        <XCircle className="h-3 w-3" />
+        Rejected
+      </span>
+    );
+  }
+  if (d === "expire" || d === "expired") {
+    return (
+      <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+        <Clock className="h-3 w-3" />
+        Expired
+      </span>
+    );
+  }
+  if (d === "invalidate" || d === "invalidated") {
+    return (
+      <span className="inline-flex items-center gap-1 text-muted-foreground">
+        <AlertTriangle className="h-3 w-3" />
+        Invalidated
+      </span>
+    );
+  }
+  if (d === "repair" || d === "repaired") {
+    return (
+      <span className="inline-flex items-center gap-1 text-blue-500">
+        <AlertTriangle className="h-3 w-3" />
+        Repaired
+      </span>
+    );
+  }
+  // Fallback: respect the legacy boolean if no decision string is present.
+  return wasApproved ? (
+    <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+      <CheckCircle2 className="h-3 w-3" />
+      Approved
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 text-muted-foreground">
+      <AlertTriangle className="h-3 w-3" />
+      {decision || "Unknown"}
+    </span>
+  );
+}
+
 function HistorySection({
   priorApprovals,
 }: {
@@ -478,17 +545,7 @@ function HistorySection({
                     {pa.resolvedBy || "—"}
                   </td>
                   <td className="py-2 pr-4">
-                    {pa.wasApproved ? (
-                      <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-                        <CheckCircle2 className="h-3 w-3" />
-                        Approved
-                      </span>
-                    ) : (
-                      <span className="inline-flex items-center gap-1 text-red-500">
-                        <XCircle className="h-3 w-3" />
-                        Rejected
-                      </span>
-                    )}
+                    <PriorOutcomeBadge decision={pa.decision} wasApproved={pa.wasApproved} />
                   </td>
                   <td className="py-2 text-muted-foreground text-xs">
                     {pa.resolvedAt

--- a/dashboard/src/pages/approvals/ApprovalDetailPage.tsx
+++ b/dashboard/src/pages/approvals/ApprovalDetailPage.tsx
@@ -433,7 +433,12 @@ export function formatTimeRemaining(ms: number): string {
 // expired/invalidated/repaired approvals as "Rejected" — confusing because
 // those are *not* human rejections; they are reconciler-driven lifecycle
 // transitions (e.g. workflow timeout, repair, replay invalidation).
-function PriorOutcomeBadge({
+//
+// Precedence: a non-empty `decision` string is authoritative. The legacy
+// `wasApproved` boolean is only consulted when `decision` is absent (older
+// fixtures without the field). Unknown non-empty decisions render verbatim
+// rather than being overridden by the boolean.
+export function PriorOutcomeBadge({
   decision,
   wasApproved,
 }: {
@@ -441,7 +446,20 @@ function PriorOutcomeBadge({
   wasApproved: boolean;
 }) {
   const d = (decision || "").toLowerCase();
-  if (d === "approve" || d === "approved" || (wasApproved && !d)) {
+  if (!d) {
+    return wasApproved ? (
+      <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+        <CheckCircle2 className="h-3 w-3" />
+        Approved
+      </span>
+    ) : (
+      <span className="inline-flex items-center gap-1 text-red-500">
+        <XCircle className="h-3 w-3" />
+        Rejected
+      </span>
+    );
+  }
+  if (d === "approve" || d === "approved") {
     return (
       <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
         <CheckCircle2 className="h-3 w-3" />
@@ -481,16 +499,10 @@ function PriorOutcomeBadge({
       </span>
     );
   }
-  // Fallback: respect the legacy boolean if no decision string is present.
-  return wasApproved ? (
-    <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-      <CheckCircle2 className="h-3 w-3" />
-      Approved
-    </span>
-  ) : (
+  return (
     <span className="inline-flex items-center gap-1 text-muted-foreground">
       <AlertTriangle className="h-3 w-3" />
-      {decision || "Unknown"}
+      {decision}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

The ApprovalDetailPage "Prior Approvals" subsection used a binary `pa.wasApproved ? "Approved" : "Rejected"` ternary that mislabeled expired/invalidated approvals as **Rejected** — confusing because those are not human rejections. They are reconciler-driven lifecycle transitions:

- workflow timeout → `expire`
- replay / repair-flow invalidation → `invalidate`
- explicit human reject → `reject`

Yaron caught this on the demo dashboard — 14 approvals all showing "Rejected by system/reconciler" when they actually expired or were invalidated.

Backend already exposes `pa.decision` as the authoritative outcome (`"approve" | "reject" | "expire" | "invalidate" | "repair"`); the dashboard just wasn't using it.

## Change

New `PriorOutcomeBadge` helper maps each decision to a distinct badge:

| decision | badge |
|---|---|
| `approve` | emerald CheckCircle2 — Approved |
| `reject` | red XCircle — Rejected |
| `expire` | amber Clock — Expired |
| `invalidate` | muted AlertTriangle — Invalidated |
| `repair` | blue AlertTriangle — Repaired |

Falls back to the legacy `wasApproved` boolean if no decision string is present, so older fixtures keep rendering correctly.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx vitest run src/pages/approvals/ApprovalDetailPage.test.tsx` — 22/22 pass
- [x] `npx vitest run src/pages/ApprovalsPage.test.tsx` — 29/29 pass
- [ ] Manual: open an approval detail page that has a mix of prior-approval outcomes; confirm distinct labels per decision type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Approval outcome display in approval history has been enhanced to show specific decision types—including approved, rejected, expired, invalidated, and repaired—each with distinct visual indicators such as icons and colors. This provides clearer distinction and helps users quickly identify different approval result types at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->