### PR TITLE
fix(ci): initialize release smoke failure array

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -404,7 +404,7 @@ jobs:
           echo "Verifying images at ghcr.io/cordum-io/cordum/*:${IMAGE_TAG}"
 
           control_plane=(api-gateway scheduler safety-kernel workflow-engine context-engine mcp)
-          declare -a failed
+          failed=()
           for name in "${control_plane[@]}" dashboard demo-quickstart-worker; do
             image="ghcr.io/cordum-io/cordum/${name}:${IMAGE_TAG}"
             echo "::group::pull ${image}"


### PR DESCRIPTION
## Summary

Follow-up to #246. The release smoke script uses `set -u`; on the all-success path Bash treated the empty declared array as unbound at `${#failed[@]}`. Initialize it as `failed=()` so the success path can reach `All published images smoke-passed.`

## Verification

- `bash -lc 'set -euo pipefail; failed=(); if (( ${#failed[@]} > 0 )); then echo fail; fi; echo ok'` ✅
- The previous v1.0.0 rerun proved all image-specific smoke checks passed; only the empty-array success check failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal Docker image smoke testing workflow initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->