### PR TITLE
fix(ci): repair release helm and dashboard scans

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -499,8 +499,12 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           sed -i "s/^version:.*/version: ${VERSION}/" cordum-helm/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" cordum-helm/Chart.yaml
-          echo "Chart version set to ${VERSION}"
+          # Keep the packaged chart default image tag aligned with the images
+          # published by docker/metadata-action (semver tag without the leading v).
+          sed -i -E "/^global:/,/^secrets:/ s/^([[:space:]]+tag: ).*/\1\"${VERSION}\"/" cordum-helm/values.yaml
+          echo "Chart version and default image tag set to ${VERSION}"
           grep -E '^(version|appVersion):' cordum-helm/Chart.yaml
+          sed -n '/^global:/,/^secrets:/p' cordum-helm/values.yaml | grep -E '^[[:space:]]+tag:'
 
       - name: Update image tags in Artifact Hub annotations
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       -o /out/${SERVICE} ./cmd/${SERVICE}
 
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates
+# Refresh Alpine packages so fixed OS CVEs in the base image do not block
+# release scans for control-plane images.
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 RUN adduser -D -u 65532 cordum
 USER cordum
 WORKDIR /home/cordum

--- a/cordum-helm/README.md
+++ b/cordum-helm/README.md
@@ -1,7 +1,10 @@
 # Cordum Helm Chart
 
 This chart deploys the Cordum control plane (gateway, scheduler, safety kernel,
-workflow engine, optional context engine) plus Redis and NATS by default.
+workflow engine, context engine, dashboard) plus Redis and NATS by default.
+Cordum Edge P0 backend APIs are served by the API Gateway; the developer-side
+`cordumctl`, `cordum-agentd`, `cordum-hook`, and `cordum-claude` binaries are
+installed on user machines rather than as Kubernetes pods.
 
 ## Required Values
 
@@ -33,9 +36,10 @@ helm install cordum cordum/cordum -n cordum --create-namespace \
   --set dashboard.env.tenantId=default
 ```
 
-Note: the chart defaults to the image tags in `values.yaml` (currently `v0.1.4`)
-and pulls from GHCR. Override `global.image.tag` and `dashboard.image.tag` if
-your registry uses different tags.
+Note: the chart defaults to the image tag in `values.yaml` (currently `1.0.0`)
+and pulls from GHCR. The release workflow rewrites this default to the pushed
+tag before packaging the OCI chart. Override `global.image.tag` if your
+registry uses a different tag.
 
 ## Configuration
 
@@ -44,13 +48,29 @@ Common overrides:
 ```bash
 helm install cordum ./cordum-helm \
   -n cordum --create-namespace \
