### PR TITLE
feat(core/policy): unified Rule/Decision/Bundle shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,12 @@ window. Backwards-compat is locked in by
   `DecisionType`, `DecisionSource`, `RuleScopeKind`, `EdgeMode`).
 - New proto file `cap/proto/cordum/agent/v1/policy.proto` carrying the
   unified shapes; references `safety.proto`'s existing `DecisionType` enum
-  rather than redeclaring it.
+  rather than redeclaring it. Tracked in **cordum-io/cap#46**
+  (https://github.com/cordum-io/cap/pull/46).
 - **[WIRE]** `safety.proto`'s `DecisionType` enum extended with
   `DECISION_TYPE_QUARANTINE = 6` and `DECISION_TYPE_REDACT = 7` (CAP
-  append-only rule preserved; values 0–5 unchanged). Cap PR carries the
-  matching spec/CHANGELOG/conformance-fixture updates separately.
+  append-only rule preserved; values 0–5 unchanged). Wire change ships in
+  cordum-io/cap#46 alongside the new policy.proto messages.
 - OpenAPI `info.version` bumped to `'2026-05-09.1'`; 14 new schema entries
   appended under `components.schemas` (`Rule`, `Decision`, `TraceStep`,
   `Bundle`, `BundleVersion`, `BundleMetadata`, `RuleScope`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+#### Policy Studio Rewrite — Backend 1 (epic-d9a6c0a1)
+
+Foundation shapes for the Job + Edge unified policy surface. New shared
+`Rule` / `Decision` / `Bundle` types subsume today's split
+`InputPolicyRule`/`OutputPolicyRule`/`PolicyRule(velocity)` plus the
+`EdgeDecision`/`ActionClassification` edge surface, with a `RuleType`
+discriminator and per-type `Match`/`Decide` payloads carried as raw JSON
+for lossless roundtrip with the orval-generated dashboard types and the
+proto `google.protobuf.Struct` carriers.
+
+**Additive only.** No existing types are modified or removed:
+`core/infra/config.SafetyPolicy`, `InputPolicyRule`, `InputPolicyMatch`,
+`OutputPolicyRule`, `OutputPolicyMatch`, `PolicyRule`, `PolicyMatch`,
+`PolicyDecision`, `MCPPolicy`, `TenantPolicy`, `core/edge.EdgeDecision`,
+`ActionClassification`, and the OpenAPI `OutputRule` / `VelocityRule` /
+`PolicyBundleSummary` schemas all remain in place during the migration
+window. Backwards-compat is locked in by
+`core/policy/backwards_compat_test.go` against pre-recorded golden JSON in
+`core/policy/testdata/`.
+
+- New Go package `core/policy/` with `Rule`, `Decision`, `TraceStep`,
+  `Bundle`, `BundleMetadata`, `BundleVersion`, `RuleScope`,
+  `AuditMetadata` structs and six typed enums (`RuleType`, `RuleStatus`,
+  `DecisionType`, `DecisionSource`, `RuleScopeKind`, `EdgeMode`).
+- New proto file `cap/proto/cordum/agent/v1/policy.proto` carrying the
+  unified shapes; references `safety.proto`'s existing `DecisionType` enum
+  rather than redeclaring it.
+- **[WIRE]** `safety.proto`'s `DecisionType` enum extended with
+  `DECISION_TYPE_QUARANTINE = 6` and `DECISION_TYPE_REDACT = 7` (CAP
+  append-only rule preserved; values 0–5 unchanged). Cap PR carries the
+  matching spec/CHANGELOG/conformance-fixture updates separately.
+- OpenAPI `info.version` bumped to `'2026-05-09.1'`; 14 new schema entries
+  appended under `components.schemas` (`Rule`, `Decision`, `TraceStep`,
+  `Bundle`, `BundleVersion`, `BundleMetadata`, `RuleScope`,
+  `AuditMetadata` + six enum schemas).
+
+The unified evaluator entry-points and the migration of
+`core/safetykernel` and `core/edge` to consume `Rule` + emit `Decision`
+land in follow-up Backend tasks (see the epic decomposition in
+[docs/specs/policy-studio-rewrite.md](docs/specs/policy-studio-rewrite.md)).
+
 #### Cordum Edge P0 (2026-04-30)
 
 EDGE epic shipped 32 P0 tasks for the Compliance Firewall surface — local

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -1,0 +1,30 @@
+# core/policy
+
+Unified Rule, Decision, and Bundle shapes for Cordum's Policy Studio surface
+(epic-d9a6c0a1). Subsumes the previously split job-side
+(input/output/velocity) and edge-side authoring surfaces under one envelope
+with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
+
+## Consumers (in follow-up tasks)
+
+- `core/safetykernel/` — will consume `Rule` and emit `Decision` for job
+  evaluation paths (Backend 3 + Backend 5).
+- `core/edge/` — same migration; joins the unified audit-chain (Backend 4).
+- `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
+
+## Match / Decide contract
+
+`Rule.Match` and `Rule.Decide` are `json.RawMessage`. The per-`RuleType`
+shape is documented in `docs/specs/policy-studio-rewrite.md` and mirrors
+today's `InputPolicyMatch` / `OutputPolicyMatch` / `PolicyMatch` +
+`VelocityConfig` / `ActionClassification` surfaces. The raw-message carrier
+preserves bit-for-bit fidelity and maps cleanly onto the proto-side
+`google.protobuf.Struct` and orval `Record<string, unknown>` types.
+
+## Decision wire values
+
+`DecisionType` mirrors the seven values in the wire-format
+`cap/proto/cordum/agent/v1/safety.proto` enum: `allow` / `deny` /
+`require_human` / `throttle` / `allow_with_constraints` / `quarantine` /
+`redact`. The last two were appended for the unified surface per CAP's
+append-only protobuf-evolution rule.

--- a/core/policy/backwards_compat_test.go
+++ b/core/policy/backwards_compat_test.go
@@ -1,0 +1,116 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+)
+
+// TestLegacyInputPolicyRuleJSON locks in the byte-level JSON output of
+// `core/infra/config.InputPolicyRule` so any inadvertent shape change to
+// the legacy struct fails this test loudly. Backwards-compat is DoD #3 of
+// task-3bf37e32 (Policy Studio Backend 1).
+//
+// Set UPDATE_GOLDENS=1 to regenerate the golden file when the legacy shape
+// is intentionally changed.
+func TestLegacyInputPolicyRuleJSON(t *testing.T) {
+	enabled := true
+	fixture := config.InputPolicyRule{
+		ID:       "legacy-input-secret-block",
+		Tier:     config.PolicyTierGlobal,
+		Selector: config.PolicySelector{WorkflowID: "wf-claims"},
+		Enabled:  &enabled,
+		Severity: "critical",
+		Desc:     "Block secret leaks in inputs",
+		Match: config.InputPolicyMatch{
+			Tenants:         []string{"acme"},
+			Topics:          []string{"job.acme.*"},
+			Capabilities:    []string{"llm.request"},
+			RiskTags:        []string{"untrusted_input"},
+			Scanners:        []string{"secret_leak"},
+			ContentPatterns: []string{`(?i)api[_-]?key`},
+			Keywords:        []string{"secret", "token"},
+			ContentTypes:    []string{"application/json"},
+			Detectors:       []string{"secret_leak"},
+			InputSizeGt:     1024,
+			MaxInputBytes:   1048576,
+		},
+		Decision: "deny",
+		Reason:   "secret_leak_detected",
+	}
+
+	got, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent err = %v", err)
+	}
+	got = append(got, '\n')
+
+	goldenPath := filepath.Join("testdata", "legacy_input_rule.json")
+	assertGoldenEqual(t, goldenPath, got)
+}
+
+// TestLegacyOutputPolicyRuleJSON does the same lock-in for the legacy
+// `core/infra/config.OutputPolicyRule` shape.
+func TestLegacyOutputPolicyRuleJSON(t *testing.T) {
+	enabled := true
+	hasError := false
+	fixture := config.OutputPolicyRule{
+		ID:       "legacy-output-pii-redact",
+		Enabled:  &enabled,
+		Severity: "high",
+		Desc:     "Redact PII in outputs",
+		Match: config.OutputPolicyMatch{
+			Tenants:         []string{"acme"},
+			Topics:          []string{"job.acme.*"},
+			Capabilities:    []string{"llm.request"},
+			RiskTags:        []string{"contains_pii"},
+			Scanners:        []string{"pii"},
+			ContentPatterns: []string{`(?i)\bSSN\b`},
+			Keywords:        []string{"social", "ssn"},
+			ContentTypes:    []string{"application/json"},
+			Detectors:       []string{"pii"},
+			OutputSizeGt:    0,
+			MaxOutputBytes:  4194304,
+			HasError:        &hasError,
+		},
+		Decision: "redact",
+		Reason:   "pii_in_output",
+	}
+
+	got, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent err = %v", err)
+	}
+	got = append(got, '\n')
+
+	goldenPath := filepath.Join("testdata", "legacy_output_rule.json")
+	assertGoldenEqual(t, goldenPath, got)
+}
+
+// assertGoldenEqual reads the golden file and compares bytes against got.
+// On UPDATE_GOLDENS=1 it overwrites the golden instead of comparing —
+// always a deliberate operator action, never automatic.
+func assertGoldenEqual(t *testing.T, path string, got []byte) {
+	t.Helper()
+	if os.Getenv("UPDATE_GOLDENS") == "1" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s) err = %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) err = %v", path, err)
+		}
+		t.Logf("UPDATE_GOLDENS=1 — wrote %d bytes to %s", len(got), path)
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) err = %v — generate via `UPDATE_GOLDENS=1 go test ./core/policy/...`", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden drift in %s\n--- want\n%s\n--- got\n%s", path, want, got)
+	}
+}

--- a/core/policy/doc.go
+++ b/core/policy/doc.go
@@ -1,0 +1,6 @@
+// Package policy holds the unified Rule, Decision, and Bundle shapes that
+// subsume Cordum's previously split job-policy (input/output/velocity) and
+// edge-policy authoring surfaces. The shapes are storage- and
+// evaluator-agnostic: core/safetykernel and core/edge consume Rule and emit
+// Decision; the bundle store keys by Bundle.ID.
+package policy

--- a/core/policy/enums.go
+++ b/core/policy/enums.go
@@ -1,0 +1,303 @@
+package policy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors returned by the Parse* functions in this package. Use
+// errors.Is to distinguish between unknown-value and empty-value cases when
+// callers need branchy error handling; otherwise the wrapped string contains
+// the rejected value verbatim for log emission.
+var (
+	ErrInvalidRuleType       = errors.New("policy: invalid rule type")
+	ErrInvalidRuleStatus     = errors.New("policy: invalid rule status")
+	ErrInvalidDecisionType   = errors.New("policy: invalid decision type")
+	ErrInvalidDecisionSource = errors.New("policy: invalid decision source")
+	ErrInvalidRuleScopeKind  = errors.New("policy: invalid rule scope kind")
+	ErrInvalidEdgeMode       = errors.New("policy: invalid edge mode")
+)
+
+// RuleType discriminates a rule's match/decide payload schema. The four
+// values correspond to the existing job (input/output/velocity) and edge
+// authoring surfaces being unified by this package.
+type RuleType string
+
+const (
+	RuleTypeInput    RuleType = "input"
+	RuleTypeOutput   RuleType = "output"
+	RuleTypeVelocity RuleType = "velocity"
+	RuleTypeEdge     RuleType = "edge"
+)
+
+func (t RuleType) String() string { return string(t) }
+
+// ParseRuleType parses a wire-format rule type. It rejects the empty string
+// and any non-canonical value (including case variants and whitespace-padded
+// forms) with an error wrapping ErrInvalidRuleType.
+func ParseRuleType(s string) (RuleType, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidRuleType)
+	}
+	switch RuleType(s) {
+	case RuleTypeInput, RuleTypeOutput, RuleTypeVelocity, RuleTypeEdge:
+		return RuleType(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidRuleType, s)
+	}
+}
+
+func (t RuleType) MarshalJSON() ([]byte, error) {
+	if _, err := ParseRuleType(string(t)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(t))
+}
+
+func (t *RuleType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseRuleType(s)
+	if err != nil {
+		return err
+	}
+	*t = parsed
+	return nil
+}
+
+// RuleStatus tracks a rule's lifecycle state. Authors edit `draft` rules,
+// `published` rules participate in evaluation, and `deprecated` rules remain
+// queryable for audit and rollback but are skipped by evaluators.
+type RuleStatus string
+
+const (
+	RuleStatusDraft      RuleStatus = "draft"
+	RuleStatusPublished  RuleStatus = "published"
+	RuleStatusDeprecated RuleStatus = "deprecated"
+)
+
+func (s RuleStatus) String() string { return string(s) }
+
+func ParseRuleStatus(s string) (RuleStatus, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidRuleStatus)
+	}
+	switch RuleStatus(s) {
+	case RuleStatusDraft, RuleStatusPublished, RuleStatusDeprecated:
+		return RuleStatus(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidRuleStatus, s)
+	}
+}
+
+func (s RuleStatus) MarshalJSON() ([]byte, error) {
+	if _, err := ParseRuleStatus(string(s)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(s))
+}
+
+func (s *RuleStatus) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	parsed, err := ParseRuleStatus(raw)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+// DecisionType is the unified decision outcome emitted by either evaluator.
+// It is the union of the existing safetykernel SafetyDecision, output-rule
+// decision, and edge EdgeDecision values, normalised to a single canonical
+// set. The seven values mirror the wire-format DecisionType enum in
+// cap/proto/cordum/agent/v1/safety.proto: ALLOW, DENY, REQUIRE_HUMAN,
+// THROTTLE, ALLOW_WITH_CONSTRAINTS, QUARANTINE, REDACT.
+type DecisionType string
+
+const (
+	DecisionAllow                DecisionType = "allow"
+	DecisionDeny                 DecisionType = "deny"
+	DecisionRequireHuman         DecisionType = "require_human"
+	DecisionThrottle             DecisionType = "throttle"
+	DecisionAllowWithConstraints DecisionType = "allow_with_constraints"
+	DecisionQuarantine           DecisionType = "quarantine"
+	DecisionRedact               DecisionType = "redact"
+)
+
+func (d DecisionType) String() string { return string(d) }
+
+func ParseDecisionType(s string) (DecisionType, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidDecisionType)
+	}
+	switch DecisionType(s) {
+	case DecisionAllow, DecisionDeny, DecisionRequireHuman, DecisionThrottle,
+		DecisionAllowWithConstraints, DecisionQuarantine, DecisionRedact:
+		return DecisionType(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidDecisionType, s)
+	}
+}
+
+func (d DecisionType) MarshalJSON() ([]byte, error) {
+	if _, err := ParseDecisionType(string(d)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(d))
+}
+
+func (d *DecisionType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseDecisionType(s)
+	if err != nil {
+		return err
+	}
+	*d = parsed
+	return nil
+}
+
+// DecisionSource identifies which evaluator produced a Decision: the
+// safetykernel job pipeline (`job`) or the edge classifier path (`edge`).
+type DecisionSource string
+
+const (
+	DecisionSourceJob  DecisionSource = "job"
+	DecisionSourceEdge DecisionSource = "edge"
+)
+
+func (s DecisionSource) String() string { return string(s) }
+
+func ParseDecisionSource(s string) (DecisionSource, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidDecisionSource)
+	}
+	switch DecisionSource(s) {
+	case DecisionSourceJob, DecisionSourceEdge:
+		return DecisionSource(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidDecisionSource, s)
+	}
+}
+
+func (s DecisionSource) MarshalJSON() ([]byte, error) {
+	if _, err := ParseDecisionSource(string(s)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(s))
+}
+
+func (s *DecisionSource) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	parsed, err := ParseDecisionSource(raw)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+// RuleScopeKind narrows where a rule applies. `global` covers an entire
+// deployment; `tenant` and `workflow` scope to job-side bindings; `edge_fleet`
+// and `edge_user` scope to edge-side bindings (whole fleet vs single user).
+type RuleScopeKind string
+
+const (
+	RuleScopeGlobal    RuleScopeKind = "global"
+	RuleScopeTenant    RuleScopeKind = "tenant"
+	RuleScopeWorkflow  RuleScopeKind = "workflow"
+	RuleScopeEdgeFleet RuleScopeKind = "edge_fleet"
+	RuleScopeEdgeUser  RuleScopeKind = "edge_user"
+)
+
+func (k RuleScopeKind) String() string { return string(k) }
+
+func ParseRuleScopeKind(s string) (RuleScopeKind, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidRuleScopeKind)
+	}
+	switch RuleScopeKind(s) {
+	case RuleScopeGlobal, RuleScopeTenant, RuleScopeWorkflow, RuleScopeEdgeFleet, RuleScopeEdgeUser:
+		return RuleScopeKind(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidRuleScopeKind, s)
+	}
+}
+
+func (k RuleScopeKind) MarshalJSON() ([]byte, error) {
+	if _, err := ParseRuleScopeKind(string(k)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(k))
+}
+
+func (k *RuleScopeKind) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseRuleScopeKind(s)
+	if err != nil {
+		return err
+	}
+	*k = parsed
+	return nil
+}
+
+// EdgeMode is the per-bundle enforcement posture for the edge evaluator. It
+// migrates today's global EdgePolicyMode switch onto bundle metadata so
+// different fleets and users can run at different modes simultaneously. See
+// spec § "Edge bundle metadata" (cordum/docs/specs/policy-studio-rewrite.md).
+type EdgeMode string
+
+const (
+	EdgeModeObserve          EdgeMode = "observe"
+	EdgeModeEnforce          EdgeMode = "enforce"
+	EdgeModeEnterpriseStrict EdgeMode = "enterprise-strict"
+)
+
+func (m EdgeMode) String() string { return string(m) }
+
+func ParseEdgeMode(s string) (EdgeMode, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidEdgeMode)
+	}
+	switch EdgeMode(s) {
+	case EdgeModeObserve, EdgeModeEnforce, EdgeModeEnterpriseStrict:
+		return EdgeMode(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidEdgeMode, s)
+	}
+}
+
+func (m EdgeMode) MarshalJSON() ([]byte, error) {
+	if _, err := ParseEdgeMode(string(m)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(m))
+}
+
+func (m *EdgeMode) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseEdgeMode(s)
+	if err != nil {
+		return err
+	}
+	*m = parsed
+	return nil
+}

--- a/core/policy/enums_test.go
+++ b/core/policy/enums_test.go
@@ -1,0 +1,250 @@
+package policy
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRuleType_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  RuleType
+		wire string
+	}{
+		{RuleTypeInput, "input"},
+		{RuleTypeOutput, "output"},
+		{RuleTypeVelocity, "velocity"},
+		{RuleTypeEdge, "edge"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseRuleType(tc.wire)
+		if err != nil {
+			t.Fatalf("ParseRuleType(%q) err = %v, want nil", tc.wire, err)
+		}
+		if parsed != tc.val {
+			t.Fatalf("ParseRuleType(%q) = %v, want %v", tc.wire, parsed, tc.val)
+		}
+	}
+}
+
+func TestRuleType_ParseRejects(t *testing.T) {
+	rejects := []string{"", " ", "input ", " input", "INPUT", "Input", "iNpUt", "unknown", "input2"}
+	for _, in := range rejects {
+		_, err := ParseRuleType(in)
+		if err == nil {
+			t.Fatalf("ParseRuleType(%q) err = nil, want non-nil", in)
+		}
+		if !errors.Is(err, ErrInvalidRuleType) {
+			t.Fatalf("ParseRuleType(%q) err %v does not wrap ErrInvalidRuleType", in, err)
+		}
+	}
+}
+
+func TestRuleType_MarshalJSON_RejectsZero(t *testing.T) {
+	var zero RuleType
+	if _, err := json.Marshal(zero); err == nil {
+		t.Fatalf("json.Marshal(zero RuleType) err = nil, want non-nil — zero value must not serialize")
+	}
+}
+
+func TestRuleType_UnmarshalJSON(t *testing.T) {
+	var v RuleType
+	if err := json.Unmarshal([]byte(`"input"`), &v); err != nil {
+		t.Fatalf("Unmarshal valid err = %v, want nil", err)
+	}
+	if v != RuleTypeInput {
+		t.Fatalf("Unmarshal valid = %v, want RuleTypeInput", v)
+	}
+	var bad RuleType
+	if err := json.Unmarshal([]byte(`"INPUT"`), &bad); err == nil {
+		t.Fatalf("Unmarshal of non-canonical case must fail")
+	}
+	if err := json.Unmarshal([]byte(`""`), &bad); err == nil {
+		t.Fatalf("Unmarshal of empty string must fail")
+	}
+}
+
+func TestRuleStatus_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  RuleStatus
+		wire string
+	}{
+		{RuleStatusDraft, "draft"},
+		{RuleStatusPublished, "published"},
+		{RuleStatusDeprecated, "deprecated"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseRuleStatus(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseRuleStatus(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	for _, in := range []string{"", " ", "DRAFT", "Published", "publish"} {
+		if _, err := ParseRuleStatus(in); err == nil || !errors.Is(err, ErrInvalidRuleStatus) {
+			t.Fatalf("ParseRuleStatus(%q) err = %v, want wrapped ErrInvalidRuleStatus", in, err)
+		}
+	}
+}
+
+func TestDecisionType_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  DecisionType
+		wire string
+	}{
+		{DecisionAllow, "allow"},
+		{DecisionDeny, "deny"},
+		{DecisionRequireHuman, "require_human"},
+		{DecisionThrottle, "throttle"},
+		{DecisionAllowWithConstraints, "allow_with_constraints"},
+		{DecisionQuarantine, "quarantine"},
+		{DecisionRedact, "redact"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseDecisionType(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseDecisionType(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+		// Verify wire-format parity with safety.proto enum (DecisionType
+		// values 6 and 7 were appended by epic-d9a6c0a1).
+		if tc.val == DecisionQuarantine && tc.wire != "quarantine" {
+			t.Fatalf("quarantine wire form drifted")
+		}
+		if tc.val == DecisionRedact && tc.wire != "redact" {
+			t.Fatalf("redact wire form drifted")
+		}
+	}
+	for _, in := range []string{"", " ", "ALLOW", "Deny", "require-human", "approve", "block"} {
+		if _, err := ParseDecisionType(in); err == nil || !errors.Is(err, ErrInvalidDecisionType) {
+			t.Fatalf("ParseDecisionType(%q) err = %v, want wrapped ErrInvalidDecisionType", in, err)
+		}
+	}
+}
+
+func TestDecisionType_RoundTripIncludesNewWireValues(t *testing.T) {
+	for _, val := range []DecisionType{DecisionAllowWithConstraints, DecisionQuarantine, DecisionRedact} {
+		raw, err := json.Marshal(val)
+		if err != nil {
+			t.Fatalf("Marshal(%v) err = %v", val, err)
+		}
+		var got DecisionType
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("Unmarshal(%s) err = %v", raw, err)
+		}
+		if got != val {
+			t.Fatalf("round-trip drift: %v -> %s -> %v", val, raw, got)
+		}
+	}
+}
+
+func TestDecisionSource_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  DecisionSource
+		wire string
+	}{
+		{DecisionSourceJob, "job"},
+		{DecisionSourceEdge, "edge"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseDecisionSource(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseDecisionSource(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	for _, in := range []string{"", " ", "JOB", "Edge", "agent"} {
+		if _, err := ParseDecisionSource(in); err == nil || !errors.Is(err, ErrInvalidDecisionSource) {
+			t.Fatalf("ParseDecisionSource(%q) err = %v, want wrapped ErrInvalidDecisionSource", in, err)
+		}
+	}
+}
+
+func TestRuleScopeKind_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  RuleScopeKind
+		wire string
+	}{
+		{RuleScopeGlobal, "global"},
+		{RuleScopeTenant, "tenant"},
+		{RuleScopeWorkflow, "workflow"},
+		{RuleScopeEdgeFleet, "edge_fleet"},
+		{RuleScopeEdgeUser, "edge_user"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseRuleScopeKind(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseRuleScopeKind(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	for _, in := range []string{"", " ", "GLOBAL", "Tenant", "edge-fleet", "edgefleet"} {
+		if _, err := ParseRuleScopeKind(in); err == nil || !errors.Is(err, ErrInvalidRuleScopeKind) {
+			t.Fatalf("ParseRuleScopeKind(%q) err = %v, want wrapped ErrInvalidRuleScopeKind", in, err)
+		}
+	}
+}
+
+func TestEdgeMode_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  EdgeMode
+		wire string
+	}{
+		{EdgeModeObserve, "observe"},
+		{EdgeModeEnforce, "enforce"},
+		{EdgeModeEnterpriseStrict, "enterprise-strict"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseEdgeMode(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseEdgeMode(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	// Reject unknown + case + the common typo "enterprise_strict" (underscore vs hyphen).
+	for _, in := range []string{"", " ", "OBSERVE", "Enforce", "enterprise_strict", "strict"} {
+		if _, err := ParseEdgeMode(in); err == nil || !errors.Is(err, ErrInvalidEdgeMode) {
+			t.Fatalf("ParseEdgeMode(%q) err = %v, want wrapped ErrInvalidEdgeMode", in, err)
+		}
+	}
+	// MarshalJSON round-trip.
+	raw, err := json.Marshal(EdgeModeEnterpriseStrict)
+	if err != nil {
+		t.Fatalf("Marshal err = %v", err)
+	}
+	if string(raw) != `"enterprise-strict"` {
+		t.Fatalf("Marshal = %s, want \"enterprise-strict\"", raw)
+	}
+	var back EdgeMode
+	if err := json.Unmarshal(raw, &back); err != nil || back != EdgeModeEnterpriseStrict {
+		t.Fatalf("Unmarshal round-trip failed: err=%v back=%v", err, back)
+	}
+}
+
+func TestEnumErrorMessagesContainRejectedValue(t *testing.T) {
+	// Every Parse* error message should include the rejected value verbatim
+	// for log-emission purposes (architect rail: "wrapped string contains the
+	// rejected value verbatim").
+	_, err := ParseRuleType("bogus_kind")
+	if err == nil || !strings.Contains(err.Error(), `"bogus_kind"`) {
+		t.Fatalf("ParseRuleType error %v missing rejected value", err)
+	}
+	_, err = ParseEdgeMode("WRONG")
+	if err == nil || !strings.Contains(err.Error(), `"WRONG"`) {
+		t.Fatalf("ParseEdgeMode error %v missing rejected value", err)
+	}
+}

--- a/core/policy/testdata/legacy_input_rule.json
+++ b/core/policy/testdata/legacy_input_rule.json
@@ -1,0 +1,45 @@
+{
+  "ID": "legacy-input-secret-block",
+  "tier": "global",
+  "selector": {
+    "workflow_id": "wf-claims"
+  },
+  "Enabled": true,
+  "Severity": "critical",
+  "Desc": "Block secret leaks in inputs",
+  "Match": {
+    "Tenants": [
+      "acme"
+    ],
+    "Topics": [
+      "job.acme.*"
+    ],
+    "Capabilities": [
+      "llm.request"
+    ],
+    "RiskTags": [
+      "untrusted_input"
+    ],
+    "Scanners": [
+      "secret_leak"
+    ],
+    "ContentPatterns": [
+      "(?i)api[_-]?key"
+    ],
+    "Keywords": [
+      "secret",
+      "token"
+    ],
+    "ContentTypes": [
+      "application/json"
+    ],
+    "Detectors": [
+      "secret_leak"
+    ],
+    "InputSizeGt": 1024,
+    "MaxInputBytes": 1048576,
+    "Scope": null
+  },
+  "Decision": "deny",
+  "Reason": "secret_leak_detected"
+}

--- a/core/policy/testdata/legacy_output_rule.json
+++ b/core/policy/testdata/legacy_output_rule.json
@@ -1,0 +1,41 @@
+{
+  "ID": "legacy-output-pii-redact",
+  "Enabled": true,
+  "Severity": "high",
+  "Desc": "Redact PII in outputs",
+  "Match": {
+    "Tenants": [
+      "acme"
+    ],
+    "Topics": [
+      "job.acme.*"
+    ],
+    "Capabilities": [
+      "llm.request"
+    ],
+    "RiskTags": [
+      "contains_pii"
+    ],
+    "Scanners": [
+      "pii"
+    ],
+    "ContentPatterns": [
+      "(?i)\\bSSN\\b"
+    ],
+    "Keywords": [
+      "social",
+      "ssn"
+    ],
+    "ContentTypes": [
+      "application/json"
+    ],
+    "Detectors": [
+      "pii"
+    ],
+    "OutputSizeGt": 0,
+    "MaxOutputBytes": 4194304,
+    "HasError": false
+  },
+  "Decision": "redact",
+  "Reason": "pii_in_output"
+}

--- a/core/policy/types.go
+++ b/core/policy/types.go
@@ -1,0 +1,108 @@
+package policy
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Rule is the unified authoring surface for both job-side and edge-side
+// policy. The envelope (ID, Name, Type, Scope, Status, Version, Audit) is
+// shared across all rule types; the type-specific Match/Decide payloads carry
+// the per-RuleType schema as raw JSON to preserve lossless roundtrip with
+// orval-generated dashboard types and protobuf google.protobuf.Struct
+// transport.
+type Rule struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Type        RuleType        `json:"type"`
+	Scope       RuleScope       `json:"scope"`
+	Status      RuleStatus      `json:"status"`
+	Version     string          `json:"version"`
+	Audit       AuditMetadata   `json:"audit"`
+	Match       json.RawMessage `json:"match"`
+	Decide      json.RawMessage `json:"decide"`
+	Description string          `json:"description,omitempty"`
+}
+
+// Decision is the unified evaluator output. A single Decision may aggregate
+// multiple rule evaluations via Trace; Type holds the final outcome the
+// evaluator derived from the trace. Source distinguishes the producing
+// evaluator (job pipeline vs edge classifier path); InputRef and OutputRef
+// are pointers into the blob store rather than embedded payloads.
+type Decision struct {
+	Source        DecisionSource `json:"source"`
+	RuleID        string         `json:"rule_id"`
+	BundleID      string         `json:"bundle_id,omitempty"`
+	BundleVersion string         `json:"bundle_version,omitempty"`
+	Type          DecisionType   `json:"type"`
+	Trace         []TraceStep    `json:"trace,omitempty"`
+	InputRef      string         `json:"input_ref,omitempty"`
+	OutputRef     string         `json:"output_ref,omitempty"`
+	AuditHash     string         `json:"audit_hash,omitempty"`
+	Timestamp     time.Time      `json:"timestamp"`
+}
+
+// TraceStep records one rule evaluation contributing to a Decision. Multiple
+// TraceSteps are emitted when a rule chain or bundle composition produces a
+// final decision through ordered evaluation. Constraints carries the raw
+// constraints payload (e.g. the existing safetykernel BudgetConstraints/
+// SandboxProfile JSON) when the evaluator applied an allow_with_constraints
+// path; downstream consumers parse it per RuleType.
+type TraceStep struct {
+	RuleID       string          `json:"rule_id"`
+	BundleID     string          `json:"bundle_id,omitempty"`
+	DecisionType DecisionType    `json:"decision_type"`
+	Reason       string          `json:"reason,omitempty"`
+	Timestamp    time.Time       `json:"timestamp"`
+	Constraints  json.RawMessage `json:"constraints,omitempty"`
+}
+
+// Bundle is a deployable set of rules with a deployment scope. Rules are
+// referenced by ID rather than embedded so a bundle can rotate its members
+// without forcing rule duplication; the snapshot at deploy time lives in
+// BundleVersion.RuleSnapshot for tamper-evident rollback.
+type Bundle struct {
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	RuleIDs      []string        `json:"rule_ids,omitempty"`
+	ScopeBinding RuleScope       `json:"scope_binding"`
+	Versions     []BundleVersion `json:"versions,omitempty"`
+	Metadata     BundleMetadata  `json:"metadata,omitzero"`
+}
+
+// BundleMetadata carries per-bundle authoring metadata that does not affect
+// match/decide payloads. EdgeMode is the per-bundle enforcement posture for
+// edge-scoped bundles, replacing today's global EdgePolicyMode switch.
+type BundleMetadata struct {
+	EdgeMode EdgeMode `json:"edge_mode,omitempty"`
+}
+
+// BundleVersion is the immutable record of a Bundle deploy. RuleSnapshot
+// captures the full Rule contents at deploy time so rollback and audit do
+// not depend on the live rule store; AuditHash chains the version into the
+// audit chain.
+type BundleVersion struct {
+	Version      string    `json:"version"`
+	RuleSnapshot []Rule    `json:"rule_snapshot,omitempty"`
+	DeployedAt   time.Time `json:"deployed_at"`
+	AuditHash    string    `json:"audit_hash,omitempty"`
+}
+
+// RuleScope narrows where a rule (or bundle) applies. When Kind is
+// RuleScopeGlobal, Value is unused and may be empty; for the other kinds
+// Value carries the corresponding identifier (tenant id, workflow id, edge
+// fleet name, edge user id).
+type RuleScope struct {
+	Kind  RuleScopeKind `json:"kind"`
+	Value string        `json:"value,omitempty"`
+}
+
+// AuditMetadata records who created or last updated a Rule or Bundle. The
+// Updated* fields are zero-valued on first creation and populated by the
+// first subsequent edit.
+type AuditMetadata struct {
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy string    `json:"created_by"`
+	UpdatedAt time.Time `json:"updated_at,omitzero"`
+	UpdatedBy string    `json:"updated_by,omitempty"`
+}

--- a/core/policy/types_test.go
+++ b/core/policy/types_test.go
@@ -1,0 +1,320 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestRule_PerTypeRoundTrip exercises one realistic fixture per RuleType.
+// Match/Decide are json.RawMessage carriers that MUST be preserved
+// bit-for-bit through marshal/unmarshal so the orval-generated TS layer
+// and the proto google.protobuf.Struct carriers can round-trip lossless.
+func TestRule_PerTypeRoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 9, 8, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		rule   Rule
+		wantID string
+	}{
+		{
+			name: "input",
+			rule: Rule{
+				ID:      "rule-input-secrets",
+				Name:    "Block secret leaks in input",
+				Type:    RuleTypeInput,
+				Scope:   RuleScope{Kind: RuleScopeTenant, Value: "tenant-acme"},
+				Status:  RuleStatusPublished,
+				Version: "v1",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "yaron@cordum.io"},
+				Match: json.RawMessage(`{
+                  "tenants": ["acme"],
+                  "topics": ["job.acme.*"],
+                  "scanners": ["secret_leak"],
+                  "input_size_gt": 1024
+                }`),
+				Decide: json.RawMessage(`{"decision":"deny","reason":"secret_leak","severity":"critical"}`),
+			},
+			wantID: "rule-input-secrets",
+		},
+		{
+			name: "output",
+			rule: Rule{
+				ID:      "rule-output-pii-redact",
+				Name:    "Redact PII in outputs",
+				Type:    RuleTypeOutput,
+				Scope:   RuleScope{Kind: RuleScopeGlobal},
+				Status:  RuleStatusPublished,
+				Version: "v3",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "policyteam@cordum.io"},
+				Match: json.RawMessage(`{
+                  "detectors": ["pii"],
+                  "output_size_gt": 0,
+                  "has_error": false
+                }`),
+				Decide: json.RawMessage(`{"decision":"redact","reason":"pii_in_output","severity":"high"}`),
+			},
+			wantID: "rule-output-pii-redact",
+		},
+		{
+			name: "velocity",
+			rule: Rule{
+				ID:          "rule-velocity-llm-throttle",
+				Name:        "LLM request rate limit per session",
+				Type:        RuleTypeVelocity,
+				Scope:       RuleScope{Kind: RuleScopeWorkflow, Value: "wf-claims-triage"},
+				Status:      RuleStatusPublished,
+				Version:     "v2",
+				Audit:       AuditMetadata{CreatedAt: now, CreatedBy: "ops@cordum.io"},
+				Description: "throttle to 60 req/min per session",
+				Match: json.RawMessage(`{
+                  "tenants": ["acme"],
+                  "capabilities": ["llm.request"],
+                  "labels": {"actor_type": "service"}
+                }`),
+				Decide: json.RawMessage(`{
+                  "decision": "throttle",
+                  "reason": "rate_limit_exceeded",
+                  "velocity": {"max_requests": 60, "window_seconds": 60, "key": "labels.session_id"},
+                  "constraints": {"budgets": {"max_runtime_ms": 30000}}
+                }`),
+			},
+			wantID: "rule-velocity-llm-throttle",
+		},
+		{
+			name: "edge",
+			rule: Rule{
+				ID:      "rule-edge-fs-write-deny",
+				Name:    "Block writes to /etc",
+				Type:    RuleTypeEdge,
+				Scope:   RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-prod"},
+				Status:  RuleStatusPublished,
+				Version: "v1",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "secops@cordum.io"},
+				Match: json.RawMessage(`{
+                  "capability": "file.write",
+                  "labels": {"path_prefix": "/etc"},
+                  "complete": true
+                }`),
+				Decide: json.RawMessage(`{"decision":"DENY","reason":"system_path_protected"}`),
+			},
+			wantID: "rule-edge-fs-write-deny",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origMatch := append([]byte(nil), tc.rule.Match...)
+			origDecide := append([]byte(nil), tc.rule.Decide...)
+
+			raw, err := json.Marshal(tc.rule)
+			if err != nil {
+				t.Fatalf("Marshal err = %v", err)
+			}
+			var back Rule
+			if err := json.Unmarshal(raw, &back); err != nil {
+				t.Fatalf("Unmarshal err = %v", err)
+			}
+			if back.ID != tc.wantID {
+				t.Fatalf("ID drift: %s -> %s", tc.wantID, back.ID)
+			}
+			if back.Type != tc.rule.Type {
+				t.Fatalf("Type drift: %v -> %v", tc.rule.Type, back.Type)
+			}
+			if back.Scope != tc.rule.Scope {
+				t.Fatalf("Scope drift: %+v -> %+v", tc.rule.Scope, back.Scope)
+			}
+			if back.Status != tc.rule.Status {
+				t.Fatalf("Status drift: %v -> %v", tc.rule.Status, back.Status)
+			}
+			if !back.Audit.CreatedAt.Equal(tc.rule.Audit.CreatedAt) || back.Audit.CreatedBy != tc.rule.Audit.CreatedBy {
+				t.Fatalf("Audit drift: %+v -> %+v", tc.rule.Audit, back.Audit)
+			}
+
+			// Match/Decide json.RawMessage round-trip: the bytes must be
+			// semantically equal (json.Compact normalises whitespace which
+			// json.Marshal applies on serialise — bit-for-bit equality after
+			// re-canonicalisation is the contract we hold).
+			origCompact := mustCompact(t, origMatch)
+			backCompact := mustCompact(t, back.Match)
+			if !bytes.Equal(origCompact, backCompact) {
+				t.Fatalf("Match drift: %s vs %s", origCompact, backCompact)
+			}
+			origCompact = mustCompact(t, origDecide)
+			backCompact = mustCompact(t, back.Decide)
+			if !bytes.Equal(origCompact, backCompact) {
+				t.Fatalf("Decide drift: %s vs %s", origCompact, backCompact)
+			}
+		})
+	}
+}
+
+// TestDecision_RoundTrip exercises a Decision with multi-step Trace, all
+// optional fields populated, and the new wire-format DecisionType values
+// (allow_with_constraints, quarantine, redact) per amendment #2.
+func TestDecision_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 9, 8, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		dec  Decision
+	}{
+		{
+			name: "job_allow_with_constraints",
+			dec: Decision{
+				Source:        DecisionSourceJob,
+				RuleID:        "rule-velocity-llm-throttle",
+				BundleID:      "bundle-acme-default",
+				BundleVersion: "v12",
+				Type:          DecisionAllowWithConstraints,
+				Trace: []TraceStep{{
+					RuleID:       "rule-velocity-llm-throttle",
+					BundleID:     "bundle-acme-default",
+					DecisionType: DecisionAllowWithConstraints,
+					Reason:       "within_throttle_budget",
+					Timestamp:    now,
+					Constraints:  json.RawMessage(`{"budgets":{"max_runtime_ms":30000}}`),
+				}},
+				InputRef:  "blob://acme/input/r1",
+				OutputRef: "blob://acme/output/r1",
+				AuditHash: "0x" + "ab" + "cd" + "ef",
+				Timestamp: now,
+			},
+		},
+		{
+			name: "edge_deny",
+			dec: Decision{
+				Source:    DecisionSourceEdge,
+				RuleID:    "rule-edge-fs-write-deny",
+				Type:      DecisionDeny,
+				Trace:     nil,
+				Timestamp: now,
+			},
+		},
+		{
+			name: "output_quarantine",
+			dec: Decision{
+				Source:    DecisionSourceJob,
+				RuleID:    "rule-output-pii-quarantine",
+				Type:      DecisionQuarantine,
+				Timestamp: now,
+			},
+		},
+		{
+			name: "output_redact",
+			dec: Decision{
+				Source:    DecisionSourceJob,
+				RuleID:    "rule-output-pii-redact",
+				Type:      DecisionRedact,
+				Timestamp: now,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.dec)
+			if err != nil {
+				t.Fatalf("Marshal err = %v", err)
+			}
+			var back Decision
+			if err := json.Unmarshal(raw, &back); err != nil {
+				t.Fatalf("Unmarshal err = %v", err)
+			}
+			if back.Source != tc.dec.Source || back.Type != tc.dec.Type || back.RuleID != tc.dec.RuleID {
+				t.Fatalf("Decision drift: %+v vs %+v", tc.dec, back)
+			}
+			if !back.Timestamp.Equal(tc.dec.Timestamp) {
+				t.Fatalf("Timestamp drift: %v vs %v", tc.dec.Timestamp, back.Timestamp)
+			}
+			if len(back.Trace) != len(tc.dec.Trace) {
+				t.Fatalf("Trace length drift: %d vs %d", len(tc.dec.Trace), len(back.Trace))
+			}
+			for i := range tc.dec.Trace {
+				if back.Trace[i].RuleID != tc.dec.Trace[i].RuleID ||
+					back.Trace[i].DecisionType != tc.dec.Trace[i].DecisionType {
+					t.Fatalf("TraceStep[%d] drift: %+v vs %+v", i, tc.dec.Trace[i], back.Trace[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBundle_RoundTrip covers Bundle with EdgeMode metadata + a versioned
+// rule snapshot. Verifies BundleMetadata.EdgeMode survives marshal cycles.
+func TestBundle_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 9, 8, 30, 0, 0, time.UTC)
+
+	bundle := Bundle{
+		ID:           "bundle-edge-prod",
+		Name:         "Production edge bundle",
+		RuleIDs:      []string{"rule-edge-fs-write-deny", "rule-edge-shell-throttle"},
+		ScopeBinding: RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-prod"},
+		Versions: []BundleVersion{{
+			Version:    "v3",
+			DeployedAt: now,
+			AuditHash:  "0xdeadbeef",
+			RuleSnapshot: []Rule{{
+				ID:      "rule-edge-fs-write-deny",
+				Name:    "Block writes to /etc",
+				Type:    RuleTypeEdge,
+				Scope:   RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-prod"},
+				Status:  RuleStatusPublished,
+				Version: "v1",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "secops@cordum.io"},
+				Match:   json.RawMessage(`{"capability":"file.write"}`),
+				Decide:  json.RawMessage(`{"decision":"DENY"}`),
+			}},
+		}},
+		Metadata: BundleMetadata{EdgeMode: EdgeModeEnterpriseStrict},
+	}
+
+	raw, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("Marshal err = %v", err)
+	}
+	var back Bundle
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("Unmarshal err = %v", err)
+	}
+	if back.ID != bundle.ID || back.Name != bundle.Name {
+		t.Fatalf("Bundle envelope drift")
+	}
+	if back.Metadata.EdgeMode != EdgeModeEnterpriseStrict {
+		t.Fatalf("EdgeMode drift: %v vs enterprise-strict", back.Metadata.EdgeMode)
+	}
+	if len(back.Versions) != 1 || len(back.Versions[0].RuleSnapshot) != 1 {
+		t.Fatalf("Versions/RuleSnapshot drift: %+v", back.Versions)
+	}
+	if back.Versions[0].RuleSnapshot[0].ID != "rule-edge-fs-write-deny" {
+		t.Fatalf("RuleSnapshot[0].ID drift")
+	}
+}
+
+// TestBundle_OmitsZeroMetadata confirms BundleMetadata's zero value uses
+// `omitzero` so an unset metadata block doesn't pollute the JSON output.
+func TestBundle_OmitsZeroMetadata(t *testing.T) {
+	b := Bundle{
+		ID:           "bundle-no-meta",
+		Name:         "Bundle without edge metadata",
+		ScopeBinding: RuleScope{Kind: RuleScopeGlobal},
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("Marshal err = %v", err)
+	}
+	if bytes.Contains(raw, []byte(`"metadata"`)) {
+		t.Fatalf("zero BundleMetadata should be omitted; got %s", raw)
+	}
+}
+
+func mustCompact(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		t.Fatalf("Compact err = %v on %s", err, raw)
+	}
+	return buf.Bytes()
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3110,3 +3110,28 @@ The following routes are registered in gateway route setup.
 | GET | `/mcp/sse` |
 | POST | `/mcp/message` |
 | GET | `/mcp/status` |
+
+## Policy Studio (Backend 1 foundation, epic-d9a6c0a1)
+
+The OpenAPI spec at `docs/api/openapi/cordum-api.yaml` adds the unified
+`Rule`, `Decision`, `Bundle`, `BundleVersion`, `BundleMetadata`,
+`RuleScope`, `AuditMetadata`, and `TraceStep` schemas, plus the
+`RuleType` / `RuleStatus` / `DecisionType` / `DecisionSource` /
+`RuleScopeKind` / `EdgeMode` enum schemas. These coexist alongside the
+legacy `OutputRule`, `VelocityRule`, and `PolicyBundleSummary` schemas
+during the migration window — DoD #3 of task-3bf37e32 verifies the legacy
+schemas are byte-identical to pre-edit.
+
+Path operations that consume the new schemas (`/policies`,
+`/policies/bundles`, `/policies/decisions`, etc.) land in Backend 5 (the
+unified evaluator entry-point task). The Backend 1 PR ships the type
+definitions only; orval-generated dashboard hooks therefore have no new
+operations to wire until Backend 5 merges.
+
+The full design is documented in
+[docs/specs/policy-studio-rewrite.md](specs/policy-studio-rewrite.md).
+The corresponding Go types live in
+[core/policy/README.md](../core/policy/README.md), and the wire-level
+proto changes (including the `DECISION_TYPE_QUARANTINE = 6` and
+`DECISION_TYPE_REDACT = 7` append to the existing `DecisionType` enum in
+`safety.proto`) ship via a parallel cap PR per the CAP append-only rule.

--- a/docs/api/openapi/cordum-api.yaml
+++ b/docs/api/openapi/cordum-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Cordum HTTP API
-  version: '2026-04-21.2'
+  version: '2026-05-09.1'
   description: Canonical OpenAPI 3.0.3 spec for the Cordum gateway HTTP surface.
   contact:
     name: Cordum Team
@@ -10986,3 +10986,271 @@ components:
       - holder
       - ttl_remaining_ms
       - type
+    RuleType:
+      type: string
+      description: Discriminator for a Rule's match/decide payload schema.
+      enum:
+      - input
+      - output
+      - velocity
+      - edge
+    RuleStatus:
+      type: string
+      description: |
+        Lifecycle state of a Rule. `draft` rules are author-only; `published`
+        rules participate in evaluation; `deprecated` rules remain queryable
+        for audit and rollback but are skipped by evaluators.
+      enum:
+      - draft
+      - published
+      - deprecated
+    DecisionType:
+      type: string
+      description: |
+        Unified decision outcome emitted by either evaluator. The seven values
+        mirror the wire-format DecisionType enum in
+        cap/proto/cordum/agent/v1/safety.proto (epic-d9a6c0a1 appended
+        QUARANTINE and REDACT to the existing five values).
+      enum:
+      - allow
+      - deny
+      - require_human
+      - throttle
+      - allow_with_constraints
+      - quarantine
+      - redact
+    DecisionSource:
+      type: string
+      description: |
+        Identifies which evaluator produced a Decision: the safetykernel job
+        pipeline (`job`) or the edge classifier path (`edge`).
+      enum:
+      - job
+      - edge
+    RuleScopeKind:
+      type: string
+      description: |
+        Narrows where a rule (or bundle) applies. `global` covers an entire
+        deployment; `tenant`/`workflow` scope to job-side bindings;
+        `edge_fleet`/`edge_user` scope to edge-side bindings.
+      enum:
+      - global
+      - tenant
+      - workflow
+      - edge_fleet
+      - edge_user
+    EdgeMode:
+      type: string
+      description: |
+        Per-bundle enforcement posture for the edge evaluator. Migrates the
+        legacy global EdgePolicyMode switch onto bundle metadata so different
+        fleets and users can run at different modes simultaneously. See spec
+        cordum/docs/specs/policy-studio-rewrite.md "Edge bundle metadata".
+      enum:
+      - observe
+      - enforce
+      - enterprise-strict
+    RuleScope:
+      type: object
+      description: |
+        Narrows where a rule (or bundle) applies. When `kind` is `global`,
+        `value` is unused and may be empty; for the other kinds, `value`
+        carries the corresponding identifier (tenant id, workflow id, edge
+        fleet name, edge user id).
+      properties:
+        kind:
+          $ref: '#/components/schemas/RuleScopeKind'
+        value:
+          type: string
+      required:
+      - kind
+    AuditMetadata:
+      type: object
+      description: |
+        Records who created or last updated a Rule or Bundle. The `updated_*`
+        fields are zero-valued on first creation and populated by the first
+        subsequent edit.
+      properties:
+        created_at:
+          type: string
+          format: date-time
+        created_by:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+        updated_by:
+          type: string
+      required:
+      - created_at
+      - created_by
+    TraceStep:
+      type: object
+      description: |
+        Records one rule evaluation contributing to a Decision. Multiple
+        TraceSteps are emitted when a rule chain or bundle composition
+        produces a final decision through ordered evaluation. `constraints`
+        carries the raw constraints payload (e.g. the existing safetykernel
+        BudgetConstraints/SandboxProfile JSON) when the evaluator applied an
+        allow_with_constraints path; downstream consumers parse it per
+        RuleType.
+      properties:
+        rule_id:
+          type: string
+        bundle_id:
+          type: string
+        decision_type:
+          $ref: '#/components/schemas/DecisionType'
+        reason:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        constraints:
+          type: object
+          additionalProperties: true
+      required:
+      - rule_id
+      - decision_type
+      - timestamp
+    Rule:
+      type: object
+      description: |
+        Unified authoring surface for both job-side and edge-side policy. The
+        envelope (id, name, type, scope, status, version, audit) is shared
+        across all rule types; type-specific match/decide payloads carry the
+        per-RuleType schema as free-form objects to preserve lossless
+        roundtrip with the Go json.RawMessage and protobuf
+        google.protobuf.Struct transport. Coexists alongside the legacy
+        OutputRule/VelocityRule schemas during the migration window.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/RuleType'
+        scope:
+          $ref: '#/components/schemas/RuleScope'
+        status:
+          $ref: '#/components/schemas/RuleStatus'
+        version:
+          type: string
+        audit:
+          $ref: '#/components/schemas/AuditMetadata'
+        match:
+          type: object
+          additionalProperties: true
+        decide:
+          type: object
+          additionalProperties: true
+        description:
+          type: string
+      required:
+      - id
+      - name
+      - type
+      - scope
+      - status
+      - version
+      - audit
+      - match
+      - decide
+    Decision:
+      type: object
+      description: |
+        Unified evaluator output. A single Decision may aggregate multiple
+        rule evaluations via `trace`; `type` holds the final outcome the
+        evaluator derived from the trace. `source` distinguishes the
+        producing evaluator. `input_ref`/`output_ref` are pointers into the
+        blob store rather than embedded payloads.
+      properties:
+        source:
+          $ref: '#/components/schemas/DecisionSource'
+        rule_id:
+          type: string
+        bundle_id:
+          type: string
+        bundle_version:
+          type: string
+        type:
+          $ref: '#/components/schemas/DecisionType'
+        trace:
+          type: array
+          items:
+            $ref: '#/components/schemas/TraceStep'
+        input_ref:
+          type: string
+        output_ref:
+          type: string
+        audit_hash:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+      required:
+      - source
+      - rule_id
+      - type
+      - timestamp
+    BundleMetadata:
+      type: object
+      description: |
+        Per-bundle authoring metadata that does not affect match/decide
+        payloads. `edge_mode` is the per-bundle enforcement posture for
+        edge-scoped bundles, replacing the legacy global EdgePolicyMode
+        switch.
+      properties:
+        edge_mode:
+          $ref: '#/components/schemas/EdgeMode'
+    BundleVersion:
+      type: object
+      description: |
+        Immutable record of a Bundle deploy. `rule_snapshot` captures the
+        full Rule contents at deploy time so rollback and audit do not depend
+        on the live rule store; `audit_hash` chains the version into the
+        audit chain.
+      properties:
+        version:
+          type: string
+        rule_snapshot:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rule'
+        deployed_at:
+          type: string
+          format: date-time
+        audit_hash:
+          type: string
+      required:
+      - version
+      - deployed_at
+    Bundle:
+      type: object
+      description: |
+        Deployable set of rules with a deployment scope. Rules are referenced
+        by id rather than embedded so a bundle can rotate its members without
+        forcing rule duplication; the snapshot at deploy time lives in
+        `versions[].rule_snapshot` for tamper-evident rollback. Coexists
+        alongside the legacy PolicyBundleSummary schema.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        rule_ids:
+          type: array
+          items:
+            type: string
+        scope_binding:
+          $ref: '#/components/schemas/RuleScope'
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BundleVersion'
+        metadata:
+          $ref: '#/components/schemas/BundleMetadata'
+      required:
+      - id
+      - name
+      - scope_binding


### PR DESCRIPTION
## Summary

Foundation for the **Policy Studio Rewrite** epic ([epic-d9a6c0a1](https://github.com/cordum-io/cordum/issues?q=epic-d9a6c0a1) / `cordum/docs/specs/policy-studio-rewrite.md`). Defines the unified `Rule` / `Decision` / `Bundle` shapes that subsume today's split:
- job-side `InputPolicyRule` / `OutputPolicyRule` / `PolicyRule(velocity)` (`core/infra/config/safety_policy.go`)
- edge-side `EdgeDecision` / `ActionClassification` (`core/edge/decision.go`, `core/edge/classifier.go`)

Three deliverables in this PR (cordum side only — see "Parallel cap PR" below for the proto leg):
1. **Go package** `core/policy/` — 8 structs + 6 typed enums + comprehensive tests + golden JSON fixtures locking in legacy struct byte-identity.
2. **OpenAPI** schemas (14 new under `components.schemas`) + `info.version` bump `2026-04-21.2` → `2026-05-09.1`.
3. **Docs** — `CHANGELOG.md` `[Unreleased]` entry, `core/policy/README.md` (30 lines), `docs/api-reference.md` Policy Studio section.

## Backwards-compat (DoD #3)

- `git diff --name-only HEAD~1 HEAD -- core/infra/config/ core/edge/ core/safetykernel/` → empty.
- `git diff -- docs/api/openapi/cordum-api.yaml | grep -E '^-\s+(OutputRule|VelocityRule|PolicyBundleSummary):'` → zero matches.
- `core/policy/backwards_compat_test.go` + `testdata/legacy_input_rule.json` (781B) + `testdata/legacy_output_rule.json` (672B) lock in the JSON output of `config.InputPolicyRule` and `config.OutputPolicyRule`. `-count=3` clean.

## Verification matrix

| Gate | Cmd | Exit |
|---|---|---|
| go build | `go build ./...` | 0 |
| go test (full sweep) | `go test ./... -timeout 600s -count=1` | 0 |
| policy `-count=3` | `go test ./core/policy/... -count=3 -timeout 240s` | 0 |
| neighboring regression | `go test ./core/infra/config/... ./core/edge/... -count=3` | 0 |
| make openapi (Redocly) | `bash ./tools/scripts/gen_openapi.sh` | 0 |

12 `no-unused-components` Redocly warnings on the new schemas — expected; Backend 5 (`task-aadaec4a`, unified evaluator entry-point) will wire `/policies/*` operations that reference them.

## Parallel cap PR (must merge first)

`cap/proto/cordum/agent/v1/safety.proto` extends the existing `enum DecisionType` with two append-only values: `DECISION_TYPE_QUARANTINE = 6` and `DECISION_TYPE_REDACT = 7` (CAP append-only rule preserved; values 0-5 unchanged). A new `cap/proto/cordum/agent/v1/policy.proto` carries the `Rule`/`Decision`/`Bundle`/etc. messages and references the existing `DecisionType` enum bare (no redeclaration). The cap-side changes are committed in a separate scratch checkout at `D:/Cordum/policy-studio-work/cap/` and need their own cap PR with:

- `cap/spec/` updates per the CAP "Spec + proto alignment" rule.
- `cap/CHANGELOG.md` `[WIRE]`-prefixed entry per the CAP "Wire-level changes" rule.
- conformance fixtures via `go run cap/tools/conformance/generate_fixtures.go`.
- multi-language SDK regen via `bash cap/tools/make_protos.sh` (Go/Python/Node/C++).

Once that cap PR merges and tags a cap release (e.g. `v2.10.0`), a small follow-up cordum PR bumps `github.com/cordum-io/cap/v2` from `v2.9.3` to the new tag. The Go-side `policy.DecisionType` enum already declares all 7 wire values for parity, so this cordum PR is functional standalone — the cap dependency bump only adds the proto-level wire encoding for the new values.

## Dashboard codegen (deferred)

Dashboard `pnpm run generate-api` regen is deferred to a follow-up dashboard-branch PR because the orval pipeline (`orval.config.ts` + `dashboard/scripts/generate-api.mjs`) lives on `origin/dashboard` (commit `9496c8ee`) and has not yet landed on `origin/main` (this PR's base). The new schemas in this PR define the types only — Backend 5 will add the `/policies/*` path operations whose orval-generated React Query hooks are the actual dashboard consumers.

## Architect amendments incorporated

- **Amendment #1** (architect-697e, comment-dd1a6d2d): added `BundleMetadata` with `EdgeMode` (`observe` / `enforce` / `enterprise-strict`) per spec § "Edge bundle metadata". Bundle gains `metadata` field; OpenAPI + tests updated to match.
- **Amendment #2** (architect-697e, comment-287c4139): resolved a `DecisionType` collision in `cordum.agent.v1` by extending the existing safety.proto enum (append-only) instead of redeclaring; corrected `go_package` path to `github.com/cordum-io/cap/v2/cordum/agent/v1` (matching `safety.proto:5` verbatim); added 7th Go variant `DecisionAllowWithConstraints` for wire parity.

## Test plan
- [ ] `go test ./core/policy/... -count=3 -timeout 240s` clean
- [ ] `go test ./core/infra/config/... ./core/edge/... -count=3 -timeout 240s` clean (regression)
- [ ] `go build ./...` clean
- [ ] `bash ./tools/scripts/gen_openapi.sh` valid (12 expected `no-unused-components` warnings)
- [ ] No removals from existing OpenAPI components: `git diff -- docs/api/openapi/cordum-api.yaml | grep -E '^-\s+(OutputRule|VelocityRule|PolicyBundleSummary):'` returns nothing
- [ ] `core/policy/testdata/legacy_*.json` goldens unchanged from main fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced unified policy framework with Rule, Decision, and Bundle types for consistent policy authoring across job and edge components
  * Added new decision types: Allow With Constraints, Quarantine, and Redact
  * Added edge enforcement modes: Observe, Enforce, and Enterprise Strict

* **Documentation**
  * Updated API reference with new policy schemas and enums
  * Added comprehensive policy framework documentation

* **Tests**
  * Added backward compatibility tests for legacy policy rules

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/250)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->