### PR TITLE
feat(core/policy): bundle store with Redis-backed CRUD + atomic deploy/rollback (epic-d9a6c0a1 Backend 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,12 @@ window. Backwards-compat is locked in by
   `DecisionType`, `DecisionSource`, `RuleScopeKind`, `EdgeMode`).
 - New proto file `cap/proto/cordum/agent/v1/policy.proto` carrying the
   unified shapes; references `safety.proto`'s existing `DecisionType` enum
-  rather than redeclaring it.
+  rather than redeclaring it. Tracked in **cordum-io/cap#46**
+  (https://github.com/cordum-io/cap/pull/46).
 - **[WIRE]** `safety.proto`'s `DecisionType` enum extended with
   `DECISION_TYPE_QUARANTINE = 6` and `DECISION_TYPE_REDACT = 7` (CAP
-  append-only rule preserved; values 0–5 unchanged). Cap PR carries the
-  matching spec/CHANGELOG/conformance-fixture updates separately.
+  append-only rule preserved; values 0–5 unchanged). Wire change ships in
+  cordum-io/cap#46 alongside the new policy.proto messages.
 - OpenAPI `info.version` bumped to `'2026-05-09.1'`; 14 new schema entries
   appended under `components.schemas` (`Rule`, `Decision`, `TraceStep`,
   `Bundle`, `BundleVersion`, `BundleMetadata`, `RuleScope`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+#### Policy Studio Rewrite — Backend 2: bundle store (epic-d9a6c0a1, task-b349524a)
+
+Redis-backed `BundleStore` for the unified Policy Studio bundles
+introduced in Backend 1. Built additively under `core/policy/`; no
+existing stores modified.
+
+- `core/policy/bundle_store.go` — BundleStore interface (10 ops: Bundle
+  CRUD + version CRUD + Deploy/Rollback/GetActive/ListHistory) +
+  Deployment record + DeploymentAction enum (deploy|rollback) + 6 typed
+  errors.
+- `core/policy/bundle_store_keys.go` — Redis schema constants + 5 key
+  constructors. Confirmed-clean prefix space at
+  `policy:bundle:*` + `policy:scope:*` (no collision with workflow's
+  `cordum:wf:*`, edge's `edge:session:*`, registry's `sys:workers:*`).
+- `core/policy/bundle_store_redis.go` — `BundleRedisStore` impl with
+  atomic Lua scripts for the multi-key Deploy/Rollback paths. Per
+  memory `mem-12f1ceeb` go-redis WATCH+TxPipelined corrupts the
+  connection pool when miniredis returns errors, so single Lua EVAL is
+  the only safe pattern. Chained rollbacks unwind one step per call
+  (v3→v2→v1) by locating the deploy entry that established the current
+  active and walking past it.
+- `core/policy/bundle_store_keys_test.go` + `bundle_store_redis_test.go`
+  — 22 tests (6 key tests + 16 store tests) covering happy-path CRUD,
+  version idempotency, deploy lifecycle, rollback chain, scope
+  isolation, concurrent-deploy serialization, and 8 nil/empty-id
+  branches. miniredis-backed via the canonical pattern from
+  `core/workflow/store_redis_test.go`.
+- `docs/policy-bundle-store.md` — full Redis schema + CRUD/atomicity
+  table + bounded-history rationale + open questions for v3.
+
+`go build ./...` clean; `go test ./core/policy/... -count=3 -cover
+-timeout 240s` clean at coverage 80.2% (clears DoD #3 80% bar).
+
 #### Policy Studio Rewrite — Backend 1 (epic-d9a6c0a1)
 
 Foundation shapes for the Job + Edge unified policy surface. New shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+#### Policy Studio Rewrite — Backend 1 (epic-d9a6c0a1)
+
+Foundation shapes for the Job + Edge unified policy surface. New shared
+`Rule` / `Decision` / `Bundle` types subsume today's split
+`InputPolicyRule`/`OutputPolicyRule`/`PolicyRule(velocity)` plus the
+`EdgeDecision`/`ActionClassification` edge surface, with a `RuleType`
+discriminator and per-type `Match`/`Decide` payloads carried as raw JSON
+for lossless roundtrip with the orval-generated dashboard types and the
+proto `google.protobuf.Struct` carriers.
+
+**Additive only.** No existing types are modified or removed:
+`core/infra/config.SafetyPolicy`, `InputPolicyRule`, `InputPolicyMatch`,
+`OutputPolicyRule`, `OutputPolicyMatch`, `PolicyRule`, `PolicyMatch`,
+`PolicyDecision`, `MCPPolicy`, `TenantPolicy`, `core/edge.EdgeDecision`,
+`ActionClassification`, and the OpenAPI `OutputRule` / `VelocityRule` /
+`PolicyBundleSummary` schemas all remain in place during the migration
+window. Backwards-compat is locked in by
+`core/policy/backwards_compat_test.go` against pre-recorded golden JSON in
+`core/policy/testdata/`.
+
+- New Go package `core/policy/` with `Rule`, `Decision`, `TraceStep`,
+  `Bundle`, `BundleMetadata`, `BundleVersion`, `RuleScope`,
+  `AuditMetadata` structs and six typed enums (`RuleType`, `RuleStatus`,
+  `DecisionType`, `DecisionSource`, `RuleScopeKind`, `EdgeMode`).
+- New proto file `cap/proto/cordum/agent/v1/policy.proto` carrying the
+  unified shapes; references `safety.proto`'s existing `DecisionType` enum
+  rather than redeclaring it.
+- **[WIRE]** `safety.proto`'s `DecisionType` enum extended with
+  `DECISION_TYPE_QUARANTINE = 6` and `DECISION_TYPE_REDACT = 7` (CAP
+  append-only rule preserved; values 0–5 unchanged). Cap PR carries the
+  matching spec/CHANGELOG/conformance-fixture updates separately.
+- OpenAPI `info.version` bumped to `'2026-05-09.1'`; 14 new schema entries
+  appended under `components.schemas` (`Rule`, `Decision`, `TraceStep`,
+  `Bundle`, `BundleVersion`, `BundleMetadata`, `RuleScope`,
+  `AuditMetadata` + six enum schemas).
+
+The unified evaluator entry-points and the migration of
+`core/safetykernel` and `core/edge` to consume `Rule` + emit `Decision`
+land in follow-up Backend tasks (see the epic decomposition in
+[docs/specs/policy-studio-rewrite.md](docs/specs/policy-studio-rewrite.md)).
+
 #### Cordum Edge P0 (2026-04-30)
 
 EDGE epic shipped 32 P0 tasks for the Compliance Firewall surface — local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+#### Policy Studio Rewrite — Backend 2 reopen #1 (epic-d9a6c0a1, task-b349524a)
+
+QA caught two correctness defects + two test gaps in the initial Backend
+2 ship; this entry covers the fix landed on top of PR #252.
+
+- `core/policy/bundle_store_redis.go` rollback semantics — the original
+  rollback walked history for "next deploy entry after the deploy
+  matching current active". After `deploy v1, deploy v2, rollback (→
+  v1), deploy v3, rollback`, the second rollback returned **v2** (the
+  raw second-most-recent deploy) instead of the active state
+  immediately before v3 was deployed (v1). Fix: each deploy event now
+  records the active pair at deploy-time as `prev_bundle_id` +
+  `prev_version` (read inside the same Lua script that writes the
+  event, so concurrent deploys serialize correctly). Rollback locates
+  the deploy event matching the current active pair and restores from
+  its `prev_*` fields. The `Deployment` Go struct gains matching
+  `PrevBundleID` + `PrevVersion` fields with `omitempty` JSON tags
+  so old golden fixtures continue to deserialize.
+- `core/policy/bundle_store_redis.go` `CreateBundleVersion` parent check
+  — the original `SETNX` pipeline accepted writes for non-existent
+  parent bundles, allowing orphan version blobs +
+  `policy:bundle:{id}:versions` index entries. Fix: `EXISTS
+  policy:bundle:{id}` precheck before the `SETNX`+`ZADD` pipeline
+  returns `ErrBundleNotFound` for missing parents. Safe non-atomic
+  precheck because the interface defines no `DeleteBundle`, so a
+  parent that exists at check-time still exists at write-time.
+- `core/policy/bundle_store_redis_test.go` — added
+  `TestDeployAfterRollback` (the QA repro permanently locked in:
+  asserts the prev-active fields on each deploy + that rollback after
+  deploy-after-rollback restores v1 with explicit regression error
+  text), `TestCreateBundleVersion_OrphanRejected` (orphan write
+  returns `ErrBundleNotFound` and the index ZSET stays empty), and
+  `TestDeploymentHistoryCapEnforced` (105 deploys → `len(hist) == 100`,
+  binding the LTRIM cap inside the deploy Lua).
+
+`go build ./...` clean. `go test ./core/policy/... -count=3 -cover
+-timeout 240s` clean at 80.3% coverage. `go test ./core/workflow/...
+./core/edge/...` clean (no neighboring-store regression).
+
 ### Added
 
 #### Policy Studio Rewrite — Backend 2: bundle store (epic-d9a6c0a1, task-b349524a)

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -11,6 +11,10 @@ with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
   evaluation paths (Backend 3 + Backend 5).
 - `core/edge/` — same migration; joins the unified audit-chain (Backend 4).
 - `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
+- `BundleRedisStore` (`bundle_store_redis.go`) — Redis-backed shared
+  bundle storage for job + edge consumers; Backend 5+ wires this into
+  the unified evaluator entry-point. Schema documented in
+  [`docs/policy-bundle-store.md`](../../docs/policy-bundle-store.md).
 
 ## Match / Decide contract
 

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -1,0 +1,30 @@
+# core/policy
+
+Unified Rule, Decision, and Bundle shapes for Cordum's Policy Studio surface
+(epic-d9a6c0a1). Subsumes the previously split job-side
+(input/output/velocity) and edge-side authoring surfaces under one envelope
+with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
+
+## Consumers (in follow-up tasks)
+
+- `core/safetykernel/` — will consume `Rule` and emit `Decision` for job
+  evaluation paths (Backend 3 + Backend 5).
+- `core/edge/` — same migration; joins the unified audit-chain (Backend 4).
+- `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
+
+## Match / Decide contract
+
+`Rule.Match` and `Rule.Decide` are `json.RawMessage`. The per-`RuleType`
+shape is documented in `docs/specs/policy-studio-rewrite.md` and mirrors
+today's `InputPolicyMatch` / `OutputPolicyMatch` / `PolicyMatch` +
+`VelocityConfig` / `ActionClassification` surfaces. The raw-message carrier
+preserves bit-for-bit fidelity and maps cleanly onto the proto-side
+`google.protobuf.Struct` and orval `Record<string, unknown>` types.
+
+## Decision wire values
+
+`DecisionType` mirrors the seven values in the wire-format
+`cap/proto/cordum/agent/v1/safety.proto` enum: `allow` / `deny` /
+`require_human` / `throttle` / `allow_with_constraints` / `quarantine` /
+`redact`. The last two were appended for the unified surface per CAP's
+append-only protobuf-evolution rule.

--- a/core/policy/backwards_compat_test.go
+++ b/core/policy/backwards_compat_test.go
@@ -1,0 +1,116 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+)
+
+// TestLegacyInputPolicyRuleJSON locks in the byte-level JSON output of
+// `core/infra/config.InputPolicyRule` so any inadvertent shape change to
+// the legacy struct fails this test loudly. Backwards-compat is DoD #3 of
+// task-3bf37e32 (Policy Studio Backend 1).
+//
+// Set UPDATE_GOLDENS=1 to regenerate the golden file when the legacy shape
+// is intentionally changed.
+func TestLegacyInputPolicyRuleJSON(t *testing.T) {
+	enabled := true
+	fixture := config.InputPolicyRule{
+		ID:       "legacy-input-secret-block",
+		Tier:     config.PolicyTierGlobal,
+		Selector: config.PolicySelector{WorkflowID: "wf-claims"},
+		Enabled:  &enabled,
+		Severity: "critical",
+		Desc:     "Block secret leaks in inputs",
+		Match: config.InputPolicyMatch{
+			Tenants:         []string{"acme"},
+			Topics:          []string{"job.acme.*"},
+			Capabilities:    []string{"llm.request"},
+			RiskTags:        []string{"untrusted_input"},
+			Scanners:        []string{"secret_leak"},
+			ContentPatterns: []string{`(?i)api[_-]?key`},
+			Keywords:        []string{"secret", "token"},
+			ContentTypes:    []string{"application/json"},
+			Detectors:       []string{"secret_leak"},
+			InputSizeGt:     1024,
+			MaxInputBytes:   1048576,
+		},
+		Decision: "deny",
+		Reason:   "secret_leak_detected",
+	}
+
+	got, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent err = %v", err)
+	}
+	got = append(got, '\n')
+
+	goldenPath := filepath.Join("testdata", "legacy_input_rule.json")
+	assertGoldenEqual(t, goldenPath, got)
+}
+
+// TestLegacyOutputPolicyRuleJSON does the same lock-in for the legacy
+// `core/infra/config.OutputPolicyRule` shape.
+func TestLegacyOutputPolicyRuleJSON(t *testing.T) {
+	enabled := true
+	hasError := false
+	fixture := config.OutputPolicyRule{
+		ID:       "legacy-output-pii-redact",
+		Enabled:  &enabled,
+		Severity: "high",
+		Desc:     "Redact PII in outputs",
+		Match: config.OutputPolicyMatch{
+			Tenants:         []string{"acme"},
+			Topics:          []string{"job.acme.*"},
+			Capabilities:    []string{"llm.request"},
+			RiskTags:        []string{"contains_pii"},
+			Scanners:        []string{"pii"},
+			ContentPatterns: []string{`(?i)\bSSN\b`},
+			Keywords:        []string{"social", "ssn"},
+			ContentTypes:    []string{"application/json"},
+			Detectors:       []string{"pii"},
+			OutputSizeGt:    0,
+			MaxOutputBytes:  4194304,
+			HasError:        &hasError,
+		},
+		Decision: "redact",
+		Reason:   "pii_in_output",
+	}
+
+	got, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent err = %v", err)
+	}
+	got = append(got, '\n')
+
+	goldenPath := filepath.Join("testdata", "legacy_output_rule.json")
+	assertGoldenEqual(t, goldenPath, got)
+}
+
+// assertGoldenEqual reads the golden file and compares bytes against got.
+// On UPDATE_GOLDENS=1 it overwrites the golden instead of comparing —
+// always a deliberate operator action, never automatic.
+func assertGoldenEqual(t *testing.T, path string, got []byte) {
+	t.Helper()
+	if os.Getenv("UPDATE_GOLDENS") == "1" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s) err = %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) err = %v", path, err)
+		}
+		t.Logf("UPDATE_GOLDENS=1 — wrote %d bytes to %s", len(got), path)
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) err = %v — generate via `UPDATE_GOLDENS=1 go test ./core/policy/...`", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden drift in %s\n--- want\n%s\n--- got\n%s", path, want, got)
+	}
+}

--- a/core/policy/bundle_store.go
+++ b/core/policy/bundle_store.go
@@ -1,0 +1,122 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// BundleStore is the unified storage interface for Policy Studio bundles
+// (epic-d9a6c0a1). Both job-side (safetykernel) and edge-side consumers
+// read through this interface; the Redis implementation lives in
+// bundle_store_redis.go (Backend 2 step-4).
+//
+// Design intent:
+//   - Bundles are authored once and deployed multiple times. Versions
+//     capture immutable RuleSnapshot at deploy time for tamper-evident
+//     rollback.
+//   - Deployments bind a (bundle, version) pair to a RuleScope. The
+//     active deployment is the one evaluators consult; rollbacks are
+//     append-only and re-bind the active pointer to a prior version.
+//   - All multi-key mutations (DeployVersionToScope, RollbackDeployment)
+//     execute inside one Redis Lua script so concurrent deploys
+//     serialize through Redis itself, not through Go-level WATCH/MULTI
+//     (see memory mem-12f1ceeb — go-redis WATCH+TxPipelined corrupts the
+//     connection pool when miniredis returns errors).
+type BundleStore interface {
+	// Bundle CRUD ----------------------------------------------------------
+
+	// CreateBundle persists a new Bundle. The Bundle's ID must be set; an
+	// existing bundle with the same ID returns ErrBundleExists.
+	CreateBundle(ctx context.Context, b *Bundle) error
+
+	// GetBundle returns the Bundle envelope (without RuleSnapshot — those
+	// live in Versions). Returns ErrBundleNotFound when no such bundle.
+	GetBundle(ctx context.Context, id string) (*Bundle, error)
+
+	// ListBundlesByScope returns every bundle whose ScopeBinding matches
+	// the supplied scope. An empty result is not an error.
+	ListBundlesByScope(ctx context.Context, scope RuleScope) ([]*Bundle, error)
+
+	// Bundle versioning ---------------------------------------------------
+
+	// CreateBundleVersion appends a new version to bundleID. Idempotent on
+	// duplicate version numbers (returns ErrBundleVersionExists). Versions
+	// are immutable once written.
+	CreateBundleVersion(ctx context.Context, bundleID string, v *BundleVersion) error
+
+	// ListBundleVersions returns all versions for the bundle in
+	// chronological deploy order (oldest first).
+	ListBundleVersions(ctx context.Context, bundleID string) ([]*BundleVersion, error)
+
+	// GetBundleVersion returns one specific version. Returns
+	// ErrBundleVersionNotFound when the (bundleID, version) pair is unknown.
+	GetBundleVersion(ctx context.Context, bundleID, version string) (*BundleVersion, error)
+
+	// Deployment ----------------------------------------------------------
+
+	// DeployVersionToScope rebinds the active deployment for scope to the
+	// given (bundleID, version). The previous active deployment (if any)
+	// is preserved in deployment history. Returns the recorded Deployment
+	// on success; ErrBundleVersionNotFound if the version doesn't exist.
+	DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error)
+
+	// RollbackDeployment reverts the active deployment for scope to the
+	// previous entry in history. Returns ErrNoRollbackTarget when history
+	// has fewer than two entries (i.e. no prior deploy to fall back to).
+	// On success the rollback itself is appended to history as a new
+	// Deployment with Action=DeploymentActionRollback.
+	RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error)
+
+	// GetActiveDeployment returns the active deployment for scope.
+	// Returns ErrNoDeploymentForScope when nothing is currently bound.
+	GetActiveDeployment(ctx context.Context, scope RuleScope) (*Deployment, error)
+
+	// ListDeploymentHistory returns up to limit entries from the scope's
+	// deployment history, newest first. The history is bounded to the
+	// last 100 entries by the implementation.
+	ListDeploymentHistory(ctx context.Context, scope RuleScope, limit int) ([]*Deployment, error)
+}
+
+// DeploymentAction discriminates a Deployment record between a fresh
+// deploy and a rollback to a prior version. The two paths share the rest
+// of the envelope; downstream readers branch on Action when they need to
+// surface the distinction (e.g. the dashboard "Deployments" tab).
+type DeploymentAction string
+
+const (
+	// DeploymentActionDeploy records a fresh deploy of a (bundle, version)
+	// pair to a scope. The Version field carries the deployed version.
+	DeploymentActionDeploy DeploymentAction = "deploy"
+
+	// DeploymentActionRollback records a rollback to a prior version. The
+	// Version field carries the version rolled BACK TO (i.e. the new
+	// active version after the rollback completes), not the version
+	// rolled away from.
+	DeploymentActionRollback DeploymentAction = "rollback"
+)
+
+// Deployment is the audit-ready record of one binding event between a
+// (bundle, version) and a scope. Stored in scope deployment history; the
+// most recent entry whose Action == DeploymentActionDeploy or Rollback
+// determines the active deployment.
+type Deployment struct {
+	BundleID      string           `json:"bundle_id"`
+	Version       string           `json:"version"`
+	Scope         RuleScope        `json:"scope"`
+	DeployedAt    time.Time        `json:"deployed_at"`
+	DeployedBy    string           `json:"deployed_by,omitempty"`
+	AuditHash     string           `json:"audit_hash,omitempty"`
+	Action        DeploymentAction `json:"action"`
+}
+
+// Typed errors returned by BundleStore implementations. Consumers should
+// branch on these via errors.Is for stable contract tests.
+var (
+	ErrBundleNotFound        = errors.New("policy: bundle not found")
+	ErrBundleExists          = errors.New("policy: bundle already exists")
+	ErrBundleVersionNotFound = errors.New("policy: bundle version not found")
+	ErrBundleVersionExists   = errors.New("policy: bundle version already exists")
+	ErrNoDeploymentForScope  = errors.New("policy: no active deployment for scope")
+	ErrNoRollbackTarget      = errors.New("policy: no prior deployment to roll back to")
+)

--- a/core/policy/bundle_store.go
+++ b/core/policy/bundle_store.go
@@ -62,10 +62,20 @@ type BundleStore interface {
 	DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error)
 
 	// RollbackDeployment reverts the active deployment for scope to the
-	// previous entry in history. Returns ErrNoRollbackTarget when history
-	// has fewer than two entries (i.e. no prior deploy to fall back to).
+	// (bundle, version) pair that was active immediately before the
+	// current binding was established. Each deploy event records its
+	// PrevBundleID + PrevVersion at write time, so rollback restores the
+	// prior active pair regardless of any rollback markers in between
+	// (e.g. deploy v1, deploy v2, rollback to v1, deploy v3, rollback
+	// returns to v1 — the active state just before v3 — not v2). Chained
+	// rollbacks unwind one step per call.
+	//
+	// Returns ErrNoRollbackTarget when no prior deploy exists (e.g. only
+	// the original deploy is in history, or its PrevBundleID is empty).
 	// On success the rollback itself is appended to history as a new
-	// Deployment with Action=DeploymentActionRollback.
+	// Deployment with Action=DeploymentActionRollback whose PrevBundleID
+	// + PrevVersion fields capture the version we rolled away from
+	// (informational; rollback does not consume its own prev fields).
 	RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error)
 
 	// GetActiveDeployment returns the active deployment for scope.
@@ -100,14 +110,25 @@ const (
 // (bundle, version) and a scope. Stored in scope deployment history; the
 // most recent entry whose Action == DeploymentActionDeploy or Rollback
 // determines the active deployment.
+//
+// Each deploy event records PrevBundleID + PrevVersion at write time —
+// the (bundle, version) pair that was active immediately before this
+// event ran. Rollback uses those fields to restore the prior active
+// pair regardless of any deploy/rollback events that landed in between.
+// On a deploy event, the prev pair is the active state just before this
+// deploy. On a rollback event, the prev pair is the active state just
+// before the rollback (i.e. the version we rolled away from); rollback
+// does not consume its own prev fields.
 type Deployment struct {
-	BundleID      string           `json:"bundle_id"`
-	Version       string           `json:"version"`
-	Scope         RuleScope        `json:"scope"`
-	DeployedAt    time.Time        `json:"deployed_at"`
-	DeployedBy    string           `json:"deployed_by,omitempty"`
-	AuditHash     string           `json:"audit_hash,omitempty"`
-	Action        DeploymentAction `json:"action"`
+	BundleID     string           `json:"bundle_id"`
+	Version      string           `json:"version"`
+	Scope        RuleScope        `json:"scope"`
+	DeployedAt   time.Time        `json:"deployed_at"`
+	DeployedBy   string           `json:"deployed_by,omitempty"`
+	AuditHash    string           `json:"audit_hash,omitempty"`
+	Action       DeploymentAction `json:"action"`
+	PrevBundleID string           `json:"prev_bundle_id,omitempty"`
+	PrevVersion  string           `json:"prev_version,omitempty"`
 }
 
 // Typed errors returned by BundleStore implementations. Consumers should

--- a/core/policy/bundle_store_keys.go
+++ b/core/policy/bundle_store_keys.go
@@ -1,0 +1,61 @@
+package policy
+
+// Redis key constructors for the Policy Studio bundle store
+// (epic-d9a6c0a1 Backend 2). All keys live under two prefixes:
+//
+//	policy:bundle:*  bundle envelopes + per-bundle versions index +
+//	                 per-version blobs
+//	policy:scope:*   per-scope active deployment pointer + history list
+//
+// These prefixes are confirmed clean against existing core/* stores per
+// the step-2 inventory: workflow uses `cordum:wf:*` + `runKey()`, edge
+// uses `edge:session:*` + `edge:rule:*`, and registry uses
+// `sys:workers:*`. None overlap with `policy:*`.
+//
+// Key shapes:
+//
+//	policy:bundle:{id}                          STRING (Bundle envelope JSON)
+//	policy:bundle:{id}:versions                 ZSET   (score = unix nanos of DeployedAt; member = version string)
+//	policy:bundle:{id}:version:{version}        STRING (BundleVersion JSON, includes RuleSnapshot)
+//	policy:scope:{kind}:{value}:active          STRING ("{bundleID}:{version}" pointer; empty when unbound)
+//	policy:scope:{kind}:{value}:history         LIST   (each element is a Deployment JSON; LPUSH on deploy/rollback; LTRIM 0 99 keeps newest 100)
+
+const (
+	bundleKeyPrefix       = "policy:bundle:"
+	bundleVersionInfix    = ":version:"
+	bundleVersionsSuffix  = ":versions"
+	scopeKeyPrefix        = "policy:scope:"
+	scopeActiveSuffix     = ":active"
+	scopeHistorySuffix    = ":history"
+	deploymentHistoryCap  = 100
+)
+
+// bundleKey returns the Redis key for a bundle envelope.
+func bundleKey(id string) string {
+	return bundleKeyPrefix + id
+}
+
+// bundleVersionKey returns the Redis key for one specific BundleVersion.
+func bundleVersionKey(id, version string) string {
+	return bundleKeyPrefix + id + bundleVersionInfix + version
+}
+
+// bundleVersionsIndexKey returns the Redis key for the ZSET that indexes
+// every version belonging to a bundle.
+func bundleVersionsIndexKey(id string) string {
+	return bundleKeyPrefix + id + bundleVersionsSuffix
+}
+
+// scopeActiveKey returns the Redis key for the active-deployment pointer
+// of a scope. The stored value is the literal "{bundleID}:{version}".
+// For RuleScopeGlobal the Value field is empty; the helper still emits a
+// deterministic key.
+func scopeActiveKey(scope RuleScope) string {
+	return scopeKeyPrefix + string(scope.Kind) + ":" + scope.Value + scopeActiveSuffix
+}
+
+// scopeDeploymentHistoryKey returns the Redis key for the LIST that
+// stores a scope's deploy/rollback history.
+func scopeDeploymentHistoryKey(scope RuleScope) string {
+	return scopeKeyPrefix + string(scope.Kind) + ":" + scope.Value + scopeHistorySuffix
+}

--- a/core/policy/bundle_store_keys_test.go
+++ b/core/policy/bundle_store_keys_test.go
@@ -1,0 +1,89 @@
+package policy
+
+import "testing"
+
+func TestBundleKey(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "simple id", id: "b1", want: "policy:bundle:b1"},
+		{name: "uuid id", id: "01H8Z1...EOF", want: "policy:bundle:01H8Z1...EOF"},
+		{name: "empty id is allowed at the helper layer", id: "", want: "policy:bundle:"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bundleKey(tt.id); got != tt.want {
+				t.Errorf("bundleKey(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBundleVersionKey(t *testing.T) {
+	got := bundleVersionKey("b1", "v3")
+	want := "policy:bundle:b1:version:v3"
+	if got != want {
+		t.Errorf("bundleVersionKey(b1, v3) = %q, want %q", got, want)
+	}
+}
+
+func TestBundleVersionsIndexKey(t *testing.T) {
+	got := bundleVersionsIndexKey("b1")
+	want := "policy:bundle:b1:versions"
+	if got != want {
+		t.Errorf("bundleVersionsIndexKey(b1) = %q, want %q", got, want)
+	}
+}
+
+func TestScopeActiveKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope RuleScope
+		want  string
+	}{
+		{
+			name:  "tenant scope",
+			scope: RuleScope{Kind: RuleScopeTenant, Value: "acme"},
+			want:  "policy:scope:tenant:acme:active",
+		},
+		{
+			name:  "global scope (empty value)",
+			scope: RuleScope{Kind: RuleScopeGlobal, Value: ""},
+			want:  "policy:scope:global::active",
+		},
+		{
+			name:  "edge fleet scope",
+			scope: RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-1"},
+			want:  "policy:scope:edge_fleet:fleet-1:active",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopeActiveKey(tt.scope); got != tt.want {
+				t.Errorf("scopeActiveKey(%+v) = %q, want %q", tt.scope, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeDeploymentHistoryKey(t *testing.T) {
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	got := scopeDeploymentHistoryKey(scope)
+	want := "policy:scope:tenant:acme:history"
+	if got != want {
+		t.Errorf("scopeDeploymentHistoryKey(%+v) = %q, want %q", scope, got, want)
+	}
+}
+
+func TestKeyPrefixIsolation(t *testing.T) {
+	// Step-2 inventory confirmed no existing core store uses these prefixes.
+	// This test pins the prefix constants so accidental rename is caught.
+	if bundleKeyPrefix != "policy:bundle:" {
+		t.Errorf("bundleKeyPrefix changed: %q (must stay 'policy:bundle:' to avoid collision audit)", bundleKeyPrefix)
+	}
+	if scopeKeyPrefix != "policy:scope:" {
+		t.Errorf("scopeKeyPrefix changed: %q (must stay 'policy:scope:' to avoid collision audit)", scopeKeyPrefix)
+	}
+}

--- a/core/policy/bundle_store_redis.go
+++ b/core/policy/bundle_store_redis.go
@@ -1,0 +1,485 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/infra/redisutil"
+	"github.com/redis/go-redis/v9"
+)
+
+// BundleRedisStore is the Redis-backed BundleStore implementation. All
+// multi-key mutations execute inside Lua scripts so concurrent
+// deploy/rollback operations serialize through Redis itself, not via
+// Go-level WATCH/MULTI/EXEC (per memory mem-12f1ceeb — go-redis
+// WATCH+TxPipelined corrupts the connection pool when miniredis returns
+// errors).
+type BundleRedisStore struct {
+	client redis.UniversalClient
+}
+
+// NewRedisBundleStore constructs a Redis-backed BundleStore.
+func NewRedisBundleStore(url string) (*BundleRedisStore, error) {
+	if url == "" {
+		return nil, fmt.Errorf("redis url required")
+	}
+	client, err := redisutil.NewClient(url)
+	if err != nil {
+		return nil, fmt.Errorf("parse redis url: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("connect redis: %w", err)
+	}
+	return &BundleRedisStore{client: client}, nil
+}
+
+// NewRedisBundleStoreFromClient wraps an existing Redis client. Used by
+// tests to share a miniredis instance with other stores.
+func NewRedisBundleStoreFromClient(client redis.UniversalClient) *BundleRedisStore {
+	return &BundleRedisStore{client: client}
+}
+
+// Close releases the underlying Redis client.
+func (s *BundleRedisStore) Close() error {
+	if s.client == nil {
+		return nil
+	}
+	return s.client.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Bundle CRUD
+// ---------------------------------------------------------------------------
+
+// CreateBundle persists a new Bundle. Returns ErrBundleExists when a
+// bundle with the same ID already exists. Versions are NOT embedded in
+// the envelope payload — they live in their own keys per the schema.
+func (s *BundleRedisStore) CreateBundle(ctx context.Context, b *Bundle) error {
+	if b == nil {
+		return fmt.Errorf("bundle: nil bundle")
+	}
+	if strings.TrimSpace(b.ID) == "" {
+		return fmt.Errorf("bundle: id required")
+	}
+	envelope := *b
+	envelope.Versions = nil
+	payload, err := json.Marshal(&envelope)
+	if err != nil {
+		return fmt.Errorf("marshal bundle: %w", err)
+	}
+	ok, err := s.client.SetNX(ctx, bundleKey(b.ID), payload, 0).Result()
+	if err != nil {
+		return fmt.Errorf("create bundle: %w", err)
+	}
+	if !ok {
+		return ErrBundleExists
+	}
+	return nil
+}
+
+// GetBundle returns a Bundle envelope by ID. Returns ErrBundleNotFound
+// when no such bundle. The Versions field is left empty; callers fetch
+// versions explicitly via ListBundleVersions / GetBundleVersion.
+func (s *BundleRedisStore) GetBundle(ctx context.Context, id string) (*Bundle, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("bundle: id required")
+	}
+	data, err := s.client.Get(ctx, bundleKey(id)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrBundleNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get bundle %s: %w", id, err)
+	}
+	var b Bundle
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("unmarshal bundle %s: %w", id, err)
+	}
+	return &b, nil
+}
+
+// ListBundlesByScope returns every bundle whose ScopeBinding matches the
+// supplied scope. Implementation uses SCAN over the `policy:bundle:*`
+// prefix and filters in-process; this is acceptable for the early
+// adopter cohort but Phase 7 / v3 should add a per-scope index.
+func (s *BundleRedisStore) ListBundlesByScope(ctx context.Context, scope RuleScope) ([]*Bundle, error) {
+	out := make([]*Bundle, 0)
+	var cursor uint64
+	versionInfix := bundleVersionInfix
+	for {
+		keys, next, err := s.client.Scan(ctx, cursor, bundleKeyPrefix+"*", 256).Result()
+		if err != nil {
+			return nil, fmt.Errorf("scan bundles: %w", err)
+		}
+		for _, k := range keys {
+			// Skip per-version + version-index keys; we only want the envelope.
+			if strings.Contains(k, versionInfix) || strings.HasSuffix(k, bundleVersionsSuffix) {
+				continue
+			}
+			data, err := s.client.Get(ctx, k).Bytes()
+			if errors.Is(err, redis.Nil) {
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("read bundle %s: %w", k, err)
+			}
+			var b Bundle
+			if err := json.Unmarshal(data, &b); err != nil {
+				return nil, fmt.Errorf("unmarshal bundle %s: %w", k, err)
+			}
+			if scopeBindingMatches(b.ScopeBinding, scope) {
+				bb := b
+				out = append(out, &bb)
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return out, nil
+}
+
+func scopeBindingMatches(have, want RuleScope) bool {
+	if have.Kind != want.Kind {
+		return false
+	}
+	if want.Kind == RuleScopeGlobal {
+		return true
+	}
+	return have.Value == want.Value
+}
+
+// ---------------------------------------------------------------------------
+// Bundle versioning
+// ---------------------------------------------------------------------------
+
+// CreateBundleVersion appends a new immutable version to bundleID.
+// SETNX on the version blob + ZADD on the index. Idempotent on
+// duplicate version numbers — returns ErrBundleVersionExists.
+func (s *BundleRedisStore) CreateBundleVersion(ctx context.Context, bundleID string, v *BundleVersion) error {
+	if v == nil {
+		return fmt.Errorf("bundle version: nil version")
+	}
+	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(v.Version) == "" {
+		return fmt.Errorf("bundle version: bundle id and version required")
+	}
+	if v.DeployedAt.IsZero() {
+		v.DeployedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal bundle version: %w", err)
+	}
+	ok, err := s.client.SetNX(ctx, bundleVersionKey(bundleID, v.Version), payload, 0).Result()
+	if err != nil {
+		return fmt.Errorf("create bundle version: %w", err)
+	}
+	if !ok {
+		return ErrBundleVersionExists
+	}
+	score := float64(v.DeployedAt.UnixNano())
+	if err := s.client.ZAdd(ctx, bundleVersionsIndexKey(bundleID), redis.Z{Score: score, Member: v.Version}).Err(); err != nil {
+		return fmt.Errorf("index bundle version: %w", err)
+	}
+	return nil
+}
+
+// ListBundleVersions returns all versions for a bundle, oldest first
+// (ascending DeployedAt).
+func (s *BundleRedisStore) ListBundleVersions(ctx context.Context, bundleID string) ([]*BundleVersion, error) {
+	if strings.TrimSpace(bundleID) == "" {
+		return nil, fmt.Errorf("bundle version: bundle id required")
+	}
+	versions, err := s.client.ZRange(ctx, bundleVersionsIndexKey(bundleID), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list versions: %w", err)
+	}
+	if len(versions) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, len(versions))
+	for i, v := range versions {
+		keys[i] = bundleVersionKey(bundleID, v)
+	}
+	raw, err := s.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("mget versions: %w", err)
+	}
+	out := make([]*BundleVersion, 0, len(raw))
+	for i, item := range raw {
+		if item == nil {
+			continue
+		}
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected version payload type for %s", versions[i])
+		}
+		var v BundleVersion
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			return nil, fmt.Errorf("unmarshal version %s: %w", versions[i], err)
+		}
+		vv := v
+		out = append(out, &vv)
+	}
+	return out, nil
+}
+
+// GetBundleVersion returns one version. Returns
+// ErrBundleVersionNotFound for unknown (bundleID, version) pairs.
+func (s *BundleRedisStore) GetBundleVersion(ctx context.Context, bundleID, version string) (*BundleVersion, error) {
+	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(version) == "" {
+		return nil, fmt.Errorf("bundle version: bundle id and version required")
+	}
+	data, err := s.client.Get(ctx, bundleVersionKey(bundleID, version)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrBundleVersionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get bundle version: %w", err)
+	}
+	var v BundleVersion
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, fmt.Errorf("unmarshal bundle version: %w", err)
+	}
+	return &v, nil
+}
+
+// ---------------------------------------------------------------------------
+// Deployment lifecycle (atomic via Lua scripts)
+// ---------------------------------------------------------------------------
+
+// deployScript atomically:
+//  1. Validates the requested (bundle_id, version) version blob exists.
+//  2. SETs `policy:scope:{kind}:{value}:active` to "{bundleID}:{version}".
+//  3. LPUSH a new Deployment{Action:deploy} JSON into the history list.
+//  4. LTRIM the history to the last 100 entries.
+//
+// KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey [3]=bundleVersionKey
+// ARGV: [1]=bundleID [2]=version [3]=deploymentJSON
+//
+// Returns: empty string on success; "ERR_VERSION_NOT_FOUND" if KEYS[3]
+// doesn't exist (caller maps to ErrBundleVersionNotFound).
+var deployScript = redis.NewScript(`
+local exists = redis.call('EXISTS', KEYS[3])
+if exists == 0 then
+  return 'ERR_VERSION_NOT_FOUND'
+end
+redis.call('SET', KEYS[1], ARGV[1] .. ':' .. ARGV[2])
+redis.call('LPUSH', KEYS[2], ARGV[3])
+redis.call('LTRIM', KEYS[2], 0, 99)
+return ''
+`)
+
+// rollbackScript atomically:
+//  1. Reads the current active (bundle_id, version) from KEYS[1].
+//  2. Walks history newest-first to find the most-recent deploy whose
+//     (bundle_id, version) differs from the current active. This skips
+//     any rollback markers AND skips the deploy entry that established
+//     the current active, so chained rollbacks unwind one step per call.
+//  3. SETs active to that prior deploy's (bundle_id, version).
+//  4. LPUSH a Deployment{Action:rollback} entry pointing at that prior pair.
+//  5. LTRIM history to last 100.
+//
+// KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey
+// ARGV: [1]=deployedAtRFC3339Nano [2]=deployedBy [3]=auditHash
+//
+// Returns: a 3-element array [bundleID, version, deploymentJSON] on
+// success, or "ERR_NO_ROLLBACK_TARGET" when no prior deploy with a
+// different (bundle_id, version) exists.
+var rollbackScript = redis.NewScript(`
+local active = redis.call('GET', KEYS[1])
+if not active or active == false or active == '' then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+local sep = string.find(active, ':')
+if not sep then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+local cur_bid = string.sub(active, 1, sep - 1)
+local cur_ver = string.sub(active, sep + 1)
+
+local hist = redis.call('LRANGE', KEYS[2], 0, -1)
+
+-- Locate the most-recent deploy entry matching the current active.
+-- This is the original deploy that introduced the current binding;
+-- we walk backwards from there to find the immediately-prior deploy.
+local cur_deploy_idx = -1
+for i, raw in ipairs(hist) do
+  local ok, dec = pcall(cjson.decode, raw)
+  if ok and type(dec) == 'table' and dec.action == 'deploy' then
+    if dec.bundle_id == cur_bid and dec.version == cur_ver then
+      cur_deploy_idx = i
+      break
+    end
+  end
+end
+if cur_deploy_idx == -1 then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+
+-- Find the next deploy entry strictly older than the current binding.
+local prior_idx = -1
+for i = cur_deploy_idx + 1, #hist do
+  local ok, dec = pcall(cjson.decode, hist[i])
+  if ok and type(dec) == 'table' and dec.action == 'deploy' then
+    prior_idx = i
+    break
+  end
+end
+if prior_idx == -1 then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+local prior = cjson.decode(hist[prior_idx])
+local bundle_id = prior.bundle_id
+local version = prior.version
+redis.call('SET', KEYS[1], bundle_id .. ':' .. version)
+local rollback_json = cjson.encode({
+  bundle_id = bundle_id,
+  version = version,
+  scope = prior.scope,
+  deployed_at = ARGV[1],
+  deployed_by = ARGV[2],
+  audit_hash = ARGV[3],
+  action = 'rollback'
+})
+redis.call('LPUSH', KEYS[2], rollback_json)
+redis.call('LTRIM', KEYS[2], 0, 99)
+return {bundle_id, version, rollback_json}
+`)
+
+// DeployVersionToScope atomically rebinds the active deployment for
+// scope to (bundleID, version) and appends the deploy event to history.
+func (s *BundleRedisStore) DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error) {
+	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(version) == "" {
+		return nil, fmt.Errorf("deploy: bundle id and version required")
+	}
+	dep := Deployment{
+		BundleID:   bundleID,
+		Version:    version,
+		Scope:      scope,
+		DeployedAt: time.Now().UTC(),
+		Action:     DeploymentActionDeploy,
+	}
+	depJSON, err := json.Marshal(&dep)
+	if err != nil {
+		return nil, fmt.Errorf("marshal deployment: %w", err)
+	}
+	keys := []string{
+		scopeActiveKey(scope),
+		scopeDeploymentHistoryKey(scope),
+		bundleVersionKey(bundleID, version),
+	}
+	res, err := deployScript.Run(ctx, s.client, keys, bundleID, version, string(depJSON)).Text()
+	if err != nil {
+		return nil, fmt.Errorf("deploy: %w", err)
+	}
+	if res == "ERR_VERSION_NOT_FOUND" {
+		return nil, ErrBundleVersionNotFound
+	}
+	return &dep, nil
+}
+
+// RollbackDeployment reverts the active deployment for scope to the
+// most-recent prior deploy (skipping rollback entries themselves so
+// chained rollbacks unwind cleanly). Returns ErrNoRollbackTarget when
+// no prior deploy exists.
+func (s *BundleRedisStore) RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error) {
+	keys := []string{
+		scopeActiveKey(scope),
+		scopeDeploymentHistoryKey(scope),
+	}
+	now := time.Now().UTC()
+	res, err := rollbackScript.Run(ctx, s.client, keys, now.Format(time.RFC3339Nano), "", "").Result()
+	if err != nil {
+		return nil, fmt.Errorf("rollback: %w", err)
+	}
+	if errStr, ok := res.(string); ok && errStr == "ERR_NO_ROLLBACK_TARGET" {
+		return nil, ErrNoRollbackTarget
+	}
+	arr, ok := res.([]interface{})
+	if !ok || len(arr) != 3 {
+		return nil, fmt.Errorf("rollback: unexpected script result %T", res)
+	}
+	rollbackJSON, _ := arr[2].(string)
+	var dep Deployment
+	if err := json.Unmarshal([]byte(rollbackJSON), &dep); err != nil {
+		return nil, fmt.Errorf("unmarshal rollback deployment: %w", err)
+	}
+	dep.DeployedAt = now
+	return &dep, nil
+}
+
+// GetActiveDeployment returns the currently-active deployment for
+// scope. The implementation reads the active pointer + the most-recent
+// matching history entry to surface the full Deployment record (incl.
+// timestamp + action). Returns ErrNoDeploymentForScope when nothing is
+// bound.
+func (s *BundleRedisStore) GetActiveDeployment(ctx context.Context, scope RuleScope) (*Deployment, error) {
+	pointer, err := s.client.Get(ctx, scopeActiveKey(scope)).Result()
+	if errors.Is(err, redis.Nil) || pointer == "" {
+		return nil, ErrNoDeploymentForScope
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get active deployment: %w", err)
+	}
+	parts := strings.SplitN(pointer, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("malformed active pointer %q", pointer)
+	}
+	bundleID, version := parts[0], parts[1]
+	// Walk history newest-first to find the deploy/rollback that produced this binding.
+	entries, err := s.client.LRange(ctx, scopeDeploymentHistoryKey(scope), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("get history: %w", err)
+	}
+	for _, raw := range entries {
+		var dep Deployment
+		if err := json.Unmarshal([]byte(raw), &dep); err != nil {
+			continue
+		}
+		if dep.BundleID == bundleID && dep.Version == version {
+			return &dep, nil
+		}
+	}
+	// Pointer set but no matching history — synthesize a minimal record.
+	return &Deployment{
+		BundleID: bundleID,
+		Version:  version,
+		Scope:    scope,
+		Action:   DeploymentActionDeploy,
+	}, nil
+}
+
+// ListDeploymentHistory returns up to limit history entries for scope,
+// newest first. The implementation always reads up to
+// deploymentHistoryCap (100) entries since LTRIM bounds it; the caller's
+// limit is applied client-side.
+func (s *BundleRedisStore) ListDeploymentHistory(ctx context.Context, scope RuleScope, limit int) ([]*Deployment, error) {
+	if limit <= 0 || limit > deploymentHistoryCap {
+		limit = deploymentHistoryCap
+	}
+	entries, err := s.client.LRange(ctx, scopeDeploymentHistoryKey(scope), 0, int64(limit-1)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list deployment history: %w", err)
+	}
+	out := make([]*Deployment, 0, len(entries))
+	for _, raw := range entries {
+		var dep Deployment
+		if err := json.Unmarshal([]byte(raw), &dep); err != nil {
+			return nil, fmt.Errorf("unmarshal deployment: %w", err)
+		}
+		dd := dep
+		out = append(out, &dd)
+	}
+	return out, nil
+}
+
+// Compile-time interface satisfaction check.
+var _ BundleStore = (*BundleRedisStore)(nil)

--- a/core/policy/bundle_store_redis.go
+++ b/core/policy/bundle_store_redis.go
@@ -161,14 +161,24 @@ func scopeBindingMatches(have, want RuleScope) bool {
 // ---------------------------------------------------------------------------
 
 // CreateBundleVersion appends a new immutable version to bundleID.
-// SETNX on the version blob + ZADD on the index. Idempotent on
-// duplicate version numbers — returns ErrBundleVersionExists.
+// Verifies the parent bundle exists (returns ErrBundleNotFound if not)
+// to prevent orphan versions, then SETNX on the version blob + ZADD on
+// the index. Idempotent on duplicate version numbers — returns
+// ErrBundleVersionExists. There is no DeleteBundle on the interface, so
+// the EXISTS-then-SETNX sequence cannot race with a parent removal.
 func (s *BundleRedisStore) CreateBundleVersion(ctx context.Context, bundleID string, v *BundleVersion) error {
 	if v == nil {
 		return fmt.Errorf("bundle version: nil version")
 	}
 	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(v.Version) == "" {
 		return fmt.Errorf("bundle version: bundle id and version required")
+	}
+	exists, err := s.client.Exists(ctx, bundleKey(bundleID)).Result()
+	if err != nil {
+		return fmt.Errorf("check parent bundle: %w", err)
+	}
+	if exists == 0 {
+		return ErrBundleNotFound
 	}
 	if v.DeployedAt.IsZero() {
 		v.DeployedAt = time.Now().UTC()
@@ -257,42 +267,67 @@ func (s *BundleRedisStore) GetBundleVersion(ctx context.Context, bundleID, versi
 
 // deployScript atomically:
 //  1. Validates the requested (bundle_id, version) version blob exists.
-//  2. SETs `policy:scope:{kind}:{value}:active` to "{bundleID}:{version}".
-//  3. LPUSH a new Deployment{Action:deploy} JSON into the history list.
-//  4. LTRIM the history to the last 100 entries.
+//  2. Reads the current active "{bundleID}:{version}" pointer (may be empty).
+//  3. Decodes the incoming deploy JSON, baking the prior active pair
+//     into prev_bundle_id + prev_version so future rollbacks can restore
+//     this exact prior state.
+//  4. SETs `policy:scope:{kind}:{value}:active` to the new "{bundleID}:{version}".
+//  5. LPUSHes the populated deploy JSON into the history list.
+//  6. LTRIMs the history to the last deploymentHistoryCap entries.
 //
 // KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey [3]=bundleVersionKey
-// ARGV: [1]=bundleID [2]=version [3]=deploymentJSON
+// ARGV: [1]=bundleID [2]=version [3]=deploymentJSON [4]=historyCap
 //
-// Returns: empty string on success; "ERR_VERSION_NOT_FOUND" if KEYS[3]
-// doesn't exist (caller maps to ErrBundleVersionNotFound).
+// Returns: the populated deployment JSON (with prev_bundle_id +
+// prev_version filled in) on success, or the literal sentinel string
+// "ERR_VERSION_NOT_FOUND" if KEYS[3] doesn't exist (caller maps to
+// ErrBundleVersionNotFound). The two cases are distinguishable by
+// prefix — JSON starts with '{', the sentinel starts with 'E'.
 var deployScript = redis.NewScript(`
 local exists = redis.call('EXISTS', KEYS[3])
 if exists == 0 then
   return 'ERR_VERSION_NOT_FOUND'
 end
+local prev = redis.call('GET', KEYS[1])
+local prev_bid = ''
+local prev_ver = ''
+if prev and prev ~= false and prev ~= '' then
+  local sep = string.find(prev, ':')
+  if sep then
+    prev_bid = string.sub(prev, 1, sep - 1)
+    prev_ver = string.sub(prev, sep + 1)
+  end
+end
+local dep = cjson.decode(ARGV[3])
+dep.prev_bundle_id = prev_bid
+dep.prev_version = prev_ver
+local dep_json = cjson.encode(dep)
 redis.call('SET', KEYS[1], ARGV[1] .. ':' .. ARGV[2])
-redis.call('LPUSH', KEYS[2], ARGV[3])
-redis.call('LTRIM', KEYS[2], 0, 99)
-return ''
+redis.call('LPUSH', KEYS[2], dep_json)
+redis.call('LTRIM', KEYS[2], 0, tonumber(ARGV[4]) - 1)
+return dep_json
 `)
 
 // rollbackScript atomically:
-//  1. Reads the current active (bundle_id, version) from KEYS[1].
-//  2. Walks history newest-first to find the most-recent deploy whose
-//     (bundle_id, version) differs from the current active. This skips
-//     any rollback markers AND skips the deploy entry that established
-//     the current active, so chained rollbacks unwind one step per call.
-//  3. SETs active to that prior deploy's (bundle_id, version).
-//  4. LPUSH a Deployment{Action:rollback} entry pointing at that prior pair.
-//  5. LTRIM history to last 100.
+//  1. Reads the current active "{bundle_id}:{version}" pointer.
+//  2. Walks history newest-first to find the most-recent deploy event
+//     matching the current active pair (skipping rollback markers).
+//  3. Reads that deploy event's prev_bundle_id + prev_version — the
+//     pair that was active immediately before this deploy ran.
+//  4. SETs active to that prior pair.
+//  5. LPUSHes a Deployment{Action:rollback} entry pointing at the
+//     restored pair, with prev_* fields capturing the pair we rolled
+//     away from (informational; rollback never reads its own prev_*).
+//  6. LTRIMs history to deploymentHistoryCap.
 //
 // KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey
-// ARGV: [1]=deployedAtRFC3339Nano [2]=deployedBy [3]=auditHash
+// ARGV: [1]=deployedAtRFC3339Nano [2]=deployedBy [3]=auditHash [4]=scopeJSON [5]=historyCap
 //
 // Returns: a 3-element array [bundleID, version, deploymentJSON] on
-// success, or "ERR_NO_ROLLBACK_TARGET" when no prior deploy with a
-// different (bundle_id, version) exists.
+// success, or the literal sentinel string "ERR_NO_ROLLBACK_TARGET"
+// when there's no current active OR no matching deploy event OR the
+// matching deploy event has empty prev_* fields (i.e. the original
+// first deploy with no prior state).
 var rollbackScript = redis.NewScript(`
 local active = redis.call('GET', KEYS[1])
 if not active or active == false or active == '' then
@@ -307,55 +342,54 @@ local cur_ver = string.sub(active, sep + 1)
 
 local hist = redis.call('LRANGE', KEYS[2], 0, -1)
 
--- Locate the most-recent deploy entry matching the current active.
--- This is the original deploy that introduced the current binding;
--- we walk backwards from there to find the immediately-prior deploy.
-local cur_deploy_idx = -1
+-- Find the most-recent deploy event matching the current active pair.
+-- That entry's prev_bundle_id + prev_version are the pair to restore.
+local prev_bid = ''
+local prev_ver = ''
+local found = false
 for i, raw in ipairs(hist) do
   local ok, dec = pcall(cjson.decode, raw)
   if ok and type(dec) == 'table' and dec.action == 'deploy' then
     if dec.bundle_id == cur_bid and dec.version == cur_ver then
-      cur_deploy_idx = i
+      prev_bid = dec.prev_bundle_id or ''
+      prev_ver = dec.prev_version or ''
+      found = true
       break
     end
   end
 end
-if cur_deploy_idx == -1 then
+if not found then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+if prev_bid == '' or prev_ver == '' then
+  -- Rolling back the original first deploy: no prior state to restore.
   return 'ERR_NO_ROLLBACK_TARGET'
 end
 
--- Find the next deploy entry strictly older than the current binding.
-local prior_idx = -1
-for i = cur_deploy_idx + 1, #hist do
-  local ok, dec = pcall(cjson.decode, hist[i])
-  if ok and type(dec) == 'table' and dec.action == 'deploy' then
-    prior_idx = i
-    break
-  end
-end
-if prior_idx == -1 then
-  return 'ERR_NO_ROLLBACK_TARGET'
-end
-local prior = cjson.decode(hist[prior_idx])
-local bundle_id = prior.bundle_id
-local version = prior.version
-redis.call('SET', KEYS[1], bundle_id .. ':' .. version)
-local rollback_json = cjson.encode({
-  bundle_id = bundle_id,
-  version = version,
-  scope = prior.scope,
+local scope = cjson.decode(ARGV[4])
+redis.call('SET', KEYS[1], prev_bid .. ':' .. prev_ver)
+local marker = {
+  bundle_id = prev_bid,
+  version = prev_ver,
+  scope = scope,
   deployed_at = ARGV[1],
   deployed_by = ARGV[2],
   audit_hash = ARGV[3],
-  action = 'rollback'
-})
-redis.call('LPUSH', KEYS[2], rollback_json)
-redis.call('LTRIM', KEYS[2], 0, 99)
-return {bundle_id, version, rollback_json}
+  action = 'rollback',
+  prev_bundle_id = cur_bid,
+  prev_version = cur_ver,
+}
+local marker_json = cjson.encode(marker)
+redis.call('LPUSH', KEYS[2], marker_json)
+redis.call('LTRIM', KEYS[2], 0, tonumber(ARGV[5]) - 1)
+return {prev_bid, prev_ver, marker_json}
 `)
 
 // DeployVersionToScope atomically rebinds the active deployment for
 // scope to (bundleID, version) and appends the deploy event to history.
+// The returned Deployment carries PrevBundleID + PrevVersion populated
+// from the active state at script-execution time (read inside Lua so
+// concurrent deploys on the same scope serialize correctly).
 func (s *BundleRedisStore) DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error) {
 	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(version) == "" {
 		return nil, fmt.Errorf("deploy: bundle id and version required")
@@ -376,34 +410,46 @@ func (s *BundleRedisStore) DeployVersionToScope(ctx context.Context, bundleID, v
 		scopeDeploymentHistoryKey(scope),
 		bundleVersionKey(bundleID, version),
 	}
-	res, err := deployScript.Run(ctx, s.client, keys, bundleID, version, string(depJSON)).Text()
+	res, err := deployScript.Run(ctx, s.client, keys, bundleID, version, string(depJSON), deploymentHistoryCap).Text()
 	if err != nil {
 		return nil, fmt.Errorf("deploy: %w", err)
 	}
 	if res == "ERR_VERSION_NOT_FOUND" {
 		return nil, ErrBundleVersionNotFound
 	}
-	return &dep, nil
+	var populated Deployment
+	if err := json.Unmarshal([]byte(res), &populated); err != nil {
+		return nil, fmt.Errorf("unmarshal deploy result: %w", err)
+	}
+	return &populated, nil
 }
 
 // RollbackDeployment reverts the active deployment for scope to the
-// most-recent prior deploy (skipping rollback entries themselves so
-// chained rollbacks unwind cleanly). Returns ErrNoRollbackTarget when
-// no prior deploy exists.
+// (bundle, version) pair that was active immediately before the current
+// binding was established. Per the rollbackScript contract, this reads
+// the matching deploy event's prev_* fields so rollback after a
+// deploy-after-rollback restores the correct prior state. Returns
+// ErrNoRollbackTarget when no current active exists, no matching deploy
+// event is found in bounded history, or the matching deploy has empty
+// prev_* fields (the first-ever deploy).
 func (s *BundleRedisStore) RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error) {
 	keys := []string{
 		scopeActiveKey(scope),
 		scopeDeploymentHistoryKey(scope),
 	}
 	now := time.Now().UTC()
-	res, err := rollbackScript.Run(ctx, s.client, keys, now.Format(time.RFC3339Nano), "", "").Result()
+	scopeJSON, err := json.Marshal(scope)
+	if err != nil {
+		return nil, fmt.Errorf("marshal rollback scope: %w", err)
+	}
+	res, err := rollbackScript.Run(ctx, s.client, keys, now.Format(time.RFC3339Nano), "", "", string(scopeJSON), deploymentHistoryCap).Result()
 	if err != nil {
 		return nil, fmt.Errorf("rollback: %w", err)
 	}
 	if errStr, ok := res.(string); ok && errStr == "ERR_NO_ROLLBACK_TARGET" {
 		return nil, ErrNoRollbackTarget
 	}
-	arr, ok := res.([]interface{})
+	arr, ok := res.([]any)
 	if !ok || len(arr) != 3 {
 		return nil, fmt.Errorf("rollback: unexpected script result %T", res)
 	}

--- a/core/policy/bundle_store_redis_test.go
+++ b/core/policy/bundle_store_redis_test.go
@@ -430,6 +430,152 @@ func TestRollbackChain(t *testing.T) {
 	}
 }
 
+// TestDeployAfterRollback locks in the regression that originally
+// shipped to QA in PR #252 reopen #1 (task-b349524a). Sequence:
+//
+//	deploy v1, deploy v2, rollback (-> v1), deploy v3, rollback
+//
+// The final rollback must restore v1 — the active state immediately
+// before v3 was deployed — NOT v2 (the second-most-recent deploy in
+// raw event order). The original implementation walked history for
+// "next deploy after the matching deploy" and returned v2; the fix
+// stores prev_bundle_id + prev_version on each deploy event inside
+// Lua so rollback restores from the matching deploy's prev fields.
+func TestDeployAfterRollback(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v3", DeployedAt: time.Now().UTC().Add(2 * time.Second)})
+
+	// Step 1+2: deploy v1, deploy v2.
+	d1, err := store.DeployVersionToScope(ctx, "b1", "v1", scope)
+	if err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if d1.PrevBundleID != "" || d1.PrevVersion != "" {
+		t.Errorf("first deploy should record empty prev pair, got %s:%s", d1.PrevBundleID, d1.PrevVersion)
+	}
+	d2, err := store.DeployVersionToScope(ctx, "b1", "v2", scope)
+	if err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+	if d2.PrevBundleID != "b1" || d2.PrevVersion != "v1" {
+		t.Errorf("v2 deploy should record prev=b1:v1, got %s:%s", d2.PrevBundleID, d2.PrevVersion)
+	}
+
+	// Step 3: rollback v2 → v1.
+	rb1, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback after v2: %v", err)
+	}
+	if rb1.Version != "v1" {
+		t.Fatalf("rollback after v2 should restore v1, got %q", rb1.Version)
+	}
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("active after rb1: %v", err)
+	}
+	if active.Version != "v1" {
+		t.Fatalf("active after rb1 = %q, want v1", active.Version)
+	}
+
+	// Step 4: deploy v3 (active state immediately before this deploy is v1).
+	d3, err := store.DeployVersionToScope(ctx, "b1", "v3", scope)
+	if err != nil {
+		t.Fatalf("deploy v3: %v", err)
+	}
+	if d3.PrevBundleID != "b1" || d3.PrevVersion != "v1" {
+		t.Errorf("v3 deploy should record prev=b1:v1 (post-rollback active), got %s:%s", d3.PrevBundleID, d3.PrevVersion)
+	}
+
+	// Step 5: final rollback must restore v1, NOT v2 (the prior deploy
+	// in raw history order).
+	rb2, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback after v3: %v", err)
+	}
+	if rb2.Version != "v1" {
+		t.Fatalf("rollback after deploy-after-rollback should restore v1, got %q (regression: returns the second-most-recent raw deploy v2 instead of the active state before v3)", rb2.Version)
+	}
+	active, err = store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("active after rb2: %v", err)
+	}
+	if active.Version != "v1" {
+		t.Fatalf("active after rb2 = %q, want v1", active.Version)
+	}
+}
+
+// TestCreateBundleVersion_OrphanRejected verifies CreateBundleVersion
+// refuses to write a version for a non-existent parent bundle. Without
+// this check the store could accumulate orphan version blobs +
+// deployment records that point at a bundle envelope nothing owns.
+func TestCreateBundleVersion_OrphanRejected(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	// No CreateBundle call — parent is absent.
+	err := store.CreateBundleVersion(ctx, "ghost", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	if !errors.Is(err, ErrBundleNotFound) {
+		t.Fatalf("orphan version creation should return ErrBundleNotFound, got %v", err)
+	}
+
+	// And the version blob must NOT have been written. Reading it back
+	// is the cleanest proof; ListBundleVersions on the same bundle ID
+	// must return an empty slice (the index ZSET also stays empty).
+	got, err := store.ListBundleVersions(ctx, "ghost")
+	if err != nil {
+		t.Fatalf("list versions for orphan parent: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("orphan parent should have no versions, got %d", len(got))
+	}
+}
+
+// TestDeploymentHistoryCapEnforced verifies the LTRIM-based history
+// cap inside the deploy Lua script. After 105 deploys to the same
+// scope, history must hold exactly 100 entries (the cap from
+// deploymentHistoryCap) and the 5 oldest deploy events must have been
+// dropped.
+func TestDeploymentHistoryCapEnforced(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+
+	const total = 105
+	for i := range total {
+		if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+			t.Fatalf("deploy %d: %v", i, err)
+		}
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, deploymentHistoryCap+50)
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(hist) != deploymentHistoryCap {
+		t.Fatalf("history len = %d, want %d (LTRIM cap)", len(hist), deploymentHistoryCap)
+	}
+	// Newest 100 entries are kept; the 5 oldest dropped. Every entry
+	// is a deploy of v1, so we can't distinguish "oldest" by version,
+	// but len(hist) == cap is the binding assertion that LTRIM ran.
+	for i, dep := range hist {
+		if dep.Action != DeploymentActionDeploy {
+			t.Errorf("history[%d].Action = %s, want deploy", i, dep.Action)
+		}
+		if dep.Version != "v1" {
+			t.Errorf("history[%d].Version = %s, want v1", i, dep.Version)
+		}
+	}
+}
+
 func TestConcurrentDeploy(t *testing.T) {
 	store := newTestBundleStore(t)
 	ctx := context.Background()

--- a/core/policy/bundle_store_redis_test.go
+++ b/core/policy/bundle_store_redis_test.go
@@ -1,0 +1,473 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+)
+
+func newTestBundleStore(t *testing.T) *BundleRedisStore {
+	t.Helper()
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisBundleStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close(); srv.Close() })
+	return store
+}
+
+func mustCreateBundle(t *testing.T, s *BundleRedisStore, b *Bundle) {
+	t.Helper()
+	if err := s.CreateBundle(context.Background(), b); err != nil {
+		t.Fatalf("create bundle: %v", err)
+	}
+}
+
+func mustCreateVersion(t *testing.T, s *BundleRedisStore, bundleID string, v *BundleVersion) {
+	t.Helper()
+	if err := s.CreateBundleVersion(context.Background(), bundleID, v); err != nil {
+		t.Fatalf("create version: %v", err)
+	}
+}
+
+func TestCreateGetBundle(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	b := &Bundle{ID: "b1", Name: "Acme baseline", ScopeBinding: scope}
+	mustCreateBundle(t, store, b)
+
+	got, err := store.GetBundle(ctx, "b1")
+	if err != nil {
+		t.Fatalf("get bundle: %v", err)
+	}
+	if got.ID != "b1" || got.Name != "Acme baseline" {
+		t.Errorf("got bundle = %+v, want id=b1 name='Acme baseline'", got)
+	}
+	if got.ScopeBinding.Kind != RuleScopeTenant || got.ScopeBinding.Value != "acme" {
+		t.Errorf("scope binding mismatch: %+v", got.ScopeBinding)
+	}
+
+	// Duplicate create returns ErrBundleExists.
+	err = store.CreateBundle(ctx, b)
+	if !errors.Is(err, ErrBundleExists) {
+		t.Errorf("duplicate create should return ErrBundleExists, got %v", err)
+	}
+}
+
+func TestGetBundle_NotFound(t *testing.T) {
+	store := newTestBundleStore(t)
+	_, err := store.GetBundle(context.Background(), "missing")
+	if !errors.Is(err, ErrBundleNotFound) {
+		t.Errorf("expected ErrBundleNotFound, got %v", err)
+	}
+}
+
+func TestListBundlesByScope(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	scopeA := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	scopeB := RuleScope{Kind: RuleScopeTenant, Value: "beta"}
+	scopeGlobal := RuleScope{Kind: RuleScopeGlobal}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b-a1", Name: "Acme one", ScopeBinding: scopeA})
+	mustCreateBundle(t, store, &Bundle{ID: "b-a2", Name: "Acme two", ScopeBinding: scopeA})
+	mustCreateBundle(t, store, &Bundle{ID: "b-b1", Name: "Beta one", ScopeBinding: scopeB})
+	mustCreateBundle(t, store, &Bundle{ID: "b-g", Name: "Global", ScopeBinding: scopeGlobal})
+
+	got, err := store.ListBundlesByScope(ctx, scopeA)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 bundles for acme, got %d", len(got))
+	}
+
+	got, err = store.ListBundlesByScope(ctx, scopeGlobal)
+	if err != nil {
+		t.Fatalf("list global: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 global bundle, got %d", len(got))
+	}
+}
+
+func TestCreateBundleVersion_Idempotent(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	v := &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()}
+	mustCreateVersion(t, store, "b1", v)
+
+	err := store.CreateBundleVersion(ctx, "b1", v)
+	if !errors.Is(err, ErrBundleVersionExists) {
+		t.Errorf("duplicate version should return ErrBundleVersionExists, got %v", err)
+	}
+}
+
+func TestListBundleVersions_OrderByDeployedAt(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	t0 := time.Now().UTC()
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v3", DeployedAt: t0.Add(3 * time.Second)})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: t0})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: t0.Add(time.Second)})
+
+	got, err := store.ListBundleVersions(ctx, "b1")
+	if err != nil {
+		t.Fatalf("list versions: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 versions, got %d", len(got))
+	}
+	want := []string{"v1", "v2", "v3"}
+	for i, v := range got {
+		if v.Version != want[i] {
+			t.Errorf("position %d: got %q, want %q", i, v.Version, want[i])
+		}
+	}
+}
+
+func TestGetBundleVersion_NotFound(t *testing.T) {
+	store := newTestBundleStore(t)
+	_, err := store.GetBundleVersion(context.Background(), "b1", "v1")
+	if !errors.Is(err, ErrBundleVersionNotFound) {
+		t.Errorf("expected ErrBundleVersionNotFound, got %v", err)
+	}
+}
+
+func TestDeployVersionToScope_FirstDeploy(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+
+	dep, err := store.DeployVersionToScope(ctx, "b1", "v1", scope)
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	if dep.BundleID != "b1" || dep.Version != "v1" || dep.Action != DeploymentActionDeploy {
+		t.Errorf("got deployment = %+v", dep)
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if active.BundleID != "b1" || active.Version != "v1" {
+		t.Errorf("active = %+v, want b1:v1", active)
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 1 {
+		t.Errorf("expected 1 history entry, got %d", len(hist))
+	}
+}
+
+func TestDeployVersionToScope_OverwritesActive(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scope); err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if active.Version != "v2" {
+		t.Errorf("active version = %q, want v2", active.Version)
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 2 {
+		t.Fatalf("expected 2 history entries, got %d", len(hist))
+	}
+	// Newest first.
+	if hist[0].Version != "v2" || hist[1].Version != "v1" {
+		t.Errorf("history order wrong: %+v", hist)
+	}
+}
+
+func TestDeployVersionToScope_VersionNotFound(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	_, err := store.DeployVersionToScope(ctx, "b1", "ghost", scope)
+	if !errors.Is(err, ErrBundleVersionNotFound) {
+		t.Errorf("expected ErrBundleVersionNotFound, got %v", err)
+	}
+}
+
+func TestRollbackDeployment(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scope); err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+
+	rb, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if rb.Version != "v1" || rb.Action != DeploymentActionRollback {
+		t.Errorf("rollback record = %+v, want v1 action=rollback", rb)
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active after rollback: %v", err)
+	}
+	if active.Version != "v1" {
+		t.Errorf("active after rollback = %q, want v1", active.Version)
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 3 {
+		t.Errorf("expected 3 history entries (deploy v1, deploy v2, rollback to v1), got %d", len(hist))
+	}
+	if hist[0].Action != DeploymentActionRollback {
+		t.Errorf("newest entry should be rollback, got %s", hist[0].Action)
+	}
+}
+
+func TestRollbackDeployment_NoHistory(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+
+	_, err := store.RollbackDeployment(ctx, scope)
+	if !errors.Is(err, ErrNoRollbackTarget) {
+		t.Errorf("expected ErrNoRollbackTarget, got %v", err)
+	}
+}
+
+func TestGetActiveDeployment_NoDeployment(t *testing.T) {
+	store := newTestBundleStore(t)
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "ghost"}
+	_, err := store.GetActiveDeployment(context.Background(), scope)
+	if !errors.Is(err, ErrNoDeploymentForScope) {
+		t.Errorf("expected ErrNoDeploymentForScope, got %v", err)
+	}
+}
+
+func TestScopeIsolation(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scopeA := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	scopeB := RuleScope{Kind: RuleScopeTenant, Value: "beta"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	// Same bundle deployed to two scopes; rollback on A should not touch B.
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scopeA); err != nil {
+		t.Fatalf("A v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scopeA); err != nil {
+		t.Fatalf("A v2: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scopeB); err != nil {
+		t.Fatalf("B v2: %v", err)
+	}
+
+	if _, err := store.RollbackDeployment(ctx, scopeA); err != nil {
+		t.Fatalf("rollback A: %v", err)
+	}
+
+	activeA, _ := store.GetActiveDeployment(ctx, scopeA)
+	activeB, _ := store.GetActiveDeployment(ctx, scopeB)
+	if activeA.Version != "v1" {
+		t.Errorf("scope A after rollback = %q, want v1", activeA.Version)
+	}
+	if activeB.Version != "v2" {
+		t.Errorf("scope B should be untouched at v2, got %q", activeB.Version)
+	}
+}
+
+func TestEmptyIDInputs(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	if err := store.CreateBundle(ctx, nil); err == nil {
+		t.Errorf("CreateBundle(nil) should error")
+	}
+	if err := store.CreateBundle(ctx, &Bundle{ID: ""}); err == nil {
+		t.Errorf("CreateBundle empty id should error")
+	}
+	if _, err := store.GetBundle(ctx, ""); err == nil {
+		t.Errorf("GetBundle empty id should error")
+	}
+	if err := store.CreateBundleVersion(ctx, "", &BundleVersion{Version: "v1"}); err == nil {
+		t.Errorf("CreateBundleVersion empty bundle id should error")
+	}
+	if err := store.CreateBundleVersion(ctx, "b1", nil); err == nil {
+		t.Errorf("CreateBundleVersion nil should error")
+	}
+	if _, err := store.GetBundleVersion(ctx, "", "v1"); err == nil {
+		t.Errorf("GetBundleVersion empty bundle id should error")
+	}
+	if _, err := store.ListBundleVersions(ctx, ""); err == nil {
+		t.Errorf("ListBundleVersions empty id should error")
+	}
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	if _, err := store.DeployVersionToScope(ctx, "", "v1", scope); err == nil {
+		t.Errorf("DeployVersionToScope empty bundle id should error")
+	}
+}
+
+func TestListBundleVersions_EmptyBundle(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	got, err := store.ListBundleVersions(ctx, "b1")
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected zero versions, got %d", len(got))
+	}
+}
+
+func TestListBundlesByScope_NoMatches(t *testing.T) {
+	store := newTestBundleStore(t)
+	got, err := store.ListBundlesByScope(context.Background(), RuleScope{Kind: RuleScopeTenant, Value: "ghost"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected zero bundles for ghost tenant, got %d", len(got))
+	}
+}
+
+func TestRollbackChain(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v3", DeployedAt: time.Now().UTC().Add(2 * time.Second)})
+
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scope); err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v3", scope); err != nil {
+		t.Fatalf("deploy v3: %v", err)
+	}
+
+	// Rollback: v3 → v2.
+	rb1, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback 1: %v", err)
+	}
+	if rb1.Version != "v2" {
+		t.Errorf("rollback 1 → %q, want v2", rb1.Version)
+	}
+
+	// Rollback again: should walk past the rollback marker to find v1.
+	rb2, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback 2: %v", err)
+	}
+	if rb2.Version != "v1" {
+		t.Errorf("rollback 2 → %q, want v1 (skipping the rollback marker)", rb2.Version)
+	}
+}
+
+func TestConcurrentDeploy(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	// Two goroutines deploy v1 + v2 to the same scope concurrently. Lua
+	// EVAL serializes Redis-side, so one fully completes before the other.
+	// Both deploys must land in history; the active pointer is whichever
+	// goroutine's SET ran last.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = store.DeployVersionToScope(ctx, "b1", "v1", scope)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = store.DeployVersionToScope(ctx, "b1", "v2", scope)
+	}()
+	wg.Wait()
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 2 {
+		t.Errorf("expected both deploys in history, got %d", len(hist))
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if active.Version != "v1" && active.Version != "v2" {
+		t.Errorf("active version should be v1 or v2, got %q", active.Version)
+	}
+}

--- a/core/policy/doc.go
+++ b/core/policy/doc.go
@@ -1,0 +1,6 @@
+// Package policy holds the unified Rule, Decision, and Bundle shapes that
+// subsume Cordum's previously split job-policy (input/output/velocity) and
+// edge-policy authoring surfaces. The shapes are storage- and
+// evaluator-agnostic: core/safetykernel and core/edge consume Rule and emit
+// Decision; the bundle store keys by Bundle.ID.
+package policy

--- a/core/policy/enums.go
+++ b/core/policy/enums.go
@@ -1,0 +1,303 @@
+package policy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors returned by the Parse* functions in this package. Use
+// errors.Is to distinguish between unknown-value and empty-value cases when
+// callers need branchy error handling; otherwise the wrapped string contains
+// the rejected value verbatim for log emission.
+var (
+	ErrInvalidRuleType       = errors.New("policy: invalid rule type")
+	ErrInvalidRuleStatus     = errors.New("policy: invalid rule status")
+	ErrInvalidDecisionType   = errors.New("policy: invalid decision type")
+	ErrInvalidDecisionSource = errors.New("policy: invalid decision source")
+	ErrInvalidRuleScopeKind  = errors.New("policy: invalid rule scope kind")
+	ErrInvalidEdgeMode       = errors.New("policy: invalid edge mode")
+)
+
+// RuleType discriminates a rule's match/decide payload schema. The four
+// values correspond to the existing job (input/output/velocity) and edge
+// authoring surfaces being unified by this package.
+type RuleType string
+
+const (
+	RuleTypeInput    RuleType = "input"
+	RuleTypeOutput   RuleType = "output"
+	RuleTypeVelocity RuleType = "velocity"
+	RuleTypeEdge     RuleType = "edge"
+)
+
+func (t RuleType) String() string { return string(t) }
+
+// ParseRuleType parses a wire-format rule type. It rejects the empty string
+// and any non-canonical value (including case variants and whitespace-padded
+// forms) with an error wrapping ErrInvalidRuleType.
+func ParseRuleType(s string) (RuleType, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidRuleType)
+	}
+	switch RuleType(s) {
+	case RuleTypeInput, RuleTypeOutput, RuleTypeVelocity, RuleTypeEdge:
+		return RuleType(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidRuleType, s)
+	}
+}
+
+func (t RuleType) MarshalJSON() ([]byte, error) {
+	if _, err := ParseRuleType(string(t)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(t))
+}
+
+func (t *RuleType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseRuleType(s)
+	if err != nil {
+		return err
+	}
+	*t = parsed
+	return nil
+}
+
+// RuleStatus tracks a rule's lifecycle state. Authors edit `draft` rules,
+// `published` rules participate in evaluation, and `deprecated` rules remain
+// queryable for audit and rollback but are skipped by evaluators.
+type RuleStatus string
+
+const (
+	RuleStatusDraft      RuleStatus = "draft"
+	RuleStatusPublished  RuleStatus = "published"
+	RuleStatusDeprecated RuleStatus = "deprecated"
+)
+
+func (s RuleStatus) String() string { return string(s) }
+
+func ParseRuleStatus(s string) (RuleStatus, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidRuleStatus)
+	}
+	switch RuleStatus(s) {
+	case RuleStatusDraft, RuleStatusPublished, RuleStatusDeprecated:
+		return RuleStatus(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidRuleStatus, s)
+	}
+}
+
+func (s RuleStatus) MarshalJSON() ([]byte, error) {
+	if _, err := ParseRuleStatus(string(s)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(s))
+}
+
+func (s *RuleStatus) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	parsed, err := ParseRuleStatus(raw)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+// DecisionType is the unified decision outcome emitted by either evaluator.
+// It is the union of the existing safetykernel SafetyDecision, output-rule
+// decision, and edge EdgeDecision values, normalised to a single canonical
+// set. The seven values mirror the wire-format DecisionType enum in
+// cap/proto/cordum/agent/v1/safety.proto: ALLOW, DENY, REQUIRE_HUMAN,
+// THROTTLE, ALLOW_WITH_CONSTRAINTS, QUARANTINE, REDACT.
+type DecisionType string
+
+const (
+	DecisionAllow                DecisionType = "allow"
+	DecisionDeny                 DecisionType = "deny"
+	DecisionRequireHuman         DecisionType = "require_human"
+	DecisionThrottle             DecisionType = "throttle"
+	DecisionAllowWithConstraints DecisionType = "allow_with_constraints"
+	DecisionQuarantine           DecisionType = "quarantine"
+	DecisionRedact               DecisionType = "redact"
+)
+
+func (d DecisionType) String() string { return string(d) }
+
+func ParseDecisionType(s string) (DecisionType, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidDecisionType)
+	}
+	switch DecisionType(s) {
+	case DecisionAllow, DecisionDeny, DecisionRequireHuman, DecisionThrottle,
+		DecisionAllowWithConstraints, DecisionQuarantine, DecisionRedact:
+		return DecisionType(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidDecisionType, s)
+	}
+}
+
+func (d DecisionType) MarshalJSON() ([]byte, error) {
+	if _, err := ParseDecisionType(string(d)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(d))
+}
+
+func (d *DecisionType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseDecisionType(s)
+	if err != nil {
+		return err
+	}
+	*d = parsed
+	return nil
+}
+
+// DecisionSource identifies which evaluator produced a Decision: the
+// safetykernel job pipeline (`job`) or the edge classifier path (`edge`).
+type DecisionSource string
+
+const (
+	DecisionSourceJob  DecisionSource = "job"
+	DecisionSourceEdge DecisionSource = "edge"
+)
+
+func (s DecisionSource) String() string { return string(s) }
+
+func ParseDecisionSource(s string) (DecisionSource, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidDecisionSource)
+	}
+	switch DecisionSource(s) {
+	case DecisionSourceJob, DecisionSourceEdge:
+		return DecisionSource(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidDecisionSource, s)
+	}
+}
+
+func (s DecisionSource) MarshalJSON() ([]byte, error) {
+	if _, err := ParseDecisionSource(string(s)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(s))
+}
+
+func (s *DecisionSource) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	parsed, err := ParseDecisionSource(raw)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+// RuleScopeKind narrows where a rule applies. `global` covers an entire
+// deployment; `tenant` and `workflow` scope to job-side bindings; `edge_fleet`
+// and `edge_user` scope to edge-side bindings (whole fleet vs single user).
+type RuleScopeKind string
+
+const (
+	RuleScopeGlobal    RuleScopeKind = "global"
+	RuleScopeTenant    RuleScopeKind = "tenant"
+	RuleScopeWorkflow  RuleScopeKind = "workflow"
+	RuleScopeEdgeFleet RuleScopeKind = "edge_fleet"
+	RuleScopeEdgeUser  RuleScopeKind = "edge_user"
+)
+
+func (k RuleScopeKind) String() string { return string(k) }
+
+func ParseRuleScopeKind(s string) (RuleScopeKind, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidRuleScopeKind)
+	}
+	switch RuleScopeKind(s) {
+	case RuleScopeGlobal, RuleScopeTenant, RuleScopeWorkflow, RuleScopeEdgeFleet, RuleScopeEdgeUser:
+		return RuleScopeKind(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidRuleScopeKind, s)
+	}
+}
+
+func (k RuleScopeKind) MarshalJSON() ([]byte, error) {
+	if _, err := ParseRuleScopeKind(string(k)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(k))
+}
+
+func (k *RuleScopeKind) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseRuleScopeKind(s)
+	if err != nil {
+		return err
+	}
+	*k = parsed
+	return nil
+}
+
+// EdgeMode is the per-bundle enforcement posture for the edge evaluator. It
+// migrates today's global EdgePolicyMode switch onto bundle metadata so
+// different fleets and users can run at different modes simultaneously. See
+// spec § "Edge bundle metadata" (cordum/docs/specs/policy-studio-rewrite.md).
+type EdgeMode string
+
+const (
+	EdgeModeObserve          EdgeMode = "observe"
+	EdgeModeEnforce          EdgeMode = "enforce"
+	EdgeModeEnterpriseStrict EdgeMode = "enterprise-strict"
+)
+
+func (m EdgeMode) String() string { return string(m) }
+
+func ParseEdgeMode(s string) (EdgeMode, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty value", ErrInvalidEdgeMode)
+	}
+	switch EdgeMode(s) {
+	case EdgeModeObserve, EdgeModeEnforce, EdgeModeEnterpriseStrict:
+		return EdgeMode(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrInvalidEdgeMode, s)
+	}
+}
+
+func (m EdgeMode) MarshalJSON() ([]byte, error) {
+	if _, err := ParseEdgeMode(string(m)); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(m))
+}
+
+func (m *EdgeMode) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := ParseEdgeMode(s)
+	if err != nil {
+		return err
+	}
+	*m = parsed
+	return nil
+}

--- a/core/policy/enums_test.go
+++ b/core/policy/enums_test.go
@@ -1,0 +1,250 @@
+package policy
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRuleType_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  RuleType
+		wire string
+	}{
+		{RuleTypeInput, "input"},
+		{RuleTypeOutput, "output"},
+		{RuleTypeVelocity, "velocity"},
+		{RuleTypeEdge, "edge"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseRuleType(tc.wire)
+		if err != nil {
+			t.Fatalf("ParseRuleType(%q) err = %v, want nil", tc.wire, err)
+		}
+		if parsed != tc.val {
+			t.Fatalf("ParseRuleType(%q) = %v, want %v", tc.wire, parsed, tc.val)
+		}
+	}
+}
+
+func TestRuleType_ParseRejects(t *testing.T) {
+	rejects := []string{"", " ", "input ", " input", "INPUT", "Input", "iNpUt", "unknown", "input2"}
+	for _, in := range rejects {
+		_, err := ParseRuleType(in)
+		if err == nil {
+			t.Fatalf("ParseRuleType(%q) err = nil, want non-nil", in)
+		}
+		if !errors.Is(err, ErrInvalidRuleType) {
+			t.Fatalf("ParseRuleType(%q) err %v does not wrap ErrInvalidRuleType", in, err)
+		}
+	}
+}
+
+func TestRuleType_MarshalJSON_RejectsZero(t *testing.T) {
+	var zero RuleType
+	if _, err := json.Marshal(zero); err == nil {
+		t.Fatalf("json.Marshal(zero RuleType) err = nil, want non-nil — zero value must not serialize")
+	}
+}
+
+func TestRuleType_UnmarshalJSON(t *testing.T) {
+	var v RuleType
+	if err := json.Unmarshal([]byte(`"input"`), &v); err != nil {
+		t.Fatalf("Unmarshal valid err = %v, want nil", err)
+	}
+	if v != RuleTypeInput {
+		t.Fatalf("Unmarshal valid = %v, want RuleTypeInput", v)
+	}
+	var bad RuleType
+	if err := json.Unmarshal([]byte(`"INPUT"`), &bad); err == nil {
+		t.Fatalf("Unmarshal of non-canonical case must fail")
+	}
+	if err := json.Unmarshal([]byte(`""`), &bad); err == nil {
+		t.Fatalf("Unmarshal of empty string must fail")
+	}
+}
+
+func TestRuleStatus_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  RuleStatus
+		wire string
+	}{
+		{RuleStatusDraft, "draft"},
+		{RuleStatusPublished, "published"},
+		{RuleStatusDeprecated, "deprecated"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseRuleStatus(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseRuleStatus(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	for _, in := range []string{"", " ", "DRAFT", "Published", "publish"} {
+		if _, err := ParseRuleStatus(in); err == nil || !errors.Is(err, ErrInvalidRuleStatus) {
+			t.Fatalf("ParseRuleStatus(%q) err = %v, want wrapped ErrInvalidRuleStatus", in, err)
+		}
+	}
+}
+
+func TestDecisionType_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  DecisionType
+		wire string
+	}{
+		{DecisionAllow, "allow"},
+		{DecisionDeny, "deny"},
+		{DecisionRequireHuman, "require_human"},
+		{DecisionThrottle, "throttle"},
+		{DecisionAllowWithConstraints, "allow_with_constraints"},
+		{DecisionQuarantine, "quarantine"},
+		{DecisionRedact, "redact"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseDecisionType(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseDecisionType(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+		// Verify wire-format parity with safety.proto enum (DecisionType
+		// values 6 and 7 were appended by epic-d9a6c0a1).
+		if tc.val == DecisionQuarantine && tc.wire != "quarantine" {
+			t.Fatalf("quarantine wire form drifted")
+		}
+		if tc.val == DecisionRedact && tc.wire != "redact" {
+			t.Fatalf("redact wire form drifted")
+		}
+	}
+	for _, in := range []string{"", " ", "ALLOW", "Deny", "require-human", "approve", "block"} {
+		if _, err := ParseDecisionType(in); err == nil || !errors.Is(err, ErrInvalidDecisionType) {
+			t.Fatalf("ParseDecisionType(%q) err = %v, want wrapped ErrInvalidDecisionType", in, err)
+		}
+	}
+}
+
+func TestDecisionType_RoundTripIncludesNewWireValues(t *testing.T) {
+	for _, val := range []DecisionType{DecisionAllowWithConstraints, DecisionQuarantine, DecisionRedact} {
+		raw, err := json.Marshal(val)
+		if err != nil {
+			t.Fatalf("Marshal(%v) err = %v", val, err)
+		}
+		var got DecisionType
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("Unmarshal(%s) err = %v", raw, err)
+		}
+		if got != val {
+			t.Fatalf("round-trip drift: %v -> %s -> %v", val, raw, got)
+		}
+	}
+}
+
+func TestDecisionSource_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  DecisionSource
+		wire string
+	}{
+		{DecisionSourceJob, "job"},
+		{DecisionSourceEdge, "edge"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseDecisionSource(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseDecisionSource(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	for _, in := range []string{"", " ", "JOB", "Edge", "agent"} {
+		if _, err := ParseDecisionSource(in); err == nil || !errors.Is(err, ErrInvalidDecisionSource) {
+			t.Fatalf("ParseDecisionSource(%q) err = %v, want wrapped ErrInvalidDecisionSource", in, err)
+		}
+	}
+}
+
+func TestRuleScopeKind_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  RuleScopeKind
+		wire string
+	}{
+		{RuleScopeGlobal, "global"},
+		{RuleScopeTenant, "tenant"},
+		{RuleScopeWorkflow, "workflow"},
+		{RuleScopeEdgeFleet, "edge_fleet"},
+		{RuleScopeEdgeUser, "edge_user"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseRuleScopeKind(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseRuleScopeKind(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	for _, in := range []string{"", " ", "GLOBAL", "Tenant", "edge-fleet", "edgefleet"} {
+		if _, err := ParseRuleScopeKind(in); err == nil || !errors.Is(err, ErrInvalidRuleScopeKind) {
+			t.Fatalf("ParseRuleScopeKind(%q) err = %v, want wrapped ErrInvalidRuleScopeKind", in, err)
+		}
+	}
+}
+
+func TestEdgeMode_StringAndParse(t *testing.T) {
+	cases := []struct {
+		val  EdgeMode
+		wire string
+	}{
+		{EdgeModeObserve, "observe"},
+		{EdgeModeEnforce, "enforce"},
+		{EdgeModeEnterpriseStrict, "enterprise-strict"},
+	}
+	for _, tc := range cases {
+		if got := tc.val.String(); got != tc.wire {
+			t.Fatalf("%v.String() = %q, want %q", tc.val, got, tc.wire)
+		}
+		parsed, err := ParseEdgeMode(tc.wire)
+		if err != nil || parsed != tc.val {
+			t.Fatalf("ParseEdgeMode(%q) = (%v, %v), want (%v, nil)", tc.wire, parsed, err, tc.val)
+		}
+	}
+	// Reject unknown + case + the common typo "enterprise_strict" (underscore vs hyphen).
+	for _, in := range []string{"", " ", "OBSERVE", "Enforce", "enterprise_strict", "strict"} {
+		if _, err := ParseEdgeMode(in); err == nil || !errors.Is(err, ErrInvalidEdgeMode) {
+			t.Fatalf("ParseEdgeMode(%q) err = %v, want wrapped ErrInvalidEdgeMode", in, err)
+		}
+	}
+	// MarshalJSON round-trip.
+	raw, err := json.Marshal(EdgeModeEnterpriseStrict)
+	if err != nil {
+		t.Fatalf("Marshal err = %v", err)
+	}
+	if string(raw) != `"enterprise-strict"` {
+		t.Fatalf("Marshal = %s, want \"enterprise-strict\"", raw)
+	}
+	var back EdgeMode
+	if err := json.Unmarshal(raw, &back); err != nil || back != EdgeModeEnterpriseStrict {
+		t.Fatalf("Unmarshal round-trip failed: err=%v back=%v", err, back)
+	}
+}
+
+func TestEnumErrorMessagesContainRejectedValue(t *testing.T) {
+	// Every Parse* error message should include the rejected value verbatim
+	// for log-emission purposes (architect rail: "wrapped string contains the
+	// rejected value verbatim").
+	_, err := ParseRuleType("bogus_kind")
+	if err == nil || !strings.Contains(err.Error(), `"bogus_kind"`) {
+		t.Fatalf("ParseRuleType error %v missing rejected value", err)
+	}
+	_, err = ParseEdgeMode("WRONG")
+	if err == nil || !strings.Contains(err.Error(), `"WRONG"`) {
+		t.Fatalf("ParseEdgeMode error %v missing rejected value", err)
+	}
+}

--- a/core/policy/testdata/legacy_input_rule.json
+++ b/core/policy/testdata/legacy_input_rule.json
@@ -1,0 +1,45 @@
+{
+  "ID": "legacy-input-secret-block",
+  "tier": "global",
+  "selector": {
+    "workflow_id": "wf-claims"
+  },
+  "Enabled": true,
+  "Severity": "critical",
+  "Desc": "Block secret leaks in inputs",
+  "Match": {
+    "Tenants": [
+      "acme"
+    ],
+    "Topics": [
+      "job.acme.*"
+    ],
+    "Capabilities": [
+      "llm.request"
+    ],
+    "RiskTags": [
+      "untrusted_input"
+    ],
+    "Scanners": [
+      "secret_leak"
+    ],
+    "ContentPatterns": [
+      "(?i)api[_-]?key"
+    ],
+    "Keywords": [
+      "secret",
+      "token"
+    ],
+    "ContentTypes": [
+      "application/json"
+    ],
+    "Detectors": [
+      "secret_leak"
+    ],
+    "InputSizeGt": 1024,
+    "MaxInputBytes": 1048576,
+    "Scope": null
+  },
+  "Decision": "deny",
+  "Reason": "secret_leak_detected"
+}

--- a/core/policy/testdata/legacy_output_rule.json
+++ b/core/policy/testdata/legacy_output_rule.json
@@ -1,0 +1,41 @@
+{
+  "ID": "legacy-output-pii-redact",
+  "Enabled": true,
+  "Severity": "high",
+  "Desc": "Redact PII in outputs",
+  "Match": {
+    "Tenants": [
+      "acme"
+    ],
+    "Topics": [
+      "job.acme.*"
+    ],
+    "Capabilities": [
+      "llm.request"
+    ],
+    "RiskTags": [
+      "contains_pii"
+    ],
+    "Scanners": [
+      "pii"
+    ],
+    "ContentPatterns": [
+      "(?i)\\bSSN\\b"
+    ],
+    "Keywords": [
+      "social",
+      "ssn"
+    ],
+    "ContentTypes": [
+      "application/json"
+    ],
+    "Detectors": [
+      "pii"
+    ],
+    "OutputSizeGt": 0,
+    "MaxOutputBytes": 4194304,
+    "HasError": false
+  },
+  "Decision": "redact",
+  "Reason": "pii_in_output"
+}

--- a/core/policy/types.go
+++ b/core/policy/types.go
@@ -1,0 +1,108 @@
+package policy
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Rule is the unified authoring surface for both job-side and edge-side
+// policy. The envelope (ID, Name, Type, Scope, Status, Version, Audit) is
+// shared across all rule types; the type-specific Match/Decide payloads carry
+// the per-RuleType schema as raw JSON to preserve lossless roundtrip with
+// orval-generated dashboard types and protobuf google.protobuf.Struct
+// transport.
+type Rule struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Type        RuleType        `json:"type"`
+	Scope       RuleScope       `json:"scope"`
+	Status      RuleStatus      `json:"status"`
+	Version     string          `json:"version"`
+	Audit       AuditMetadata   `json:"audit"`
+	Match       json.RawMessage `json:"match"`
+	Decide      json.RawMessage `json:"decide"`
+	Description string          `json:"description,omitempty"`
+}
+
+// Decision is the unified evaluator output. A single Decision may aggregate
+// multiple rule evaluations via Trace; Type holds the final outcome the
+// evaluator derived from the trace. Source distinguishes the producing
+// evaluator (job pipeline vs edge classifier path); InputRef and OutputRef
+// are pointers into the blob store rather than embedded payloads.
+type Decision struct {
+	Source        DecisionSource `json:"source"`
+	RuleID        string         `json:"rule_id"`
+	BundleID      string         `json:"bundle_id,omitempty"`
+	BundleVersion string         `json:"bundle_version,omitempty"`
+	Type          DecisionType   `json:"type"`
+	Trace         []TraceStep    `json:"trace,omitempty"`
+	InputRef      string         `json:"input_ref,omitempty"`
+	OutputRef     string         `json:"output_ref,omitempty"`
+	AuditHash     string         `json:"audit_hash,omitempty"`
+	Timestamp     time.Time      `json:"timestamp"`
+}
+
+// TraceStep records one rule evaluation contributing to a Decision. Multiple
+// TraceSteps are emitted when a rule chain or bundle composition produces a
+// final decision through ordered evaluation. Constraints carries the raw
+// constraints payload (e.g. the existing safetykernel BudgetConstraints/
+// SandboxProfile JSON) when the evaluator applied an allow_with_constraints
+// path; downstream consumers parse it per RuleType.
+type TraceStep struct {
+	RuleID       string          `json:"rule_id"`
+	BundleID     string          `json:"bundle_id,omitempty"`
+	DecisionType DecisionType    `json:"decision_type"`
+	Reason       string          `json:"reason,omitempty"`
+	Timestamp    time.Time       `json:"timestamp"`
+	Constraints  json.RawMessage `json:"constraints,omitempty"`
+}
+
+// Bundle is a deployable set of rules with a deployment scope. Rules are
+// referenced by ID rather than embedded so a bundle can rotate its members
+// without forcing rule duplication; the snapshot at deploy time lives in
+// BundleVersion.RuleSnapshot for tamper-evident rollback.
+type Bundle struct {
+	ID           string          `json:"id"`
+	Name         string          `json:"name"`
+	RuleIDs      []string        `json:"rule_ids,omitempty"`
+	ScopeBinding RuleScope       `json:"scope_binding"`
+	Versions     []BundleVersion `json:"versions,omitempty"`
+	Metadata     BundleMetadata  `json:"metadata,omitzero"`
+}
+
+// BundleMetadata carries per-bundle authoring metadata that does not affect
+// match/decide payloads. EdgeMode is the per-bundle enforcement posture for
+// edge-scoped bundles, replacing today's global EdgePolicyMode switch.
+type BundleMetadata struct {
+	EdgeMode EdgeMode `json:"edge_mode,omitempty"`
+}
+
+// BundleVersion is the immutable record of a Bundle deploy. RuleSnapshot
+// captures the full Rule contents at deploy time so rollback and audit do
+// not depend on the live rule store; AuditHash chains the version into the
+// audit chain.
+type BundleVersion struct {
+	Version      string    `json:"version"`
+	RuleSnapshot []Rule    `json:"rule_snapshot,omitempty"`
+	DeployedAt   time.Time `json:"deployed_at"`
+	AuditHash    string    `json:"audit_hash,omitempty"`
+}
+
+// RuleScope narrows where a rule (or bundle) applies. When Kind is
+// RuleScopeGlobal, Value is unused and may be empty; for the other kinds
+// Value carries the corresponding identifier (tenant id, workflow id, edge
+// fleet name, edge user id).
+type RuleScope struct {
+	Kind  RuleScopeKind `json:"kind"`
+	Value string        `json:"value,omitempty"`
+}
+
+// AuditMetadata records who created or last updated a Rule or Bundle. The
+// Updated* fields are zero-valued on first creation and populated by the
+// first subsequent edit.
+type AuditMetadata struct {
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy string    `json:"created_by"`
+	UpdatedAt time.Time `json:"updated_at,omitzero"`
+	UpdatedBy string    `json:"updated_by,omitempty"`
+}

--- a/core/policy/types_test.go
+++ b/core/policy/types_test.go
@@ -1,0 +1,320 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestRule_PerTypeRoundTrip exercises one realistic fixture per RuleType.
+// Match/Decide are json.RawMessage carriers that MUST be preserved
+// bit-for-bit through marshal/unmarshal so the orval-generated TS layer
+// and the proto google.protobuf.Struct carriers can round-trip lossless.
+func TestRule_PerTypeRoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 9, 8, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		rule   Rule
+		wantID string
+	}{
+		{
+			name: "input",
+			rule: Rule{
+				ID:      "rule-input-secrets",
+				Name:    "Block secret leaks in input",
+				Type:    RuleTypeInput,
+				Scope:   RuleScope{Kind: RuleScopeTenant, Value: "tenant-acme"},
+				Status:  RuleStatusPublished,
+				Version: "v1",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "yaron@cordum.io"},
+				Match: json.RawMessage(`{
+                  "tenants": ["acme"],
+                  "topics": ["job.acme.*"],
+                  "scanners": ["secret_leak"],
+                  "input_size_gt": 1024
+                }`),
+				Decide: json.RawMessage(`{"decision":"deny","reason":"secret_leak","severity":"critical"}`),
+			},
+			wantID: "rule-input-secrets",
+		},
+		{
+			name: "output",
+			rule: Rule{
+				ID:      "rule-output-pii-redact",
+				Name:    "Redact PII in outputs",
+				Type:    RuleTypeOutput,
+				Scope:   RuleScope{Kind: RuleScopeGlobal},
+				Status:  RuleStatusPublished,
+				Version: "v3",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "policyteam@cordum.io"},
+				Match: json.RawMessage(`{
+                  "detectors": ["pii"],
+                  "output_size_gt": 0,
+                  "has_error": false
+                }`),
+				Decide: json.RawMessage(`{"decision":"redact","reason":"pii_in_output","severity":"high"}`),
+			},
+			wantID: "rule-output-pii-redact",
+		},
+		{
+			name: "velocity",
+			rule: Rule{
+				ID:          "rule-velocity-llm-throttle",
+				Name:        "LLM request rate limit per session",
+				Type:        RuleTypeVelocity,
+				Scope:       RuleScope{Kind: RuleScopeWorkflow, Value: "wf-claims-triage"},
+				Status:      RuleStatusPublished,
+				Version:     "v2",
+				Audit:       AuditMetadata{CreatedAt: now, CreatedBy: "ops@cordum.io"},
+				Description: "throttle to 60 req/min per session",
+				Match: json.RawMessage(`{
+                  "tenants": ["acme"],
+                  "capabilities": ["llm.request"],
+                  "labels": {"actor_type": "service"}
+                }`),
+				Decide: json.RawMessage(`{
+                  "decision": "throttle",
+                  "reason": "rate_limit_exceeded",
+                  "velocity": {"max_requests": 60, "window_seconds": 60, "key": "labels.session_id"},
+                  "constraints": {"budgets": {"max_runtime_ms": 30000}}
+                }`),
+			},
+			wantID: "rule-velocity-llm-throttle",
+		},
+		{
+			name: "edge",
+			rule: Rule{
+				ID:      "rule-edge-fs-write-deny",
+				Name:    "Block writes to /etc",
+				Type:    RuleTypeEdge,
+				Scope:   RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-prod"},
+				Status:  RuleStatusPublished,
+				Version: "v1",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "secops@cordum.io"},
+				Match: json.RawMessage(`{
+                  "capability": "file.write",
+                  "labels": {"path_prefix": "/etc"},
+                  "complete": true
+                }`),
+				Decide: json.RawMessage(`{"decision":"DENY","reason":"system_path_protected"}`),
+			},
+			wantID: "rule-edge-fs-write-deny",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origMatch := append([]byte(nil), tc.rule.Match...)
+			origDecide := append([]byte(nil), tc.rule.Decide...)
+
+			raw, err := json.Marshal(tc.rule)
+			if err != nil {
+				t.Fatalf("Marshal err = %v", err)
+			}
+			var back Rule
+			if err := json.Unmarshal(raw, &back); err != nil {
+				t.Fatalf("Unmarshal err = %v", err)
+			}
+			if back.ID != tc.wantID {
+				t.Fatalf("ID drift: %s -> %s", tc.wantID, back.ID)
+			}
+			if back.Type != tc.rule.Type {
+				t.Fatalf("Type drift: %v -> %v", tc.rule.Type, back.Type)
+			}
+			if back.Scope != tc.rule.Scope {
+				t.Fatalf("Scope drift: %+v -> %+v", tc.rule.Scope, back.Scope)
+			}
+			if back.Status != tc.rule.Status {
+				t.Fatalf("Status drift: %v -> %v", tc.rule.Status, back.Status)
+			}
+			if !back.Audit.CreatedAt.Equal(tc.rule.Audit.CreatedAt) || back.Audit.CreatedBy != tc.rule.Audit.CreatedBy {
+				t.Fatalf("Audit drift: %+v -> %+v", tc.rule.Audit, back.Audit)
+			}
+
+			// Match/Decide json.RawMessage round-trip: the bytes must be
+			// semantically equal (json.Compact normalises whitespace which
+			// json.Marshal applies on serialise — bit-for-bit equality after
+			// re-canonicalisation is the contract we hold).
+			origCompact := mustCompact(t, origMatch)
+			backCompact := mustCompact(t, back.Match)
+			if !bytes.Equal(origCompact, backCompact) {
+				t.Fatalf("Match drift: %s vs %s", origCompact, backCompact)
+			}
+			origCompact = mustCompact(t, origDecide)
+			backCompact = mustCompact(t, back.Decide)
+			if !bytes.Equal(origCompact, backCompact) {
+				t.Fatalf("Decide drift: %s vs %s", origCompact, backCompact)
+			}
+		})
+	}
+}
+
+// TestDecision_RoundTrip exercises a Decision with multi-step Trace, all
+// optional fields populated, and the new wire-format DecisionType values
+// (allow_with_constraints, quarantine, redact) per amendment #2.
+func TestDecision_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 9, 8, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		dec  Decision
+	}{
+		{
+			name: "job_allow_with_constraints",
+			dec: Decision{
+				Source:        DecisionSourceJob,
+				RuleID:        "rule-velocity-llm-throttle",
+				BundleID:      "bundle-acme-default",
+				BundleVersion: "v12",
+				Type:          DecisionAllowWithConstraints,
+				Trace: []TraceStep{{
+					RuleID:       "rule-velocity-llm-throttle",
+					BundleID:     "bundle-acme-default",
+					DecisionType: DecisionAllowWithConstraints,
+					Reason:       "within_throttle_budget",
+					Timestamp:    now,
+					Constraints:  json.RawMessage(`{"budgets":{"max_runtime_ms":30000}}`),
+				}},
+				InputRef:  "blob://acme/input/r1",
+				OutputRef: "blob://acme/output/r1",
+				AuditHash: "0x" + "ab" + "cd" + "ef",
+				Timestamp: now,
+			},
+		},
+		{
+			name: "edge_deny",
+			dec: Decision{
+				Source:    DecisionSourceEdge,
+				RuleID:    "rule-edge-fs-write-deny",
+				Type:      DecisionDeny,
+				Trace:     nil,
+				Timestamp: now,
+			},
+		},
+		{
+			name: "output_quarantine",
+			dec: Decision{
+				Source:    DecisionSourceJob,
+				RuleID:    "rule-output-pii-quarantine",
+				Type:      DecisionQuarantine,
+				Timestamp: now,
+			},
+		},
+		{
+			name: "output_redact",
+			dec: Decision{
+				Source:    DecisionSourceJob,
+				RuleID:    "rule-output-pii-redact",
+				Type:      DecisionRedact,
+				Timestamp: now,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.dec)
+			if err != nil {
+				t.Fatalf("Marshal err = %v", err)
+			}
+			var back Decision
+			if err := json.Unmarshal(raw, &back); err != nil {
+				t.Fatalf("Unmarshal err = %v", err)
+			}
+			if back.Source != tc.dec.Source || back.Type != tc.dec.Type || back.RuleID != tc.dec.RuleID {
+				t.Fatalf("Decision drift: %+v vs %+v", tc.dec, back)
+			}
+			if !back.Timestamp.Equal(tc.dec.Timestamp) {
+				t.Fatalf("Timestamp drift: %v vs %v", tc.dec.Timestamp, back.Timestamp)
+			}
+			if len(back.Trace) != len(tc.dec.Trace) {
+				t.Fatalf("Trace length drift: %d vs %d", len(tc.dec.Trace), len(back.Trace))
+			}
+			for i := range tc.dec.Trace {
+				if back.Trace[i].RuleID != tc.dec.Trace[i].RuleID ||
+					back.Trace[i].DecisionType != tc.dec.Trace[i].DecisionType {
+					t.Fatalf("TraceStep[%d] drift: %+v vs %+v", i, tc.dec.Trace[i], back.Trace[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBundle_RoundTrip covers Bundle with EdgeMode metadata + a versioned
+// rule snapshot. Verifies BundleMetadata.EdgeMode survives marshal cycles.
+func TestBundle_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 9, 8, 30, 0, 0, time.UTC)
+
+	bundle := Bundle{
+		ID:           "bundle-edge-prod",
+		Name:         "Production edge bundle",
+		RuleIDs:      []string{"rule-edge-fs-write-deny", "rule-edge-shell-throttle"},
+		ScopeBinding: RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-prod"},
+		Versions: []BundleVersion{{
+			Version:    "v3",
+			DeployedAt: now,
+			AuditHash:  "0xdeadbeef",
+			RuleSnapshot: []Rule{{
+				ID:      "rule-edge-fs-write-deny",
+				Name:    "Block writes to /etc",
+				Type:    RuleTypeEdge,
+				Scope:   RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-prod"},
+				Status:  RuleStatusPublished,
+				Version: "v1",
+				Audit:   AuditMetadata{CreatedAt: now, CreatedBy: "secops@cordum.io"},
+				Match:   json.RawMessage(`{"capability":"file.write"}`),
+				Decide:  json.RawMessage(`{"decision":"DENY"}`),
+			}},
+		}},
+		Metadata: BundleMetadata{EdgeMode: EdgeModeEnterpriseStrict},
+	}
+
+	raw, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("Marshal err = %v", err)
+	}
+	var back Bundle
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("Unmarshal err = %v", err)
+	}
+	if back.ID != bundle.ID || back.Name != bundle.Name {
+		t.Fatalf("Bundle envelope drift")
+	}
+	if back.Metadata.EdgeMode != EdgeModeEnterpriseStrict {
+		t.Fatalf("EdgeMode drift: %v vs enterprise-strict", back.Metadata.EdgeMode)
+	}
+	if len(back.Versions) != 1 || len(back.Versions[0].RuleSnapshot) != 1 {
+		t.Fatalf("Versions/RuleSnapshot drift: %+v", back.Versions)
+	}
+	if back.Versions[0].RuleSnapshot[0].ID != "rule-edge-fs-write-deny" {
+		t.Fatalf("RuleSnapshot[0].ID drift")
+	}
+}
+
+// TestBundle_OmitsZeroMetadata confirms BundleMetadata's zero value uses
+// `omitzero` so an unset metadata block doesn't pollute the JSON output.
+func TestBundle_OmitsZeroMetadata(t *testing.T) {
+	b := Bundle{
+		ID:           "bundle-no-meta",
+		Name:         "Bundle without edge metadata",
+		ScopeBinding: RuleScope{Kind: RuleScopeGlobal},
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("Marshal err = %v", err)
+	}
+	if bytes.Contains(raw, []byte(`"metadata"`)) {
+		t.Fatalf("zero BundleMetadata should be omitted; got %s", raw)
+	}
+}
+
+func mustCompact(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		t.Fatalf("Compact err = %v on %s", err, raw)
+	}
+	return buf.Bytes()
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3110,3 +3110,28 @@ The following routes are registered in gateway route setup.
 | GET | `/mcp/sse` |
 | POST | `/mcp/message` |
 | GET | `/mcp/status` |
+
+## Policy Studio (Backend 1 foundation, epic-d9a6c0a1)
+
+The OpenAPI spec at `docs/api/openapi/cordum-api.yaml` adds the unified
+`Rule`, `Decision`, `Bundle`, `BundleVersion`, `BundleMetadata`,
+`RuleScope`, `AuditMetadata`, and `TraceStep` schemas, plus the
+`RuleType` / `RuleStatus` / `DecisionType` / `DecisionSource` /
+`RuleScopeKind` / `EdgeMode` enum schemas. These coexist alongside the
+legacy `OutputRule`, `VelocityRule`, and `PolicyBundleSummary` schemas
+during the migration window — DoD #3 of task-3bf37e32 verifies the legacy
+schemas are byte-identical to pre-edit.
+
+Path operations that consume the new schemas (`/policies`,
+`/policies/bundles`, `/policies/decisions`, etc.) land in Backend 5 (the
+unified evaluator entry-point task). The Backend 1 PR ships the type
+definitions only; orval-generated dashboard hooks therefore have no new
+operations to wire until Backend 5 merges.
+
+The full design is documented in
+[docs/specs/policy-studio-rewrite.md](specs/policy-studio-rewrite.md).
+The corresponding Go types live in
+[core/policy/README.md](../core/policy/README.md), and the wire-level
+proto changes (including the `DECISION_TYPE_QUARANTINE = 6` and
+`DECISION_TYPE_REDACT = 7` append to the existing `DecisionType` enum in
+`safety.proto`) ship via a parallel cap PR per the CAP append-only rule.

--- a/docs/api/openapi/cordum-api.yaml
+++ b/docs/api/openapi/cordum-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Cordum HTTP API
-  version: '2026-04-21.2'
+  version: '2026-05-09.1'
   description: Canonical OpenAPI 3.0.3 spec for the Cordum gateway HTTP surface.
   contact:
     name: Cordum Team
@@ -10986,3 +10986,271 @@ components:
       - holder
       - ttl_remaining_ms
       - type
+    RuleType:
+      type: string
+      description: Discriminator for a Rule's match/decide payload schema.
+      enum:
+      - input
+      - output
+      - velocity
+      - edge
+    RuleStatus:
+      type: string
+      description: |
+        Lifecycle state of a Rule. `draft` rules are author-only; `published`
+        rules participate in evaluation; `deprecated` rules remain queryable
+        for audit and rollback but are skipped by evaluators.
+      enum:
+      - draft
+      - published
+      - deprecated
+    DecisionType:
+      type: string
+      description: |
+        Unified decision outcome emitted by either evaluator. The seven values
+        mirror the wire-format DecisionType enum in
+        cap/proto/cordum/agent/v1/safety.proto (epic-d9a6c0a1 appended
+        QUARANTINE and REDACT to the existing five values).
+      enum:
+      - allow
+      - deny
+      - require_human
+      - throttle
+      - allow_with_constraints
+      - quarantine
+      - redact
+    DecisionSource:
+      type: string
+      description: |
+        Identifies which evaluator produced a Decision: the safetykernel job
+        pipeline (`job`) or the edge classifier path (`edge`).
+      enum:
+      - job
+      - edge
+    RuleScopeKind:
+      type: string
+      description: |
+        Narrows where a rule (or bundle) applies. `global` covers an entire
+        deployment; `tenant`/`workflow` scope to job-side bindings;
+        `edge_fleet`/`edge_user` scope to edge-side bindings.
+      enum:
+      - global
+      - tenant
+      - workflow
+      - edge_fleet
+      - edge_user
+    EdgeMode:
+      type: string
+      description: |
+        Per-bundle enforcement posture for the edge evaluator. Migrates the
+        legacy global EdgePolicyMode switch onto bundle metadata so different
+        fleets and users can run at different modes simultaneously. See spec
+        cordum/docs/specs/policy-studio-rewrite.md "Edge bundle metadata".
+      enum:
+      - observe
+      - enforce
+      - enterprise-strict
+    RuleScope:
+      type: object
+      description: |
+        Narrows where a rule (or bundle) applies. When `kind` is `global`,
+        `value` is unused and may be empty; for the other kinds, `value`
+        carries the corresponding identifier (tenant id, workflow id, edge
+        fleet name, edge user id).
+      properties:
+        kind:
+          $ref: '#/components/schemas/RuleScopeKind'
+        value:
+          type: string
+      required:
+      - kind
+    AuditMetadata:
+      type: object
+      description: |
+        Records who created or last updated a Rule or Bundle. The `updated_*`
+        fields are zero-valued on first creation and populated by the first
+        subsequent edit.
+      properties:
+        created_at:
+          type: string
+          format: date-time
+        created_by:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+        updated_by:
+          type: string
+      required:
+      - created_at
+      - created_by
+    TraceStep:
+      type: object
+      description: |
+        Records one rule evaluation contributing to a Decision. Multiple
+        TraceSteps are emitted when a rule chain or bundle composition
+        produces a final decision through ordered evaluation. `constraints`
+        carries the raw constraints payload (e.g. the existing safetykernel
+        BudgetConstraints/SandboxProfile JSON) when the evaluator applied an
+        allow_with_constraints path; downstream consumers parse it per
+        RuleType.
+      properties:
+        rule_id:
+          type: string
+        bundle_id:
+          type: string
+        decision_type:
+          $ref: '#/components/schemas/DecisionType'
+        reason:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        constraints:
+          type: object
+          additionalProperties: true
+      required:
+      - rule_id
+      - decision_type
+      - timestamp
+    Rule:
+      type: object
+      description: |
+        Unified authoring surface for both job-side and edge-side policy. The
+        envelope (id, name, type, scope, status, version, audit) is shared
+        across all rule types; type-specific match/decide payloads carry the
+        per-RuleType schema as free-form objects to preserve lossless
+        roundtrip with the Go json.RawMessage and protobuf
+        google.protobuf.Struct transport. Coexists alongside the legacy
+        OutputRule/VelocityRule schemas during the migration window.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/RuleType'
+        scope:
+          $ref: '#/components/schemas/RuleScope'
+        status:
+          $ref: '#/components/schemas/RuleStatus'
+        version:
+          type: string
+        audit:
+          $ref: '#/components/schemas/AuditMetadata'
+        match:
+          type: object
+          additionalProperties: true
+        decide:
+          type: object
+          additionalProperties: true
+        description:
+          type: string
+      required:
+      - id
+      - name
+      - type
+      - scope
+      - status
+      - version
+      - audit
+      - match
+      - decide
+    Decision:
+      type: object
+      description: |
+        Unified evaluator output. A single Decision may aggregate multiple
+        rule evaluations via `trace`; `type` holds the final outcome the
+        evaluator derived from the trace. `source` distinguishes the
+        producing evaluator. `input_ref`/`output_ref` are pointers into the
+        blob store rather than embedded payloads.
+      properties:
+        source:
+          $ref: '#/components/schemas/DecisionSource'
+        rule_id:
+          type: string
+        bundle_id:
+          type: string
+        bundle_version:
+          type: string
+        type:
+          $ref: '#/components/schemas/DecisionType'
+        trace:
+          type: array
+          items:
+            $ref: '#/components/schemas/TraceStep'
+        input_ref:
+          type: string
+        output_ref:
+          type: string
+        audit_hash:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+      required:
+      - source
+      - rule_id
+      - type
+      - timestamp
+    BundleMetadata:
+      type: object
+      description: |
+        Per-bundle authoring metadata that does not affect match/decide
+        payloads. `edge_mode` is the per-bundle enforcement posture for
+        edge-scoped bundles, replacing the legacy global EdgePolicyMode
+        switch.
+      properties:
+        edge_mode:
+          $ref: '#/components/schemas/EdgeMode'
+    BundleVersion:
+      type: object
+      description: |
+        Immutable record of a Bundle deploy. `rule_snapshot` captures the
+        full Rule contents at deploy time so rollback and audit do not depend
+        on the live rule store; `audit_hash` chains the version into the
+        audit chain.
+      properties:
+        version:
+          type: string
+        rule_snapshot:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rule'
+        deployed_at:
+          type: string
+          format: date-time
+        audit_hash:
+          type: string
+      required:
+      - version
+      - deployed_at
+    Bundle:
+      type: object
+      description: |
+        Deployable set of rules with a deployment scope. Rules are referenced
+        by id rather than embedded so a bundle can rotate its members without
+        forcing rule duplication; the snapshot at deploy time lives in
+        `versions[].rule_snapshot` for tamper-evident rollback. Coexists
+        alongside the legacy PolicyBundleSummary schema.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        rule_ids:
+          type: array
+          items:
+            type: string
+        scope_binding:
+          $ref: '#/components/schemas/RuleScope'
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BundleVersion'
+        metadata:
+          $ref: '#/components/schemas/BundleMetadata'
+      required:
+      - id
+      - name
+      - scope_binding

--- a/docs/policy-bundle-store.md
+++ b/docs/policy-bundle-store.md
@@ -63,11 +63,26 @@ All multi-key mutations execute inside a single Redis Lua script:
   scripts in-process to completion).
 
 - `rollbackScript` — reads the current active pointer, locates the
-  deploy entry that established it (skipping rollback markers), walks
-  backward to the immediately-prior deploy entry, SETs active to that
-  pair, and LPUSHes a rollback marker. Chained rollbacks unwind one
-  step per call (`v3 → v2 → v1`); this is the test
-  `TestRollbackChain` invariant.
+  deploy entry that established it (skipping rollback markers), reads
+  the `prev_bundle_id` + `prev_version` fields recorded ON that deploy
+  event at deploy-time, SETs active to that prior pair, and LPUSHes a
+  rollback marker. Chained rollbacks unwind one step per call
+  (`v3 → v2 → v1`); the test `TestRollbackChain` pins this. After a
+  deploy-after-rollback (`v1 → v2 → rollback → v3 → rollback`) the
+  final rollback restores v1 — the active state immediately before
+  v3 was deployed — because that pair was captured on the v3 deploy
+  event. The test `TestDeployAfterRollback` pins this regression
+  closed (was QA reopen #1 on 2026-05-09).
+
+### Why prev-active is recorded on each deploy event
+
+Without per-event prev-active fields, rollback can only inspect raw
+history order, which loses information after a deploy-after-rollback:
+the second-most-recent deploy event (v2) is no longer the active
+state immediately before the current deploy (v1, post-rollback). The
+script reads the current active pointer and writes the deploy event
+inside the same Lua execution, so concurrent deploys to the same scope
+produce a totally-ordered prev-active chain.
 
 The Lua-EVAL choice is load-bearing: per memory `mem-12f1ceeb`,
 go-redis's WATCH+TxPipelined sequence corrupts the connection pool when

--- a/docs/policy-bundle-store.md
+++ b/docs/policy-bundle-store.md
@@ -1,0 +1,110 @@
+# Policy Bundle Store
+
+Redis-backed storage for the unified Policy Studio bundles introduced in
+epic-d9a6c0a1. The store sits in `core/policy/` and is consumed by both
+job-side (safetykernel) and edge-side evaluators via the
+[`BundleStore`](../core/policy/bundle_store.go) interface; the unified
+view replaces the per-track bundle tables that lived in v2.
+
+## Purpose
+
+Policy Studio's three-surface IA (`/policies`, `/policies/bundles`,
+`/policies/decisions`) needs a single canonical store for:
+
+- Bundle envelopes (id, name, scope binding, metadata).
+- Per-bundle version history (immutable BundleVersion records with
+  full RuleSnapshot for tamper-evident rollback).
+- Per-scope active deployment + ordered deploy/rollback history.
+
+`BundleStore` is the contract; `BundleRedisStore` is the canonical
+implementation.
+
+## Redis schema
+
+| Key | Type | Purpose | Cardinality | TTL |
+|---|---|---|---|---|
+| `policy:bundle:{id}` | STRING (JSON Bundle envelope, no Versions) | Bundle metadata | 1 per bundle | none (immutable + long-lived) |
+| `policy:bundle:{id}:versions` | ZSET (member=version, score=DeployedAt unix nanos) | Per-bundle version index | 1 per bundle | none |
+| `policy:bundle:{id}:version:{version}` | STRING (JSON BundleVersion incl. RuleSnapshot + AuditHash) | Immutable version blob | 1 per (bundle, version) | none |
+| `policy:scope:{kind}:{value}:active` | STRING (`"{bundleID}:{version}"` pointer) | Active deployment for scope | 1 per scope | none |
+| `policy:scope:{kind}:{value}:history` | LIST (each element a Deployment JSON; LPUSH on deploy/rollback) | Ordered history (newest first) | bounded to 100 entries via LTRIM in Lua | none |
+
+### Why the prefix split
+
+`policy:bundle:*` covers everything keyed by bundle id; `policy:scope:*`
+covers everything keyed by scope. Step-2 inventory confirmed neither
+prefix collides with existing core/* stores (workflow uses `cordum:wf:*`
++ `runKey()`, edge uses `edge:session:*`, registry uses
+`sys:workers:*`).
+
+## CRUD operations
+
+| Operation | Atomic? | Idempotent? | Typed errors |
+|---|---|---|---|
+| `CreateBundle` | SETNX (single key) | yes (duplicate returns ErrBundleExists) | ErrBundleExists |
+| `GetBundle` | GET (single key) | yes | ErrBundleNotFound |
+| `ListBundlesByScope` | SCAN over `policy:bundle:*` + in-process filter | yes | — |
+| `CreateBundleVersion` | SETNX + ZADD pipeline | yes (duplicate version-number returns ErrBundleVersionExists) | ErrBundleVersionExists |
+| `ListBundleVersions` | ZRANGE + MGET pipeline | yes | — |
+| `GetBundleVersion` | GET (single key) | yes | ErrBundleVersionNotFound |
+| `DeployVersionToScope` | **single Lua EVAL** (`deployScript`) | yes | ErrBundleVersionNotFound |
+| `RollbackDeployment` | **single Lua EVAL** (`rollbackScript`) | yes | ErrNoRollbackTarget |
+| `GetActiveDeployment` | GET pointer + LRANGE history (read-only) | yes | ErrNoDeploymentForScope |
+| `ListDeploymentHistory` | LRANGE | yes | — |
+
+## Concurrency model
+
+All multi-key mutations execute inside a single Redis Lua script:
+
+- `deployScript` — validates the requested `policy:bundle:{id}:version:{n}`
+  exists, then SETs the active pointer, LPUSHes the deploy event into
+  history, and LTRIMs to the last 100 entries. Atomic; concurrent
+  deploys to the same scope serialize Redis-side (Redis runs Lua
+  scripts in-process to completion).
+
+- `rollbackScript` — reads the current active pointer, locates the
+  deploy entry that established it (skipping rollback markers), walks
+  backward to the immediately-prior deploy entry, SETs active to that
+  pair, and LPUSHes a rollback marker. Chained rollbacks unwind one
+  step per call (`v3 → v2 → v1`); this is the test
+  `TestRollbackChain` invariant.
+
+The Lua-EVAL choice is load-bearing: per memory `mem-12f1ceeb`,
+go-redis's WATCH+TxPipelined sequence corrupts the connection pool when
+miniredis returns errors, which broke the workflow store's
+`TestHandleJobResult_UpdateRunRetry_Succeeds` during task-a45b8eb1.
+Lua scripts have no equivalent failure mode under miniredis.
+
+## Bounded sizes
+
+History lists are LTRIMmed to the most recent 100 entries (constant
+`deploymentHistoryCap` in `bundle_store_keys.go`). The cap fires inside
+each Lua mutation, so no separate sweeper is needed. 100 is the
+DoD-defined upper bound; tune if dashboard's "Deployments" tab needs
+deeper history.
+
+## Open questions for v3
+
+1. **`ListBundlesByScope` SCAN cost** — current impl scans every
+   `policy:bundle:*` key and filters in-process. At ~1k bundles per
+   tenant this is fine; at 100k+ a per-scope ZSET index would amortize
+   the cost. Defer until a real performance signal appears.
+
+2. **Cluster-mode key colocation** — the deploy/rollback Lua scripts
+   touch two keys (active + history) for a single scope. Both keys
+   share the `policy:scope:{kind}:{value}:` prefix; with Redis
+   Cluster's hash-tag rule, wrap the scope segment in `{...}` when the
+   cluster topology requires colocation. Not needed for single-node
+   deployments.
+
+3. **Audit-chain integration** — `Deployment.AuditHash` is currently
+   plumbed but unused; Backend 5 will populate it via the existing
+   `core/audit` chain.
+
+## Cross-references
+
+- Task: `task-b349524a` (Backend 2 of epic-d9a6c0a1).
+- Predecessor: `task-3bf37e32` (Backend 1 — types).
+- Consumers: Backend 3 (job evaluator), Backend 4 (edge evaluator),
+  Backend 5 (unified evaluator entry-point).
+- Spec: `docs/specs/policy-studio-rewrite.md`.


### PR DESCRIPTION
## Summary

Implements the **BundleStore** for Policy Studio's unified bundle storage (epic-d9a6c0a1 Backend 2). Redis-backed CRUD with atomic Lua scripts for the multi-key Deploy/Rollback paths.

## Scope

- `core/policy/bundle_store.go` — BundleStore interface (10 ops) + Deployment record + 6 typed errors.
- `core/policy/bundle_store_keys.go` — Redis schema constants + 5 key constructors. Confirmed-clean prefix space at `policy:bundle:*` + `policy:scope:*`.
- `core/policy/bundle_store_redis.go` — `BundleRedisStore` impl with `deployScript` + `rollbackScript` Lua scripts (single-EVAL atomic per memory mem-12f1ceeb). Chained rollbacks unwind one step per call (v3→v2→v1).
- `core/policy/bundle_store_keys_test.go` + `bundle_store_redis_test.go` — 22 tests, 80.2% coverage, miniredis-backed.
- `docs/policy-bundle-store.md` — operator-facing schema reference.
- CHANGELOG + README updates.

## DoD evidence

- **DoD #1** (full CRUD; tests cover happy path + version rollback + scope deployment + concurrent-write): 16 tests in bundle_store_redis_test.go covering each of those four areas. TestRollbackChain validates the chained-rollback semantic (v3→v2→v1).
- **DoD #2** (Redis schema documented): `docs/policy-bundle-store.md` with full schema table + CRUD ops table + concurrency model.
- **DoD #3** (make build + make test green; coverage > 80%): `go build ./...` EXIT=0; `go test ./core/policy/... -count=3 -cover -timeout 240s` EXIT=0 with **coverage 80.2%**.

## Stacking + merge note

This PR stacks on Backend 1's `policy-studio-backend` PR (#250) per Yaron 2026-05-09 stacking-PR directive. Stays in REVIEW until the full epic merge wave (no individual merge).

## Test plan

- [ ] CI runs `go build ./...` + `go test ./core/...` against the merged predecessor base.
- [ ] cordum-core verification rail: `make build` + `make test` + `make openapi` (no proto changes — no `make proto` required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)