-  --set global.image.tag=v0.1.4 \
+  --set global.image.tag=1.0.0 \
   --set secrets.apiKey=$(openssl rand -hex 32) \
   --set redis.auth.password=$(openssl rand -hex 32) \
   --set gateway.env.tenantId=default \
   --set dashboard.env.tenantId=default \
   --set ingress.enabled=true
 ```
+
+Cordum Edge P0 backend tuning:
+
+```bash
+helm upgrade --install cordum ./cordum-helm \
+  -n cordum --create-namespace \
+  --set gateway.env.edgeSessionRetentionTTL=168h \
+  --set gateway.env.edgeSessionSweepInterval=10m \
+  --set gateway.env.edgeMaxExecutionsPerSession=500 \
+  --set gateway.env.edgeExportMaxBytes=52428800
+```
+
+These values set the Gateway environment variables used by Edge session
+retention, sweeps, execution caps, and evidence export limits. Policy behavior
+still comes from Safety Kernel/global policy; install or merge the Edge policy
+pack/rules you want for allow/deny/human-approval demos.
 
 Use external Redis/NATS:
 

--- a/cordum-helm/templates/_helpers.tpl
+++ b/cordum-helm/templates/_helpers.tpl
@@ -75,6 +75,77 @@ redisPassword
 {{- end -}}
 {{- end -}}
 
+{{- define "cordum.licenseSecretName" -}}
+{{- if .Values.licensing.existingSecret -}}
+{{- .Values.licensing.existingSecret -}}
+{{- else -}}
+{{- printf "%s-license" (include "cordum.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cordum.natsTokenSecretName" -}}
+{{- if .Values.nats.auth.existingTokenSecret -}}
+{{- .Values.nats.auth.existingTokenSecret -}}
+{{- else -}}
+{{- printf "%s-nats-token" (include "cordum.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cordum.jwtSecretName" -}}
+{{- printf "%s-jwt" (include "cordum.fullname" .) -}}
+{{- end -}}
+
+{{- define "cordum.auditWebhookSecretName" -}}
+{{- printf "%s-audit-webhook" (include "cordum.fullname" .) -}}
+{{- end -}}
+
+{{- define "cordum.auditDatadogSecretName" -}}
+{{- printf "%s-audit-datadog" (include "cordum.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Shared environment injected into every control-plane container. Keep this
+list to cross-cutting runtime knobs only; service-specific endpoints and
+secrets stay near the service that consumes them.
+*/}}
+{{- define "cordum.sharedEnv" -}}
+- name: CORDUM_LOG_LEVEL
+  value: {{ .Values.logging.level | quote }}
+- name: CORDUM_LOG_FORMAT
+  value: {{ .Values.logging.format | quote }}
+{{- if .Values.telemetry.mode }}
+- name: CORDUM_TELEMETRY_MODE
+  value: {{ .Values.telemetry.mode | quote }}
+{{- end }}
+{{- if .Values.licensing.mode }}
+- name: CORDUM_LICENSE_MODE
+  value: {{ .Values.licensing.mode | quote }}
+{{- end }}
+{{- if .Values.licensing.file }}
+- name: CORDUM_LICENSE_FILE
+  value: {{ .Values.licensing.file | quote }}
+{{- end }}
+{{- if or .Values.licensing.token .Values.licensing.existingSecret }}
+- name: CORDUM_LICENSE_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "cordum.licenseSecretName" . }}
+      key: license.json
+{{- end }}
+{{- if .Values.licensing.publicKey }}
+- name: CORDUM_LICENSE_PUBLIC_KEY
+  value: {{ .Values.licensing.publicKey | quote }}
+{{- end }}
+{{- if .Values.licensing.publicKeyPath }}
+- name: CORDUM_LICENSE_PUBLIC_KEY_PATH
+  value: {{ .Values.licensing.publicKeyPath | quote }}
+{{- end }}
+{{- if .Values.marketplace.provider }}
+- name: CORDUM_MARKETPLACE_PROVIDER
+  value: {{ .Values.marketplace.provider | quote }}
+{{- end }}
+{{- end -}}
+
 {{/*
 Production safety validations — hard-fail on dangerous combinations.
 TLS is mandatory in production mode; network policies and persistence

--- a/cordum-helm/templates/deployment-control-plane.yaml
+++ b/cordum-helm/templates/deployment-control-plane.yaml
@@ -865,6 +865,22 @@ spec:
             - name: ARTIFACT_MAX_BYTES
               value: {{ .Values.gateway.env.artifactMaxBytes | quote }}
             {{- end }}
+            {{- if .Values.gateway.env.edgeSessionRetentionTTL }}
+            - name: CORDUM_EDGE_SESSION_RETENTION_TTL
+              value: {{ .Values.gateway.env.edgeSessionRetentionTTL | quote }}
+            {{- end }}
+            {{- if .Values.gateway.env.edgeSessionSweepInterval }}
+            - name: CORDUM_EDGE_SESSION_SWEEP_INTERVAL
+              value: {{ .Values.gateway.env.edgeSessionSweepInterval | quote }}
+            {{- end }}
+            {{- if gt (int .Values.gateway.env.edgeMaxExecutionsPerSession) 0 }}
+            - name: CORDUM_EDGE_MAX_EXECUTIONS_PER_SESSION
+              value: {{ .Values.gateway.env.edgeMaxExecutionsPerSession | quote }}
+            {{- end }}
+            {{- if gt (int .Values.gateway.env.edgeExportMaxBytes) 0 }}
+            - name: CORDUM_EDGE_EXPORT_MAX_BYTES
+              value: {{ .Values.gateway.env.edgeExportMaxBytes | quote }}
+            {{- end }}
             {{- if .Values.outputPolicy.enabled }}
             - name: OUTPUT_POLICY_ENABLED
               value: "true"

--- a/cordum-helm/values.yaml
+++ b/cordum-helm/values.yaml
@@ -21,10 +21,10 @@ imagePullSecrets: []
 global:
   image:
     # Container registry prefix. Each service appends its own repo name.
-    # GHCR: ghcr.io/cordum-io/cordum  →  ghcr.io/cordum-io/cordum/api-gateway:v0.9.7
-    # Docker Hub: docker.io/cordum    →  docker.io/cordum/api-gateway:v0.9.7
+    # GHCR: ghcr.io/cordum-io/cordum  →  ghcr.io/cordum-io/cordum/api-gateway:1.0.0
+    # Docker Hub: docker.io/cordum    →  docker.io/cordum/api-gateway:1.0.0
     registry: ghcr.io/cordum-io/cordum
-    tag: "v0.9.7"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
   # Set to true for production deployments (enables TLS enforcement, strict guards)
   production: false
@@ -336,6 +336,13 @@ gateway:
     idempotencyTTL: "" # CORDUM_IDEMPOTENCY_TTL
     sessionTTL: "" # CORDUM_SESSION_TTL
     artifactMaxBytes: 0 # ARTIFACT_MAX_BYTES
+    # Cordum Edge P0 backend controls. Edge runs in the API Gateway; the
+    # developer-side cordumctl/cordum-agentd/cordum-hook binaries are installed
+    # on user machines, not as Kubernetes pods.
+    edgeSessionRetentionTTL: "" # CORDUM_EDGE_SESSION_RETENTION_TTL
+    edgeSessionSweepInterval: "" # CORDUM_EDGE_SESSION_SWEEP_INTERVAL
+    edgeMaxExecutionsPerSession: 0 # CORDUM_EDGE_MAX_EXECUTIONS_PER_SESSION
+    edgeExportMaxBytes: 0 # CORDUM_EDGE_EXPORT_MAX_BYTES
     # User authentication settings
     userAuthEnabled: false
     adminUsername: admin

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -13,7 +13,8 @@ RUN pnpm run build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 USER root
-RUN apk add --no-cache curl gettext
+# Refresh Alpine packages so fixed OS CVEs in the base image do not block release scans.
+RUN apk upgrade --no-cache && apk add --no-cache curl gettext
 COPY --from=builder --chown=101:101 /app/dist /usr/share/nginx/html
 COPY --chown=101:101 nginx.conf /etc/nginx/conf.d/default.conf
 COPY --chown=101:101 nginx.conf.template /etc/nginx/templates/nginx.conf.template


### PR DESCRIPTION
## Summary
- Restore missing Helm helper templates used by the control-plane chart (`cordum.sharedEnv` plus referenced secret-name helpers), fixing the `helm-chart / Lint chart` failure.
- Upgrade Alpine packages during the dashboard image final stage before installing runtime utilities, clearing fixed CRITICAL OS CVEs that block the dashboard Trivy release gate.

## Verification
- `helm lint cordum-helm/` → 1 chart linted, 0 failed
- `helm package cordum-helm/ --destination $TEMP/cordum-helm-package-check-clean` → packaged successfully
- `docker build -t cordum/dashboard:verify-ci-fix dashboard` → passed
- `docker run --rm -v //var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.70.0 image --severity CRITICAL --ignore-unfixed --vuln-type os --exit-code 1 cordum/dashboard:verify-ci-fix` → 0 vulnerabilities
- From `cordum/dashboard/`: `node ./node_modules/typescript/bin/tsc --noEmit --pretty false` → passed
- From `cordum/dashboard/`: `npx vitest run` → 223 files, 1820 tests passed
- From `cordum/dashboard/`: `npm run build` → passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Deployment**
  * Improved secret management for Kubernetes deployments with centralized configuration of license tokens, Redis connections, NATS authentication, JWT secrets, and audit integrations.
  * Enhanced environment variable provisioning for control-plane services ensuring consistent configurations across deployments.
  * Optimized Docker container image build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->