### PR TITLE
feat(core/safetykernel): consume unified policy rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ The unified evaluator entry-points and the migration of
 land in follow-up Backend tasks (see the epic decomposition in
 [docs/specs/policy-studio-rewrite.md](docs/specs/policy-studio-rewrite.md)).
 
+#### Policy Studio Rewrite — Backend 3 (epic-d9a6c0a1)
+
+Safety Kernel now has an additive unified-policy boundary for the Policy
+Studio migration:
+
+- Added pure adapters that validate unified `core/policy.Rule` values and
+  compile them into today's input/output/velocity evaluator structs without
+  mutating or removing the legacy `core/infra/config` policy types.
+- Added a stateless unified `policy.Decision` emitter for job-side decisions,
+  including UTC timestamps, source=`job`, rule id, trace, and optional bundle
+  binding metadata while preserving existing Safety Kernel gRPC responses.
+- Added audit transition-window dual emission for job policy decisions:
+  `AUDIT_UNIFIED_DECISION_MODE=dual` writes legacy `safety.decision` followed
+  by unified `policy.decision.v2`; `legacy` writes only the old shape; and
+  `unified` writes only the new shape for matched-rule decisions.
+
 #### Cordum Edge P0 (2026-04-30)
 
 EDGE epic shipped 32 P0 tasks for the Compliance Firewall surface — local

--- a/core/audit/config.go
+++ b/core/audit/config.go
@@ -1,0 +1,203 @@
+package audit
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+)
+
+const (
+	// EnvUnifiedDecisionMode selects legacy/unified/dual policy-decision audit emission.
+	EnvUnifiedDecisionMode = "AUDIT_UNIFIED_DECISION_MODE"
+	// EventPolicyDecisionV2 carries the unified policy.Decision shape in SIEM form.
+	EventPolicyDecisionV2 = "policy.decision.v2"
+)
+
+// UnifiedDecisionMode controls transition-window audit decision emission.
+type UnifiedDecisionMode string
+
+const (
+	UnifiedDecisionModeDual    UnifiedDecisionMode = "dual"
+	UnifiedDecisionModeLegacy  UnifiedDecisionMode = "legacy"
+	UnifiedDecisionModeUnified UnifiedDecisionMode = "unified"
+)
+
+var logInvalidUnifiedDecisionModeOnce sync.Once
+
+// ParseUnifiedDecisionMode accepts dual, legacy, or unified; invalid defaults dual.
+func ParseUnifiedDecisionMode(raw string) UnifiedDecisionMode {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", string(UnifiedDecisionModeDual):
+		return UnifiedDecisionModeDual
+	case string(UnifiedDecisionModeLegacy):
+		return UnifiedDecisionModeLegacy
+	case string(UnifiedDecisionModeUnified):
+		return UnifiedDecisionModeUnified
+	default:
+		return UnifiedDecisionModeDual
+	}
+}
+
+// UnifiedDecisionModeFromEnv reads AUDIT_UNIFIED_DECISION_MODE.
+func UnifiedDecisionModeFromEnv() UnifiedDecisionMode {
+	raw := os.Getenv(EnvUnifiedDecisionMode)
+	mode := ParseUnifiedDecisionMode(raw)
+	if mode == UnifiedDecisionModeDual && strings.TrimSpace(raw) != "" {
+		if !isKnownUnifiedDecisionMode(raw) {
+			logInvalidUnifiedDecisionModeOnce.Do(func() {
+				slog.Warn("invalid audit unified decision mode; defaulting to dual", "raw", raw)
+			})
+		}
+	}
+	return mode
+}
+
+// DecisionEventsForMode returns deterministic legacy/v2 event(s) for a decision.
+func DecisionEventsForMode(
+	mode UnifiedDecisionMode,
+	legacy SIEMEvent,
+	decision policy.Decision,
+) ([]SIEMEvent, error) {
+	mode = normalizeUnifiedDecisionMode(mode)
+	if mode != UnifiedDecisionModeUnified {
+		if err := validateLegacyDecisionEvent(legacy); err != nil {
+			return nil, err
+		}
+	}
+	if mode != UnifiedDecisionModeLegacy {
+		if err := validateUnifiedPolicyDecision(decision); err != nil {
+			return nil, err
+		}
+	}
+	return decisionEventsForValidMode(mode, legacy, decision), nil
+}
+
+func decisionEventsForValidMode(
+	mode UnifiedDecisionMode,
+	legacy SIEMEvent,
+	decision policy.Decision,
+) []SIEMEvent {
+	switch mode {
+	case UnifiedDecisionModeLegacy:
+		return []SIEMEvent{cloneSIEMEvent(legacy)}
+	case UnifiedDecisionModeUnified:
+		return []SIEMEvent{eventFromUnifiedDecision(legacy, decision)}
+	default:
+		return []SIEMEvent{cloneSIEMEvent(legacy), eventFromUnifiedDecision(legacy, decision)}
+	}
+}
+
+func eventFromUnifiedDecision(legacy SIEMEvent, decision policy.Decision) SIEMEvent {
+	extra := cloneExtra(legacy.Extra)
+	setExtra(extra, "source", decision.Source.String())
+	setExtra(extra, "bundle_id", decision.BundleID)
+	setExtra(extra, "bundle_version", decision.BundleVersion)
+	setExtra(extra, "input_ref", decision.InputRef)
+	setExtra(extra, "output_ref", decision.OutputRef)
+	setExtra(extra, "audit_hash", decision.AuditHash)
+	return SIEMEvent{
+		Timestamp:     decisionTimestamp(legacy.Timestamp, decision.Timestamp),
+		EventType:     EventPolicyDecisionV2,
+		Severity:      legacy.Severity,
+		TenantID:      legacy.TenantID,
+		AgentID:       legacy.AgentID,
+		AgentName:     legacy.AgentName,
+		AgentRiskTier: legacy.AgentRiskTier,
+		JobID:         legacy.JobID,
+		Action:        legacy.Action,
+		Decision:      decision.Type.String(),
+		MatchedRule:   decision.RuleID,
+		Reason:        decisionReason(legacy.Reason, decision.Trace),
+		RiskTags:      append([]string{}, legacy.RiskTags...),
+		Capabilities:  append([]string{}, legacy.Capabilities...),
+		PolicyVersion: firstNonEmpty(decision.BundleVersion, legacy.PolicyVersion),
+		Identity:      legacy.Identity,
+		Extra:         extra,
+	}
+}
+
+func validateLegacyDecisionEvent(event SIEMEvent) error {
+	if strings.TrimSpace(event.EventType) == "" || strings.TrimSpace(event.TenantID) == "" {
+		return fmt.Errorf("legacy event requires event_type and tenant_id")
+	}
+	return nil
+}
+
+func validateUnifiedPolicyDecision(decision policy.Decision) error {
+	if strings.TrimSpace(decision.RuleID) == "" || decision.Type == "" || decision.Source == "" {
+		return fmt.Errorf("policy decision requires source, type, and rule_id")
+	}
+	return nil
+}
+
+func normalizeUnifiedDecisionMode(mode UnifiedDecisionMode) UnifiedDecisionMode {
+	switch mode {
+	case UnifiedDecisionModeLegacy, UnifiedDecisionModeUnified:
+		return mode
+	default:
+		return UnifiedDecisionModeDual
+	}
+}
+
+func isKnownUnifiedDecisionMode(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(UnifiedDecisionModeDual), string(UnifiedDecisionModeLegacy), string(UnifiedDecisionModeUnified):
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneSIEMEvent(event SIEMEvent) SIEMEvent {
+	event.RiskTags = append([]string{}, event.RiskTags...)
+	event.Capabilities = append([]string{}, event.Capabilities...)
+	event.Extra = cloneExtra(event.Extra)
+	return event
+}
+
+func cloneExtra(extra map[string]string) map[string]string {
+	out := make(map[string]string, len(extra)+6)
+	for key, value := range extra {
+		out[key] = value
+	}
+	return out
+}
+
+func setExtra(extra map[string]string, key string, value string) {
+	if strings.TrimSpace(value) != "" {
+		extra[key] = strings.TrimSpace(value)
+	}
+}
+
+func decisionTimestamp(legacy, unified time.Time) time.Time {
+	if !unified.IsZero() {
+		return unified.UTC()
+	}
+	if !legacy.IsZero() {
+		return legacy.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func decisionReason(legacy string, trace []policy.TraceStep) string {
+	for _, step := range trace {
+		if reason := strings.TrimSpace(step.Reason); reason != "" {
+			return reason
+		}
+	}
+	return strings.TrimSpace(legacy)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/core/audit/dual_emit_test.go
+++ b/core/audit/dual_emit_test.go
@@ -1,0 +1,90 @@
+package audit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUnifiedDecisionMode(t *testing.T) {
+	require.Equal(t, UnifiedDecisionModeDual, ParseUnifiedDecisionMode(""))
+	require.Equal(t, UnifiedDecisionModeDual, ParseUnifiedDecisionMode("DUAL"))
+	require.Equal(t, UnifiedDecisionModeLegacy, ParseUnifiedDecisionMode("legacy"))
+	require.Equal(t, UnifiedDecisionModeUnified, ParseUnifiedDecisionMode(" unified "))
+	require.Equal(t, UnifiedDecisionModeDual, ParseUnifiedDecisionMode("bogus"))
+}
+
+func TestUnifiedDecisionModeFromEnvDefaultsInvalidValues(t *testing.T) {
+	t.Setenv(EnvUnifiedDecisionMode, "definitely-invalid")
+
+	require.Equal(t, UnifiedDecisionModeDual, UnifiedDecisionModeFromEnv())
+}
+
+func TestDecisionEventsForMode(t *testing.T) {
+	legacy := SIEMEvent{
+		Timestamp:     time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		EventType:     EventSafetyDecision,
+		Severity:      SeverityHigh,
+		TenantID:      "tenant-acme",
+		JobID:         "job-123",
+		Action:        "submit_denied",
+		Decision:      "deny",
+		MatchedRule:   "legacy-rule",
+		Reason:        "legacy deny",
+		PolicyVersion: "legacy-snap",
+	}
+	decision := policy.Decision{
+		Source:        policy.DecisionSourceJob,
+		RuleID:        "unified-rule",
+		BundleID:      "bundle-main",
+		BundleVersion: "v7",
+		Type:          policy.DecisionDeny,
+		InputRef:      "blob://input",
+		AuditHash:     "sha256:audit",
+		Timestamp:     legacy.Timestamp,
+	}
+
+	cases := []struct {
+		name      string
+		mode      UnifiedDecisionMode
+		wantTypes []string
+	}{
+		{"dual", UnifiedDecisionModeDual, []string{EventSafetyDecision, EventPolicyDecisionV2}},
+		{"legacy", UnifiedDecisionModeLegacy, []string{EventSafetyDecision}},
+		{"unified", UnifiedDecisionModeUnified, []string{EventPolicyDecisionV2}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecisionEventsForMode(tc.mode, legacy, decision)
+			require.NoError(t, err)
+			require.Len(t, got, len(tc.wantTypes))
+			for i, wantType := range tc.wantTypes {
+				require.Equal(t, wantType, got[i].EventType)
+			}
+			if tc.mode != UnifiedDecisionModeLegacy {
+				v2 := got[len(got)-1]
+				require.Equal(t, "deny", v2.Decision)
+				require.Equal(t, "unified-rule", v2.MatchedRule)
+				require.Equal(t, "v7", v2.PolicyVersion)
+				require.Equal(t, "job", v2.Extra["source"])
+				require.Equal(t, "bundle-main", v2.Extra["bundle_id"])
+				require.Equal(t, "sha256:audit", v2.Extra["audit_hash"])
+			}
+		})
+	}
+}
+
+func TestDecisionEventsForModeRequiresLegacyAndUnifiedInputs(t *testing.T) {
+	_, err := DecisionEventsForMode(UnifiedDecisionModeDual, SIEMEvent{}, policy.Decision{})
+	require.ErrorContains(t, err, "legacy event")
+
+	_, err = DecisionEventsForMode(
+		UnifiedDecisionModeUnified,
+		SIEMEvent{TenantID: "tenant-acme", EventType: EventSafetyDecision},
+		policy.Decision{},
+	)
+	require.ErrorContains(t, err, "policy decision")
+}

--- a/core/controlplane/gateway/handlers_policy_bundles.go
+++ b/core/controlplane/gateway/handlers_policy_bundles.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cordum/cordum/core/audit"
 	"github.com/cordum/cordum/core/configsvc"
 	"github.com/cordum/cordum/core/controlplane/gateway/auth"
 	"github.com/cordum/cordum/core/controlplane/gateway/packs"
@@ -1269,7 +1270,14 @@ func (s *server) appendPolicyAudit(ctx context.Context, entry policybundles.Poli
 
 	// Fan-out to SIEM exporter (non-blocking) after persistence.
 	if s.auditExporter != nil {
-		s.auditExporter.Send(policybundles.AuditEntryToSIEM(entry, s.tenant))
+		events, err := policybundles.AuditEntryToSIEMEvents(entry, s.tenant, audit.UnifiedDecisionModeFromEnv())
+		if err != nil {
+			slog.Warn("policy audit SIEM dual emission failed; falling back to legacy event", "error", err)
+			events = []audit.SIEMEvent{policybundles.AuditEntryToSIEM(entry, s.tenant)}
+		}
+		for _, event := range events {
+			s.auditExporter.Send(event)
+		}
 	}
 
 	return nil

--- a/core/controlplane/gateway/policybundles/audit.go
+++ b/core/controlplane/gateway/policybundles/audit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cordum/cordum/core/audit"
 	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/policy"
 )
 
 // AuditEntryToSIEM converts a PolicyAuditEntry to a SIEM-compatible event.
@@ -65,6 +66,61 @@ func AuditEntryToSIEM(entry PolicyAuditEntry, tenantID string) audit.SIEMEvent {
 		Identity:      entry.ActorID,
 		Reason:        firstNonEmpty(strings.TrimSpace(entry.Reason), strings.TrimSpace(entry.Message)),
 		Extra:         extra,
+	}
+}
+
+// AuditEntryToSIEMEvents converts policy-audit entries into transition-window
+// SIEM events. Job safety decisions can dual-write legacy + unified v2 shapes.
+func AuditEntryToSIEMEvents(
+	entry PolicyAuditEntry,
+	tenantID string,
+	mode audit.UnifiedDecisionMode,
+) ([]audit.SIEMEvent, error) {
+	legacy := AuditEntryToSIEM(entry, tenantID)
+	if legacy.EventType != audit.EventSafetyDecision {
+		return []audit.SIEMEvent{legacy}, nil
+	}
+	decision := unifiedDecisionFromSIEM(legacy)
+	if decision.RuleID == "" {
+		return []audit.SIEMEvent{legacy}, nil
+	}
+	return audit.DecisionEventsForMode(mode, legacy, decision)
+}
+
+func unifiedDecisionFromSIEM(event audit.SIEMEvent) policy.Decision {
+	return policy.Decision{
+		Source:        policy.DecisionSourceJob,
+		RuleID:        strings.TrimSpace(event.MatchedRule),
+		BundleID:      strings.TrimSpace(event.Extra["bundle_id"]),
+		BundleVersion: strings.TrimSpace(event.PolicyVersion),
+		Type:          unifiedDecisionType(event.Decision),
+		AuditHash:     strings.TrimSpace(event.EventHash),
+		Timestamp:     event.Timestamp,
+		Trace: []policy.TraceStep{{
+			RuleID:       strings.TrimSpace(event.MatchedRule),
+			DecisionType: unifiedDecisionType(event.Decision),
+			Reason:       strings.TrimSpace(event.Reason),
+			Timestamp:    event.Timestamp,
+		}},
+	}
+}
+
+func unifiedDecisionType(decision string) policy.DecisionType {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "deny", "block":
+		return policy.DecisionDeny
+	case "require_approval", "require_human":
+		return policy.DecisionRequireHuman
+	case "throttle":
+		return policy.DecisionThrottle
+	case "constrain", "allow_with_constraints":
+		return policy.DecisionAllowWithConstraints
+	case "quarantine":
+		return policy.DecisionQuarantine
+	case "redact":
+		return policy.DecisionRedact
+	default:
+		return policy.DecisionAllow
 	}
 }
 

--- a/core/controlplane/gateway/policybundles/audit_test.go
+++ b/core/controlplane/gateway/policybundles/audit_test.go
@@ -1,0 +1,80 @@
+package policybundles
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditEntryToSIEMEventsDecisionModes(t *testing.T) {
+	entry := PolicyAuditEntry{
+		Action:        "submit",
+		ResourceType:  "job",
+		ResourceID:    "job-123",
+		ResourceName:  "job.topic",
+		ActorID:       "principal-1",
+		Decision:      "deny",
+		MatchedRule:   "rule-1",
+		PolicyVersion: "snap-1",
+		Reason:        "blocked by rule",
+		Extra:         map[string]string{"bundle_id": "bundle-main"},
+		CreatedAt:     "2026-05-09T12:00:00Z",
+	}
+
+	cases := []struct {
+		name      string
+		mode      audit.UnifiedDecisionMode
+		wantTypes []string
+	}{
+		{"dual", audit.UnifiedDecisionModeDual, []string{audit.EventSafetyDecision, audit.EventPolicyDecisionV2}},
+		{"legacy", audit.UnifiedDecisionModeLegacy, []string{audit.EventSafetyDecision}},
+		{"unified", audit.UnifiedDecisionModeUnified, []string{audit.EventPolicyDecisionV2}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AuditEntryToSIEMEvents(entry, "tenant-acme", tc.mode)
+			require.NoError(t, err)
+			require.Len(t, got, len(tc.wantTypes))
+			for i, wantType := range tc.wantTypes {
+				require.Equal(t, wantType, got[i].EventType)
+			}
+
+			if tc.mode == audit.UnifiedDecisionModeLegacy {
+				return
+			}
+			v2 := got[len(got)-1]
+			require.Equal(t, "tenant-acme", v2.TenantID)
+			require.Equal(t, "job-123", v2.Extra["resource_id"])
+			require.Equal(t, "deny", v2.Decision)
+			require.Equal(t, "rule-1", v2.MatchedRule)
+			require.Equal(t, "snap-1", v2.PolicyVersion)
+			require.Equal(t, "job", v2.Extra["source"])
+			require.Equal(t, "bundle-main", v2.Extra["bundle_id"])
+			require.Equal(t, "snap-1", v2.Extra["bundle_version"])
+			require.Equal(t, "blocked by rule", v2.Reason)
+			require.Equal(t, time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC), v2.Timestamp)
+		})
+	}
+}
+
+func TestAuditEntryToSIEMEventsSkipsUnifiedForNonSafetyOrNoRule(t *testing.T) {
+	changeEvent, err := AuditEntryToSIEMEvents(PolicyAuditEntry{
+		Action:    "publish",
+		CreatedAt: "2026-05-09T12:00:00Z",
+	}, "tenant-acme", audit.UnifiedDecisionModeDual)
+	require.NoError(t, err)
+	require.Len(t, changeEvent, 1)
+	require.Equal(t, audit.EventPolicyChange, changeEvent[0].EventType)
+
+	noRuleEvent, err := AuditEntryToSIEMEvents(PolicyAuditEntry{
+		Action:    "submit",
+		Decision:  "allow",
+		CreatedAt: "2026-05-09T12:00:00Z",
+	}, "tenant-acme", audit.UnifiedDecisionModeUnified)
+	require.NoError(t, err)
+	require.Len(t, noRuleEvent, 1)
+	require.Equal(t, audit.EventSafetyDecision, noRuleEvent[0].EventType)
+}

--- a/core/controlplane/safetykernel/decision_emitter.go
+++ b/core/controlplane/safetykernel/decision_emitter.go
@@ -1,0 +1,68 @@
+package safetykernel
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+)
+
+// BundleBinding identifies the bundle snapshot that supplied a rule.
+type BundleBinding struct {
+	BundleID      string
+	BundleVersion string
+}
+
+type bundleBindingContextKey struct{}
+
+// WithBundleBinding attaches optional bundle metadata to decision emission.
+func WithBundleBinding(ctx context.Context, binding BundleBinding) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, bundleBindingContextKey{}, sanitizeBundleBinding(binding))
+}
+
+// EmitDecision builds a unified, job-sourced policy.Decision.
+func EmitDecision(
+	ctx context.Context,
+	rule policy.Rule,
+	decisionType policy.DecisionType,
+	trace []policy.TraceStep,
+	inputRef string,
+	outputRef string,
+	auditHash string,
+) policy.Decision {
+	binding := bundleBindingFromContext(ctx)
+	return policy.Decision{
+		Source:        policy.DecisionSourceJob,
+		RuleID:        strings.TrimSpace(rule.ID),
+		BundleID:      binding.BundleID,
+		BundleVersion: binding.BundleVersion,
+		Type:          decisionType,
+		Trace:         append([]policy.TraceStep{}, trace...),
+		InputRef:      strings.TrimSpace(inputRef),
+		OutputRef:     strings.TrimSpace(outputRef),
+		AuditHash:     strings.TrimSpace(auditHash),
+		Timestamp:     time.Now().UTC(),
+	}
+}
+
+func bundleBindingFromContext(ctx context.Context) BundleBinding {
+	if ctx == nil {
+		return BundleBinding{}
+	}
+	binding, ok := ctx.Value(bundleBindingContextKey{}).(BundleBinding)
+	if !ok {
+		return BundleBinding{}
+	}
+	return sanitizeBundleBinding(binding)
+}
+
+func sanitizeBundleBinding(binding BundleBinding) BundleBinding {
+	return BundleBinding{
+		BundleID:      strings.TrimSpace(binding.BundleID),
+		BundleVersion: strings.TrimSpace(binding.BundleVersion),
+	}
+}

--- a/core/controlplane/safetykernel/decision_emitter_test.go
+++ b/core/controlplane/safetykernel/decision_emitter_test.go
@@ -1,0 +1,114 @@
+package safetykernel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cordum/cordum/core/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmitDecisionBuildsUnifiedDecisionForEveryDecisionType(t *testing.T) {
+	types := []policy.DecisionType{
+		policy.DecisionAllow,
+		policy.DecisionDeny,
+		policy.DecisionRequireHuman,
+		policy.DecisionThrottle,
+		policy.DecisionAllowWithConstraints,
+		policy.DecisionQuarantine,
+		policy.DecisionRedact,
+	}
+
+	for _, decisionType := range types {
+		t.Run(decisionType.String(), func(t *testing.T) {
+			ctx := WithBundleBinding(context.Background(), BundleBinding{
+				BundleID:      "bundle-main",
+				BundleVersion: "v3",
+			})
+			rule := policy.Rule{ID: "rule-" + decisionType.String(), Type: policy.RuleTypeInput}
+			trace := []policy.TraceStep{{
+				RuleID:       rule.ID,
+				DecisionType: decisionType,
+				Reason:       "matched",
+			}}
+
+			got := EmitDecision(ctx, rule, decisionType, trace, "blob://input", "blob://output", "sha256:audit")
+
+			require.Equal(t, policy.DecisionSourceJob, got.Source)
+			require.Equal(t, rule.ID, got.RuleID)
+			require.Equal(t, "bundle-main", got.BundleID)
+			require.Equal(t, "v3", got.BundleVersion)
+			require.Equal(t, decisionType, got.Type)
+			require.Equal(t, trace, got.Trace)
+			require.Equal(t, "blob://input", got.InputRef)
+			require.Equal(t, "blob://output", got.OutputRef)
+			require.Equal(t, "sha256:audit", got.AuditHash)
+			require.False(t, got.Timestamp.IsZero())
+			require.Equal(t, got.Timestamp.UTC(), got.Timestamp)
+		})
+	}
+}
+
+func TestEmitDecisionMissingBundleBindingUsesEmptyFields(t *testing.T) {
+	got := EmitDecision(
+		context.Background(),
+		policy.Rule{ID: "rule-no-binding", Type: policy.RuleTypeInput},
+		policy.DecisionAllow,
+		nil,
+		"",
+		"",
+		"",
+	)
+
+	require.Equal(t, "rule-no-binding", got.RuleID)
+	require.Empty(t, got.BundleID)
+	require.Empty(t, got.BundleVersion)
+	require.Equal(t, policy.DecisionAllow, got.Type)
+}
+
+func TestWithBundleBindingAcceptsNilContext(t *testing.T) {
+	//nolint:staticcheck // SA1012: deliberate nil context to exercise the default branch.
+	ctx := WithBundleBinding(nil, BundleBinding{BundleID: " bundle ", BundleVersion: " v1 "})
+	require.NotNil(t, ctx)
+
+	got := EmitDecision(ctx, policy.Rule{ID: "r-nil-ctx", Type: policy.RuleTypeInput}, policy.DecisionAllow, nil, "", "", "")
+	require.Equal(t, "bundle", got.BundleID)
+	require.Equal(t, "v1", got.BundleVersion)
+}
+
+func TestBundleBindingFromContextIgnoresWrongType(t *testing.T) {
+	type otherKey struct{}
+	ctx := context.WithValue(context.Background(), otherKey{}, "not-a-binding")
+
+	got := EmitDecision(ctx, policy.Rule{ID: "r-other", Type: policy.RuleTypeInput}, policy.DecisionAllow, nil, "", "", "")
+	require.Empty(t, got.BundleID)
+	require.Empty(t, got.BundleVersion)
+}
+
+func TestBundleBindingFromContextHandlesNil(t *testing.T) {
+	//nolint:staticcheck // SA1012: deliberate nil context to exercise the default branch.
+	got := EmitDecision(nil, policy.Rule{ID: "r-nil"}, policy.DecisionAllow, nil, "", "", "")
+	require.Empty(t, got.BundleID)
+	require.Empty(t, got.BundleVersion)
+}
+
+func TestEmitDecisionIsConcurrentSafe(t *testing.T) {
+	ctx := WithBundleBinding(context.Background(), BundleBinding{BundleID: "bundle", BundleVersion: "v1"})
+	rule := policy.Rule{ID: "rule-concurrent", Type: policy.RuleTypeInput}
+	errCh := make(chan error, 32)
+
+	for i := 0; i < cap(errCh); i++ {
+		go func() {
+			got := EmitDecision(ctx, rule, policy.DecisionDeny, nil, "", "", "")
+			if got.Source != policy.DecisionSourceJob || got.RuleID != rule.ID || got.Type != policy.DecisionDeny {
+				errCh <- context.Canceled
+				return
+			}
+			errCh <- nil
+		}()
+	}
+
+	for i := 0; i < cap(errCh); i++ {
+		require.NoError(t, <-errCh)
+	}
+}

--- a/core/controlplane/safetykernel/kernel_unified_helpers_test.go
+++ b/core/controlplane/safetykernel/kernel_unified_helpers_test.go
@@ -1,0 +1,128 @@
+package safetykernel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInputDecisionTypesTable(t *testing.T) {
+	cases := []struct {
+		raw         string
+		wantPB      pb.DecisionType
+		wantUnified policy.DecisionType
+	}{
+		{"deny", pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionDeny},
+		{"require_approval", pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN, policy.DecisionRequireHuman},
+		{"require-approval", pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN, policy.DecisionRequireHuman},
+		{"require_human", pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN, policy.DecisionRequireHuman},
+		{"unknown", pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionDeny},
+		{"", pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionDeny},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("input=%q", tc.raw), func(t *testing.T) {
+			gotPB, gotUnified := inputDecisionTypes(tc.raw)
+			require.Equal(t, tc.wantPB, gotPB)
+			require.Equal(t, tc.wantUnified, gotUnified)
+		})
+	}
+}
+
+func TestOutputDecisionTypesTable(t *testing.T) {
+	cases := []struct {
+		raw         pb.OutputDecision
+		wantPB      pb.DecisionType
+		wantUnified policy.DecisionType
+	}{
+		{pb.OutputDecision_OUTPUT_DECISION_REDACT, pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionRedact},
+		{pb.OutputDecision_OUTPUT_DECISION_QUARANTINE, pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionQuarantine},
+		{pb.OutputDecision_OUTPUT_DECISION_ALLOW, pb.DecisionType_DECISION_TYPE_ALLOW, policy.DecisionAllow},
+		{pb.OutputDecision(99), pb.DecisionType_DECISION_TYPE_ALLOW, policy.DecisionAllow},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw.String(), func(t *testing.T) {
+			gotPB, gotUnified := outputDecisionTypes(tc.raw)
+			require.Equal(t, tc.wantPB, gotPB)
+			require.Equal(t, tc.wantUnified, gotUnified)
+		})
+	}
+}
+
+func TestUnifiedDecisionFromLegacyTable(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want policy.DecisionType
+	}{
+		{"deny", policy.DecisionDeny},
+		{"require_approval", policy.DecisionRequireHuman},
+		{"require_human", policy.DecisionRequireHuman},
+		{"throttle", policy.DecisionThrottle},
+		{"allow_with_constraints", policy.DecisionAllowWithConstraints},
+		{"allow", policy.DecisionAllow},
+		{"", policy.DecisionAllow},
+		{"garbage", policy.DecisionAllow},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("legacy=%q", tc.raw), func(t *testing.T) {
+			require.Equal(t, tc.want, unifiedDecisionFromLegacy(tc.raw))
+		})
+	}
+}
+
+func TestResponseFromPolicyDecisionTable(t *testing.T) {
+	cases := []struct {
+		decision config.PolicyDecision
+		wantPB   pb.DecisionType
+		wantRule string
+	}{
+		{config.PolicyDecision{Decision: "deny", Reason: "blocked", RuleID: "r1"}, pb.DecisionType_DECISION_TYPE_DENY, "r1"},
+		{config.PolicyDecision{Decision: "require_approval", Reason: "ask"}, pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN, ""},
+		{config.PolicyDecision{Decision: "throttle", Reason: "rate"}, pb.DecisionType_DECISION_TYPE_THROTTLE, ""},
+		{config.PolicyDecision{Decision: "allow_with_constraints"}, pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS, ""},
+		{config.PolicyDecision{Decision: "allow"}, pb.DecisionType_DECISION_TYPE_ALLOW, ""},
+		{config.PolicyDecision{Decision: ""}, pb.DecisionType_DECISION_TYPE_ALLOW, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.decision.Decision, func(t *testing.T) {
+			resp := responseFromPolicyDecision(tc.decision)
+			require.Equal(t, tc.wantPB, resp.GetDecision())
+			require.Equal(t, tc.wantRule, resp.GetRuleId())
+		})
+	}
+}
+
+func TestPolicyInputFromRequestPropagatesFields(t *testing.T) {
+	req := &pb.PolicyCheckRequest{
+		Tenant: "tenant-acme",
+		Topic:  "job.acme.velocity",
+		Labels: map[string]string{"session_id": "sess-1", "actor_type": "service"},
+	}
+	got := policyInputFromRequest(req)
+	require.Equal(t, "tenant-acme", got.Tenant)
+	require.Equal(t, "job.acme.velocity", got.Topic)
+	require.Equal(t, "service", got.Labels["actor_type"])
+}
+
+func TestOutputEvalRequestFromPolicyDereferencesContent(t *testing.T) {
+	req := &pb.PolicyCheckRequest{
+		JobId:            "job-out-deref",
+		Tenant:           "tenant-acme",
+		Topic:            "job.acme.evaluate",
+		InputContent:     []byte("payload"),
+		InputContentType: "application/json",
+		Labels:           map[string]string{"k": "v"},
+		InputSizeBytes:   42,
+	}
+	got := outputEvalRequestFromPolicy(req)
+	require.Equal(t, "job-out-deref", got.JobID)
+	require.Equal(t, "job.acme.evaluate", got.Topic)
+	require.Equal(t, "tenant-acme", got.Tenant)
+	require.Equal(t, []byte("payload"), got.OutputContent)
+	require.Equal(t, "application/json", got.ContentType)
+	require.Equal(t, int64(42), got.OutputSizeBytes)
+	require.Equal(t, "v", got.Labels["k"])
+}

--- a/core/controlplane/safetykernel/kernel_unified_test.go
+++ b/core/controlplane/safetykernel/kernel_unified_test.go
@@ -1,0 +1,241 @@
+package safetykernel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateRuleUnifiedInputPreservesLegacyDecisionAndEmitsUnifiedDecision(t *testing.T) {
+	srv := &server{
+		scanners: map[string]OutputScanner{},
+	}
+	rule := policy.Rule{
+		ID:    "unified-input-deny",
+		Type:  policy.RuleTypeInput,
+		Scope: policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-acme"},
+		Match: json.RawMessage(`{
+			"tenants":["tenant-acme"],
+			"topics":["job.acme.evaluate"],
+			"keywords":["blocked-token"],
+			"content_types":["text/plain"]
+		}`),
+		Decide: json.RawMessage(`{
+			"decision":"deny",
+			"reason":"blocked input token",
+			"severity":"high"
+		}`),
+	}
+	req := &pb.PolicyCheckRequest{
+		JobId:            "job-123",
+		Tenant:           "tenant-acme",
+		Topic:            "job.acme.evaluate",
+		InputContent:     []byte("contains blocked-token"),
+		InputContentType: "text/plain",
+	}
+
+	legacy, unified, err := srv.EvaluateRule(context.Background(), rule, req)
+
+	require.NoError(t, err)
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_DENY, legacy.GetDecision())
+	require.Equal(t, "blocked input token", legacy.GetReason())
+	require.Equal(t, "unified-input-deny", legacy.GetRuleId())
+	require.Equal(t, policy.DecisionSourceJob, unified.Source)
+	require.Equal(t, policy.DecisionDeny, unified.Type)
+	require.Equal(t, "unified-input-deny", unified.RuleID)
+	require.False(t, unified.Timestamp.IsZero())
+	require.NotEmpty(t, unified.Trace)
+	require.Equal(t, policy.DecisionDeny, unified.Trace[0].DecisionType)
+}
+
+func TestEvaluateRuleScopeMismatchEmitsAllow(t *testing.T) {
+	srv := &server{scanners: map[string]OutputScanner{}}
+	rule := policy.Rule{
+		ID:     "unified-input-other-tenant",
+		Type:   policy.RuleTypeInput,
+		Scope:  policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-other"},
+		Match:  json.RawMessage(`{"keywords":["blocked-token"]}`),
+		Decide: json.RawMessage(`{"decision":"deny","reason":"would deny"}`),
+	}
+	req := &pb.PolicyCheckRequest{
+		Tenant:           "tenant-acme",
+		Topic:            "job.acme.evaluate",
+		InputContent:     []byte("contains blocked-token"),
+		InputContentType: "text/plain",
+	}
+
+	legacy, unified, err := srv.EvaluateRule(context.Background(), rule, req)
+
+	require.NoError(t, err)
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_ALLOW, legacy.GetDecision())
+	require.Equal(t, "rule scope did not match job", legacy.GetReason())
+	require.Equal(t, policy.DecisionAllow, unified.Type)
+	require.NotEmpty(t, unified.Trace)
+}
+
+func TestEvaluateRuleNilRequestReturnsError(t *testing.T) {
+	srv := &server{scanners: map[string]OutputScanner{}}
+	rule := policy.Rule{ID: "r", Type: policy.RuleTypeInput}
+
+	_, _, err := srv.EvaluateRule(context.Background(), rule, nil)
+
+	require.ErrorContains(t, err, "missing policy check request")
+}
+
+func TestEvaluateRuleNilContextDefaults(t *testing.T) {
+	srv := &server{scanners: map[string]OutputScanner{}}
+	rule := policy.Rule{
+		ID:     "r-nil-ctx",
+		Type:   policy.RuleTypeInput,
+		Match:  json.RawMessage(`{"topics":["nope"]}`),
+		Decide: json.RawMessage(`{"decision":"deny","reason":"would deny"}`),
+	}
+	req := &pb.PolicyCheckRequest{Topic: "different"}
+
+	//nolint:staticcheck // SA1012: deliberate nil context to exercise the default branch.
+	legacy, _, err := srv.EvaluateRule(nil, rule, req)
+
+	require.NoError(t, err)
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_ALLOW, legacy.GetDecision())
+}
+
+func TestEvaluateRuleUnsupportedRuleTypeReturnsError(t *testing.T) {
+	srv := &server{scanners: map[string]OutputScanner{}}
+	rule := policy.Rule{
+		ID:     "r-unsup",
+		Type:   policy.RuleType("unknown"),
+		Match:  json.RawMessage(`{}`),
+		Decide: json.RawMessage(`{"decision":"deny"}`),
+	}
+	req := &pb.PolicyCheckRequest{Topic: "t"}
+
+	_, _, err := srv.EvaluateRule(context.Background(), rule, req)
+
+	require.ErrorContains(t, err, "unsupported unified rule type")
+}
+
+func TestEvaluateRuleUnifiedOutputRedactsAndEmitsUnifiedDecision(t *testing.T) {
+	srv := &server{scanners: map[string]OutputScanner{}}
+	rule := policy.Rule{
+		ID:     "unified-output-redact",
+		Type:   policy.RuleTypeOutput,
+		Scope:  policy.RuleScope{Kind: policy.RuleScopeGlobal},
+		Match:  json.RawMessage(`{"topics":["job.acme.evaluate"],"keywords":["secret"]}`),
+		Decide: json.RawMessage(`{"decision":"redact","reason":"redact secret","severity":"high"}`),
+	}
+	req := &pb.PolicyCheckRequest{
+		JobId:            "job-out-1",
+		Tenant:           "tenant-acme",
+		Topic:            "job.acme.evaluate",
+		InputContent:     []byte("contains a secret"),
+		InputContentType: "text/plain",
+	}
+
+	legacy, unified, err := srv.EvaluateRule(context.Background(), rule, req)
+
+	require.NoError(t, err)
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_DENY, legacy.GetDecision())
+	require.Equal(t, "redact secret", legacy.GetReason())
+	require.Equal(t, "unified-output-redact", legacy.GetRuleId())
+	require.Equal(t, policy.DecisionRedact, unified.Type)
+}
+
+func TestEvaluateRuleUnifiedOutputQuarantinesAndEmitsUnifiedDecision(t *testing.T) {
+	srv := &server{scanners: map[string]OutputScanner{}}
+	rule := policy.Rule{
+		ID:     "unified-output-quarantine",
+		Type:   policy.RuleTypeOutput,
+		Scope:  policy.RuleScope{Kind: policy.RuleScopeGlobal},
+		Match:  json.RawMessage(`{"topics":["job.acme.evaluate"],"keywords":["q-tag"]}`),
+		Decide: json.RawMessage(`{"decision":"quarantine","reason":"q-output","severity":"critical"}`),
+	}
+	req := &pb.PolicyCheckRequest{
+		JobId:            "job-out-2",
+		Tenant:           "tenant-acme",
+		Topic:            "job.acme.evaluate",
+		InputContent:     []byte("contains a q-tag"),
+		InputContentType: "text/plain",
+	}
+
+	legacy, unified, err := srv.EvaluateRule(context.Background(), rule, req)
+
+	require.NoError(t, err)
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_DENY, legacy.GetDecision())
+	require.Equal(t, policy.DecisionQuarantine, unified.Type)
+}
+
+func TestEvaluateRuleUnifiedOutputDoesNotMatchEmitsAllow(t *testing.T) {
+	srv := &server{scanners: map[string]OutputScanner{}}
+	rule := policy.Rule{
+		ID:     "unified-output-nomatch",
+		Type:   policy.RuleTypeOutput,
+		Scope:  policy.RuleScope{Kind: policy.RuleScopeGlobal},
+		Match:  json.RawMessage(`{"topics":["job.other"],"keywords":["secret"]}`),
+		Decide: json.RawMessage(`{"decision":"redact","reason":"would redact"}`),
+	}
+	req := &pb.PolicyCheckRequest{
+		Topic:            "job.acme.evaluate",
+		InputContent:     []byte("contains a secret"),
+		InputContentType: "text/plain",
+	}
+
+	legacy, unified, err := srv.EvaluateRule(context.Background(), rule, req)
+
+	require.NoError(t, err)
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_ALLOW, legacy.GetDecision())
+	require.Equal(t, "output rule did not match", legacy.GetReason())
+	require.Equal(t, policy.DecisionAllow, unified.Type)
+}
+
+func TestEvaluateRuleUnifiedVelocityThrottlesOnFourthCall(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	srv := &server{
+		resultClient:    client,
+		velocityChecker: newVelocityChecker(client),
+	}
+	rule := policy.Rule{
+		ID:    "unified-velocity-throttle",
+		Type:  policy.RuleTypeVelocity,
+		Scope: policy.RuleScope{Kind: policy.RuleScopeGlobal},
+		Match: json.RawMessage(`{"topics":["job.acme.velocity"]}`),
+		Decide: json.RawMessage(`{
+			"decision":"throttle",
+			"reason":"velocity throttled",
+			"velocity":{"max_requests":3,"window_seconds":60,"key":"labels.session_id"}
+		}`),
+	}
+
+	for i := 1; i <= 3; i++ {
+		req := &pb.PolicyCheckRequest{
+			JobId:  fmt.Sprintf("job-%d", i),
+			Topic:  "job.acme.velocity",
+			Tenant: "tenant-acme",
+			Labels: map[string]string{"session_id": "sess-1"},
+		}
+		legacy, _, err := srv.EvaluateRule(context.Background(), rule, req)
+		require.NoError(t, err)
+		require.Equal(t, pb.DecisionType_DECISION_TYPE_ALLOW, legacy.GetDecision(), "call %d should allow", i)
+	}
+
+	throttledReq := &pb.PolicyCheckRequest{
+		JobId:  "job-4",
+		Topic:  "job.acme.velocity",
+		Tenant: "tenant-acme",
+		Labels: map[string]string{"session_id": "sess-1"},
+	}
+	legacy, unified, err := srv.EvaluateRule(context.Background(), rule, throttledReq)
+
+	require.NoError(t, err)
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_THROTTLE, legacy.GetDecision())
+	require.Equal(t, policy.DecisionThrottle, unified.Type)
+	require.NotEmpty(t, unified.Trace)
+}

--- a/core/controlplane/safetykernel/policy_adapter.go
+++ b/core/controlplane/safetykernel/policy_adapter.go
@@ -1,0 +1,234 @@
+package safetykernel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// JobContext carries job-side scope fields used by unified Rule envelopes.
+type JobContext struct {
+	Tenant     string
+	WorkflowID string
+	JobID      string
+}
+
+// RuleToCompiledInput adapts a unified input Rule into the existing matcher.
+func RuleToCompiledInput(rule policy.Rule) (compiledInputRule, error) {
+	if rule.Type != policy.RuleTypeInput {
+		return compiledInputRule{}, ruleTypeError(rule.Type, policy.RuleTypeInput)
+	}
+	match, err := decodeInputMatch(rule.Match)
+	if err != nil {
+		return compiledInputRule{}, err
+	}
+	decide, err := decodeRuleDecision(rule.Decide)
+	if err != nil {
+		return compiledInputRule{}, err
+	}
+	decision, ok := normalizeInputDecision(decide.Decision)
+	if !ok {
+		return compiledInputRule{}, fmt.Errorf("unsupported input decision %q", decide.Decision)
+	}
+	return buildCompiledInput(rule, match, decide, decision)
+}
+
+// RuleToCompiledOutput adapts a unified output Rule into the existing matcher.
+func RuleToCompiledOutput(rule policy.Rule) (compiledOutputRule, error) {
+	if rule.Type != policy.RuleTypeOutput {
+		return compiledOutputRule{}, ruleTypeError(rule.Type, policy.RuleTypeOutput)
+	}
+	match, err := decodeOutputMatch(rule.Match)
+	if err != nil {
+		return compiledOutputRule{}, err
+	}
+	decide, err := decodeRuleDecision(rule.Decide)
+	if err != nil {
+		return compiledOutputRule{}, err
+	}
+	decision, ok := parseOutputDecision(decide.Decision)
+	if !ok {
+		return compiledOutputRule{}, fmt.Errorf("unsupported output decision %q", decide.Decision)
+	}
+	return buildCompiledOutput(rule, match, decide, decision)
+}
+
+// RuleToCompiledVelocity adapts a unified velocity Rule into legacy PolicyRule.
+func RuleToCompiledVelocity(rule policy.Rule) (config.PolicyRule, error) {
+	if rule.Type != policy.RuleTypeVelocity {
+		return config.PolicyRule{}, ruleTypeError(rule.Type, policy.RuleTypeVelocity)
+	}
+	match, err := decodeVelocityMatch(rule.Match)
+	if err != nil {
+		return config.PolicyRule{}, err
+	}
+	decide, err := decodeRuleDecision(rule.Decide)
+	if err != nil {
+		return config.PolicyRule{}, err
+	}
+	if decide.Velocity == nil {
+		return config.PolicyRule{}, fmt.Errorf("missing velocity config")
+	}
+	if err := decide.Velocity.Validate(strings.TrimSpace(rule.ID)); err != nil {
+		return config.PolicyRule{}, err
+	}
+	return buildVelocityRule(rule, match, decide), nil
+}
+
+// RuleScopeMatchesJob reports whether a unified job-side scope includes a job.
+func RuleScopeMatchesJob(scope policy.RuleScope, job JobContext) bool {
+	value := strings.TrimSpace(scope.Value)
+	switch scope.Kind {
+	case "", policy.RuleScopeGlobal:
+		return true
+	case policy.RuleScopeTenant:
+		return value != "" && value == strings.TrimSpace(job.Tenant)
+	case policy.RuleScopeWorkflow:
+		return value != "" && value == strings.TrimSpace(job.WorkflowID)
+	case policy.RuleScopeEdgeFleet, policy.RuleScopeEdgeUser:
+		return false
+	default:
+		return false
+	}
+}
+
+func buildCompiledInput(rule policy.Rule, match inputRuleMatchWire, decide ruleDecisionWire, decision string) (compiledInputRule, error) {
+	patterns, err := compilePolicyPatterns(rule.ID, match.ContentPatterns)
+	if err != nil {
+		return compiledInputRule{}, err
+	}
+	if match.Scope != nil {
+		if err := validateScopeConfig(match.Scope); err != nil {
+			return compiledInputRule{}, fmt.Errorf("invalid input scope: %w", err)
+		}
+	}
+	maxBytes := maxPositive(match.MaxInputBytes, match.InputSizeGt)
+	tier, selector := legacyTierSelector(rule.Scope)
+	return compiledInputRule{
+		id:           strings.TrimSpace(rule.ID),
+		tier:         tier,
+		selector:     selector,
+		decision:     decision,
+		reason:       strings.TrimSpace(decide.Reason),
+		severity:     normalizeSeverity(decide.Severity),
+		tenants:      normalizeList(match.Tenants),
+		topics:       normalizeList(match.Topics),
+		capabilities: normalizeList(match.Capabilities),
+		riskTags:     normalizeList(match.RiskTags),
+		contentTypes: normalizeList(match.ContentTypes),
+		scanners:     mergeScannerLists(match.Scanners, match.Detectors),
+		patterns:     patterns,
+		keywords:     normalizeList(match.Keywords),
+		maxBytes:     maxBytes,
+		scope:        match.Scope,
+	}, nil
+}
+
+func buildCompiledOutput(rule policy.Rule, match outputRuleMatchWire, decide ruleDecisionWire, decision pb.OutputDecision) (compiledOutputRule, error) {
+	patterns, err := compilePolicyPatterns(rule.ID, match.ContentPatterns)
+	if err != nil {
+		return compiledOutputRule{}, err
+	}
+	return compiledOutputRule{
+		id:             strings.TrimSpace(rule.ID),
+		decision:       decision,
+		reason:         strings.TrimSpace(decide.Reason),
+		severity:       normalizeSeverity(decide.Severity),
+		tenants:        normalizeList(match.Tenants),
+		topics:         normalizeList(match.Topics),
+		capabilities:   normalizeList(match.Capabilities),
+		riskTags:       normalizeList(match.RiskTags),
+		contentTypes:   normalizeList(match.ContentTypes),
+		scanners:       mergeScannerLists(match.Scanners, match.Detectors),
+		patterns:       patterns,
+		keywords:       normalizeList(match.Keywords),
+		maxOutputBytes: maxPositive(match.MaxOutputBytes, match.OutputSizeGt),
+		hasError:       match.HasError,
+	}, nil
+}
+
+func buildVelocityRule(rule policy.Rule, match velocityRuleMatchWire, decide ruleDecisionWire) config.PolicyRule {
+	tier, selector := legacyTierSelector(rule.Scope)
+	return config.PolicyRule{
+		ID:          strings.TrimSpace(rule.ID),
+		Tier:        tier,
+		Selector:    selector,
+		Match:       legacyPolicyMatch(match),
+		Velocity:    decide.Velocity,
+		Decision:    normalizeVelocityDecision(decide.Decision),
+		Reason:      strings.TrimSpace(decide.Reason),
+		Constraints: decide.Constraints,
+	}
+}
+
+func ruleTypeError(got, want policy.RuleType) error {
+	return fmt.Errorf("rule type mismatch: got %q want %q", got, want)
+}
+
+func normalizeInputDecision(raw string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "deny":
+		return "deny", true
+	case "require_approval", "require-approval", "require_human":
+		return "require_approval", true
+	default:
+		return "", false
+	}
+}
+
+func normalizeVelocityDecision(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "throttle":
+		return "throttle"
+	case "deny", "block":
+		return "deny"
+	case "require_approval", "require-approval", "require_human":
+		return "require_approval"
+	case "allow_with_constraints", "allow-with-constraints":
+		return "allow_with_constraints"
+	default:
+		return "throttle"
+	}
+}
+
+func legacyTierSelector(scope policy.RuleScope) (string, config.PolicySelector) {
+	value := strings.TrimSpace(scope.Value)
+	switch scope.Kind {
+	case policy.RuleScopeWorkflow:
+		return config.PolicyTierWorkflow, config.PolicySelector{WorkflowID: value}
+	default:
+		return config.PolicyTierGlobal, config.PolicySelector{}
+	}
+}
+
+func legacyPolicyMatch(match velocityRuleMatchWire) config.PolicyMatch {
+	return config.PolicyMatch{
+		Tenants:                  normalizeList(match.Tenants),
+		Topics:                   normalizeList(match.Topics),
+		Capabilities:             normalizeList(match.Capabilities),
+		RiskTags:                 normalizeList(match.RiskTags),
+		Requires:                 normalizeList(match.Requires),
+		PackIDs:                  normalizeList(match.PackIDs),
+		ActorIDs:                 normalizeList(match.ActorIDs),
+		ActorTypes:               normalizeList(match.ActorTypes),
+		AgentRiskTiers:           normalizeList(match.AgentRiskTiers),
+		AgentDataClassifications: normalizeList(match.AgentDataClassifications),
+		Labels:                   match.Labels,
+		LabelAllowlist:           match.LabelAllowlist,
+		LabelThreshold:           match.LabelThreshold,
+		SecretsPresent:           match.SecretsPresent,
+		Predicate:                strings.TrimSpace(match.Predicate),
+		Delegation:               match.Delegation,
+		MCP:                      match.MCP,
+	}
+}
+
+func maxPositive(a, b int64) int64 {
+	if b > a {
+		return b
+	}
+	return a
+}

--- a/core/controlplane/safetykernel/policy_adapter_test.go
+++ b/core/controlplane/safetykernel/policy_adapter_test.go
@@ -1,0 +1,314 @@
+package safetykernel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cordum/cordum/core/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuleToCompiledInput(t *testing.T) {
+	rule := policy.Rule{
+		ID:    "input-secret",
+		Type:  policy.RuleTypeInput,
+		Scope: policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-acme"},
+		Match: json.RawMessage(`{
+			"tenants":["tenant-acme"],
+			"topics":["job.acme.*"],
+			"capabilities":["llm.request"],
+			"risk_tags":["secret"],
+			"content_types":["text/plain"],
+			"keywords":["OPENAI_API_KEY"],
+			"input_size_gt":128
+		}`),
+		Decide: json.RawMessage(`{
+			"decision":"deny",
+			"reason":"secret in prompt",
+			"severity":"critical"
+		}`),
+	}
+
+	compiled, err := RuleToCompiledInput(rule)
+	require.NoError(t, err)
+	require.Equal(t, "input-secret", compiled.id)
+	require.Equal(t, "deny", compiled.decision)
+	require.Equal(t, "secret in prompt", compiled.reason)
+	require.Equal(t, "critical", compiled.severity)
+	require.Equal(t, []string{"tenant-acme"}, compiled.tenants)
+	require.Equal(t, []string{"job.acme.*"}, compiled.topics)
+	require.Equal(t, []string{"llm.request"}, compiled.capabilities)
+	require.Equal(t, []string{"secret"}, compiled.riskTags)
+	require.Equal(t, []string{"text/plain"}, compiled.contentTypes)
+	require.Equal(t, []string{"OPENAI_API_KEY"}, compiled.keywords)
+	require.Equal(t, int64(128), compiled.maxBytes)
+	require.True(t, RuleScopeMatchesJob(rule.Scope, JobContext{Tenant: "tenant-acme"}))
+}
+
+func TestRuleToCompiledOutput(t *testing.T) {
+	hasError := false
+	rule := policy.Rule{
+		ID:    "output-pii",
+		Type:  policy.RuleTypeOutput,
+		Scope: policy.RuleScope{Kind: policy.RuleScopeGlobal},
+		Match: json.RawMessage(`{
+			"detectors":["pii"],
+			"content_types":["application/json"],
+			"output_size_gt":256,
+			"has_error":false
+		}`),
+		Decide: json.RawMessage(`{
+			"decision":"redact",
+			"reason":"pii in output",
+			"severity":"high"
+		}`),
+	}
+
+	compiled, err := RuleToCompiledOutput(rule)
+	require.NoError(t, err)
+	require.Equal(t, "output-pii", compiled.id)
+	require.Equal(t, "pii in output", compiled.reason)
+	require.Equal(t, "high", compiled.severity)
+	require.Equal(t, []string{"pii"}, compiled.scanners)
+	require.Equal(t, []string{"application/json"}, compiled.contentTypes)
+	require.Equal(t, int64(256), compiled.maxOutputBytes)
+	require.NotNil(t, compiled.hasError)
+	require.Equal(t, hasError, *compiled.hasError)
+	require.Equal(t, "redact", outputDecisionString(compiled.decision))
+}
+
+func TestRuleToCompiledVelocity(t *testing.T) {
+	rule := policy.Rule{
+		ID:    "velocity-session",
+		Type:  policy.RuleTypeVelocity,
+		Scope: policy.RuleScope{Kind: policy.RuleScopeWorkflow, Value: "wf-claims"},
+		Match: json.RawMessage(`{
+			"tenants":["tenant-acme"],
+			"topics":["job.claims.*"],
+			"labels":{"actor_type":"service"}
+		}`),
+		Decide: json.RawMessage(`{
+			"decision":"throttle",
+			"reason":"session rate limit",
+			"velocity":{"max_requests":3,"window_seconds":60,"key":"labels.session_id"}
+		}`),
+	}
+
+	legacy, err := RuleToCompiledVelocity(rule)
+	require.NoError(t, err)
+	require.Equal(t, "velocity-session", legacy.ID)
+	require.Equal(t, "throttle", legacy.Decision)
+	require.Equal(t, "session rate limit", legacy.Reason)
+	require.Equal(t, []string{"tenant-acme"}, legacy.Match.Tenants)
+	require.Equal(t, []string{"job.claims.*"}, legacy.Match.Topics)
+	require.Equal(t, map[string]string{"actor_type": "service"}, legacy.Match.Labels)
+	require.NotNil(t, legacy.Velocity)
+	require.Equal(t, 3, legacy.Velocity.MaxRequests)
+	require.Equal(t, 60, legacy.Velocity.WindowSeconds)
+	require.Equal(t, "labels.session_id", legacy.Velocity.Key)
+}
+
+func TestRuleToCompiledRejectsBadBoundaryInputs(t *testing.T) {
+	cases := []struct {
+		name    string
+		fn      func(policy.Rule) error
+		rule    policy.Rule
+		wantErr string
+	}{
+		{
+			name:    "input type mismatch",
+			fn:      func(r policy.Rule) error { _, err := RuleToCompiledInput(r); return err },
+			rule:    policy.Rule{ID: "r1", Type: policy.RuleTypeOutput, Match: json.RawMessage(`{}`), Decide: json.RawMessage(`{"decision":"deny"}`)},
+			wantErr: "rule type mismatch",
+		},
+		{
+			name:    "output missing match",
+			fn:      func(r policy.Rule) error { _, err := RuleToCompiledOutput(r); return err },
+			rule:    policy.Rule{ID: "r2", Type: policy.RuleTypeOutput, Decide: json.RawMessage(`{"decision":"redact"}`)},
+			wantErr: "missing rule match",
+		},
+		{
+			name:    "velocity corrupt match",
+			fn:      func(r policy.Rule) error { _, err := RuleToCompiledVelocity(r); return err },
+			rule:    policy.Rule{ID: "r3", Type: policy.RuleTypeVelocity, Match: json.RawMessage(`{"topics":`), Decide: json.RawMessage(`{"decision":"throttle"}`)},
+			wantErr: "decode rule match",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn(tc.rule)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestRuleScopeMatchesJobAcrossKinds(t *testing.T) {
+	job := JobContext{Tenant: "tenant-acme", WorkflowID: "wf-acme", JobID: "job-1"}
+	cases := []struct {
+		name  string
+		scope policy.RuleScope
+		want  bool
+	}{
+		{"empty kind allows", policy.RuleScope{}, true},
+		{"global allows", policy.RuleScope{Kind: policy.RuleScopeGlobal}, true},
+		{"tenant match", policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-acme"}, true},
+		{"tenant mismatch", policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-other"}, false},
+		{"tenant empty value", policy.RuleScope{Kind: policy.RuleScopeTenant, Value: ""}, false},
+		{"workflow match", policy.RuleScope{Kind: policy.RuleScopeWorkflow, Value: "wf-acme"}, true},
+		{"workflow mismatch", policy.RuleScope{Kind: policy.RuleScopeWorkflow, Value: "wf-other"}, false},
+		{"workflow empty value", policy.RuleScope{Kind: policy.RuleScopeWorkflow, Value: ""}, false},
+		{"edge fleet rejected", policy.RuleScope{Kind: policy.RuleScopeEdgeFleet, Value: "fleet-1"}, false},
+		{"edge user rejected", policy.RuleScope{Kind: policy.RuleScopeEdgeUser, Value: "user-1"}, false},
+		{"unknown kind rejected", policy.RuleScope{Kind: policy.RuleScopeKind("unsupported"), Value: "x"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, RuleScopeMatchesJob(tc.scope, job))
+		})
+	}
+}
+
+func TestNormalizeInputDecisionTable(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    string
+		wantOK  bool
+	}{
+		{"deny", "deny", true},
+		{" Deny ", "deny", true},
+		{"require_approval", "require_approval", true},
+		{"require-approval", "require_approval", true},
+		{"require_human", "require_approval", true},
+		{"throttle", "", false},
+		{"", "", false},
+		{"garbage", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, ok := normalizeInputDecision(tc.raw)
+			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.wantOK, ok)
+		})
+	}
+}
+
+func TestNormalizeVelocityDecisionTable(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"throttle", "throttle"},
+		{"deny", "deny"},
+		{"block", "deny"},
+		{"require_approval", "require_approval"},
+		{"require-approval", "require_approval"},
+		{"require_human", "require_approval"},
+		{"allow_with_constraints", "allow_with_constraints"},
+		{"allow-with-constraints", "allow_with_constraints"},
+		{"", "throttle"},
+		{"garbage", "throttle"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeVelocityDecision(tc.raw))
+		})
+	}
+}
+
+func TestCompilePolicyPatternsRejectsRedos(t *testing.T) {
+	_, err := compilePolicyPatterns("rule-redos", []string{"(.*)+"})
+	require.ErrorContains(t, err, "rule-redos")
+}
+
+func TestCompilePolicyPatternsRejectsInvalidRegex(t *testing.T) {
+	_, err := compilePolicyPatterns("rule-bad", []string{"["})
+	require.ErrorContains(t, err, "rule-bad")
+}
+
+func TestRuleToCompiledInputRejectsCorruptDecideAndUnsupportedDecision(t *testing.T) {
+	corrupt := policy.Rule{
+		ID:     "input-corrupt-decide",
+		Type:   policy.RuleTypeInput,
+		Match:  json.RawMessage(`{}`),
+		Decide: json.RawMessage(`{"decision":`),
+	}
+	_, err := RuleToCompiledInput(corrupt)
+	require.ErrorContains(t, err, "decode rule decision")
+
+	unsupported := policy.Rule{
+		ID:     "input-unsupported",
+		Type:   policy.RuleTypeInput,
+		Match:  json.RawMessage(`{}`),
+		Decide: json.RawMessage(`{"decision":"throttle"}`),
+	}
+	_, err = RuleToCompiledInput(unsupported)
+	require.ErrorContains(t, err, "unsupported input decision")
+}
+
+func TestRuleToCompiledOutputRejectsCorruptDecideAndUnsupportedDecision(t *testing.T) {
+	missingDecide := policy.Rule{
+		ID:    "output-missing-decide",
+		Type:  policy.RuleTypeOutput,
+		Match: json.RawMessage(`{}`),
+	}
+	_, err := RuleToCompiledOutput(missingDecide)
+	require.ErrorContains(t, err, "missing rule decision")
+
+	unsupported := policy.Rule{
+		ID:     "output-unsupported",
+		Type:   policy.RuleTypeOutput,
+		Match:  json.RawMessage(`{}`),
+		Decide: json.RawMessage(`{"decision":"throttle"}`),
+	}
+	_, err = RuleToCompiledOutput(unsupported)
+	require.ErrorContains(t, err, "unsupported output decision")
+}
+
+func TestRuleToCompiledVelocityRejectsMissingAndInvalidVelocity(t *testing.T) {
+	missingVelocity := policy.Rule{
+		ID:     "vel-missing",
+		Type:   policy.RuleTypeVelocity,
+		Match:  json.RawMessage(`{}`),
+		Decide: json.RawMessage(`{"decision":"throttle"}`),
+	}
+	_, err := RuleToCompiledVelocity(missingVelocity)
+	require.ErrorContains(t, err, "missing velocity config")
+
+	invalidVelocity := policy.Rule{
+		ID:     "vel-invalid",
+		Type:   policy.RuleTypeVelocity,
+		Match:  json.RawMessage(`{}`),
+		Decide: json.RawMessage(`{"decision":"throttle","velocity":{"max_requests":0,"window_seconds":60,"key":"k"}}`),
+	}
+	_, err = RuleToCompiledVelocity(invalidVelocity)
+	require.Error(t, err)
+
+	corruptDecide := policy.Rule{
+		ID:     "vel-corrupt-decide",
+		Type:   policy.RuleTypeVelocity,
+		Match:  json.RawMessage(`{}`),
+		Decide: json.RawMessage(`{"decision":`),
+	}
+	_, err = RuleToCompiledVelocity(corruptDecide)
+	require.ErrorContains(t, err, "decode rule decision")
+}
+
+func TestRuleToCompiledOutputRejectsBadPattern(t *testing.T) {
+	rule := policy.Rule{
+		ID:     "output-bad-pattern",
+		Type:   policy.RuleTypeOutput,
+		Match:  json.RawMessage(`{"content_patterns":["["]}`),
+		Decide: json.RawMessage(`{"decision":"redact"}`),
+	}
+	_, err := RuleToCompiledOutput(rule)
+	require.ErrorContains(t, err, "output-bad-pattern")
+}
+
+func TestCompilePolicyPatternsCompilesValid(t *testing.T) {
+	got, err := compilePolicyPatterns("rule-ok", []string{"  ", "secret-\\d+"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "secret-\\d+", got[0].raw)
+	require.True(t, got[0].re.MatchString("secret-12"))
+}

--- a/core/controlplane/safetykernel/policy_adapter_wire.go
+++ b/core/controlplane/safetykernel/policy_adapter_wire.go
@@ -1,0 +1,136 @@
+package safetykernel
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cordum/cordum/core/infra/config"
+)
+
+type ruleDecisionWire struct {
+	Decision    string                 `json:"decision"`
+	Reason      string                 `json:"reason"`
+	Severity    string                 `json:"severity"`
+	Velocity    *config.VelocityConfig `json:"velocity"`
+	Constraints config.PolicyConstraints
+}
+
+type inputRuleMatchWire struct {
+	Tenants         []string            `json:"tenants"`
+	Topics          []string            `json:"topics"`
+	Capabilities    []string            `json:"capabilities"`
+	RiskTags        []string            `json:"risk_tags"`
+	Scanners        []string            `json:"scanners"`
+	ContentPatterns []string            `json:"content_patterns"`
+	Keywords        []string            `json:"keywords"`
+	ContentTypes    []string            `json:"content_types"`
+	Detectors       []string            `json:"detectors"`
+	InputSizeGt     int64               `json:"input_size_gt"`
+	MaxInputBytes   int64               `json:"max_input_bytes"`
+	Scope           *config.ScopeConfig `json:"scope"`
+}
+
+type outputRuleMatchWire struct {
+	Tenants         []string `json:"tenants"`
+	Topics          []string `json:"topics"`
+	Capabilities    []string `json:"capabilities"`
+	RiskTags        []string `json:"risk_tags"`
+	Scanners        []string `json:"scanners"`
+	ContentPatterns []string `json:"content_patterns"`
+	Keywords        []string `json:"keywords"`
+	ContentTypes    []string `json:"content_types"`
+	Detectors       []string `json:"detectors"`
+	OutputSizeGt    int64    `json:"output_size_gt"`
+	MaxOutputBytes  int64    `json:"max_output_bytes"`
+	HasError        *bool    `json:"has_error"`
+}
+
+type velocityRuleMatchWire struct {
+	Tenants                  []string                `json:"tenants"`
+	Topics                   []string                `json:"topics"`
+	Capabilities             []string                `json:"capabilities"`
+	RiskTags                 []string                `json:"risk_tags"`
+	Requires                 []string                `json:"requires"`
+	PackIDs                  []string                `json:"pack_ids"`
+	ActorIDs                 []string                `json:"actor_ids"`
+	ActorTypes               []string                `json:"actor_types"`
+	AgentRiskTiers           []string                `json:"agent_risk_tiers"`
+	AgentDataClassifications []string                `json:"agent_data_classifications"`
+	Labels                   map[string]string       `json:"labels"`
+	LabelAllowlist           map[string][]string     `json:"label_allowlist"`
+	LabelThreshold           map[string]float64      `json:"label_threshold"`
+	SecretsPresent           *bool                   `json:"secrets_present"`
+	Predicate                string                  `json:"predicate"`
+	Delegation               *config.DelegationMatch `json:"delegation"`
+	MCP                      config.MCPPolicy        `json:"mcp"`
+}
+
+func compilePolicyPatterns(ruleID string, rawPatterns []string) ([]compiledOutputPattern, error) {
+	patterns := make([]compiledOutputPattern, 0, len(rawPatterns))
+	for _, raw := range rawPatterns {
+		pattern := strings.TrimSpace(raw)
+		if pattern == "" {
+			continue
+		}
+		if err := validateRegexComplexity(pattern); err != nil {
+			return nil, fmt.Errorf("compile rule %q pattern: %w", ruleID, err)
+		}
+		compiled, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("compile rule %q pattern: %w", ruleID, err)
+		}
+		patterns = append(patterns, compiledOutputPattern{raw: pattern, re: compiled})
+	}
+	return patterns, nil
+}
+
+func decodeInputMatch(raw json.RawMessage) (inputRuleMatchWire, error) {
+	var out inputRuleMatchWire
+	if ruleJSONMissing(raw) {
+		return out, fmt.Errorf("missing rule match")
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, fmt.Errorf("decode rule match: %w", err)
+	}
+	return out, nil
+}
+
+func decodeOutputMatch(raw json.RawMessage) (outputRuleMatchWire, error) {
+	var out outputRuleMatchWire
+	if ruleJSONMissing(raw) {
+		return out, fmt.Errorf("missing rule match")
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, fmt.Errorf("decode rule match: %w", err)
+	}
+	return out, nil
+}
+
+func decodeVelocityMatch(raw json.RawMessage) (velocityRuleMatchWire, error) {
+	var out velocityRuleMatchWire
+	if ruleJSONMissing(raw) {
+		return out, fmt.Errorf("missing rule match")
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, fmt.Errorf("decode rule match: %w", err)
+	}
+	return out, nil
+}
+
+func decodeRuleDecision(raw json.RawMessage) (ruleDecisionWire, error) {
+	var out ruleDecisionWire
+	if ruleJSONMissing(raw) {
+		return out, fmt.Errorf("missing rule decision")
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, fmt.Errorf("decode rule decision: %w", err)
+	}
+	return out, nil
+}
+
+func ruleJSONMissing(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed == "" || trimmed == "null"
+}

--- a/core/controlplane/safetykernel/unified_rule.go
+++ b/core/controlplane/safetykernel/unified_rule.go
@@ -1,0 +1,275 @@
+package safetykernel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// EvaluateRule evaluates one unified Rule and returns legacy + unified shapes.
+func (s *server) EvaluateRule(
+	ctx context.Context,
+	rule policy.Rule,
+	req *pb.PolicyCheckRequest,
+) (*pb.PolicyCheckResponse, policy.Decision, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if req == nil {
+		return nil, policy.Decision{}, fmt.Errorf("missing policy check request")
+	}
+	if !RuleScopeMatchesJob(rule.Scope, jobContextFromRequest(req)) {
+		return unmatchedRuleResult(s, ctx, rule, "rule scope did not match job")
+	}
+	switch rule.Type {
+	case policy.RuleTypeInput:
+		return s.evaluateUnifiedInputRule(ctx, rule, req)
+	case policy.RuleTypeOutput:
+		return s.evaluateUnifiedOutputRule(ctx, rule, req)
+	case policy.RuleTypeVelocity:
+		return s.evaluateUnifiedVelocityRule(ctx, rule, req)
+	default:
+		return nil, policy.Decision{}, fmt.Errorf("unsupported unified rule type %q", rule.Type)
+	}
+}
+
+func (s *server) unmatchedRuleDecision(
+	ctx context.Context,
+	rule policy.Rule,
+	reason string,
+) (*pb.PolicyCheckResponse, policy.Decision) {
+	resp := &pb.PolicyCheckResponse{
+		Decision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		Reason:   strings.TrimSpace(reason),
+	}
+	return resp, emitRuleDecision(ctx, rule, policy.DecisionAllow, resp.Reason, "", "")
+}
+
+func unmatchedRuleResult(
+	s *server,
+	ctx context.Context,
+	rule policy.Rule,
+	reason string,
+) (*pb.PolicyCheckResponse, policy.Decision, error) {
+	resp, decision := s.unmatchedRuleDecision(ctx, rule, reason)
+	return resp, decision, nil
+}
+
+func (s *server) evaluateUnifiedInputRule(
+	ctx context.Context,
+	rule policy.Rule,
+	req *pb.PolicyCheckRequest,
+) (*pb.PolicyCheckResponse, policy.Decision, error) {
+	compiled, err := RuleToCompiledInput(rule)
+	if err != nil {
+		return nil, policy.Decision{}, err
+	}
+	matched, findings := evaluateInputRule(compiled, inputEvalRequestFromPolicy(req), s.scannerSnapshot())
+	if !matched {
+		return unmatchedRuleResult(s, ctx, rule, "input rule did not match")
+	}
+	pbDecision, decisionType := inputDecisionTypes(compiled.decision)
+	reason := strings.TrimSpace(compiled.reason)
+	if reason == "" {
+		reason = inputRuleReason(compiled, findings)
+	}
+	resp := &pb.PolicyCheckResponse{Decision: pbDecision, Reason: reason, RuleId: compiled.id}
+	return resp, emitRuleDecision(ctx, rule, decisionType, reason, "", ""), nil
+}
+
+func (s *server) evaluateUnifiedOutputRule(
+	ctx context.Context,
+	rule policy.Rule,
+	req *pb.PolicyCheckRequest,
+) (*pb.PolicyCheckResponse, policy.Decision, error) {
+	compiled, err := RuleToCompiledOutput(rule)
+	if err != nil {
+		return nil, policy.Decision{}, err
+	}
+	matched, findings := evaluateOutputRule(compiled, outputEvalRequestFromPolicy(req), s.scannerSnapshot())
+	if !matched {
+		return unmatchedRuleResult(s, ctx, rule, "output rule did not match")
+	}
+	legacyDecision, decisionType := outputDecisionTypes(compiled.decision)
+	reason := outputRuleReason(compiled, findings)
+	resp := &pb.PolicyCheckResponse{Decision: legacyDecision, Reason: reason, RuleId: compiled.id}
+	return resp, emitRuleDecision(ctx, rule, decisionType, reason, "", ""), nil
+}
+
+func (s *server) evaluateUnifiedVelocityRule(
+	ctx context.Context,
+	rule policy.Rule,
+	req *pb.PolicyCheckRequest,
+) (*pb.PolicyCheckResponse, policy.Decision, error) {
+	legacyRule, err := RuleToCompiledVelocity(rule)
+	if err != nil {
+		return nil, policy.Decision{}, err
+	}
+	policyDoc := &config.SafetyPolicy{Rules: []config.PolicyRule{legacyRule}, DefaultDecision: "allow"}
+	decision := s.evaluateRulesWithVelocity(ctx, policyDoc, policyInputFromRequest(req), req.GetJobId(), "evaluate")
+	resp := responseFromPolicyDecision(decision)
+	decisionType := unifiedDecisionFromLegacy(decision.Decision)
+	return resp, emitRuleDecision(ctx, rule, decisionType, resp.GetReason(), "", ""), nil
+}
+
+func inputEvalRequestFromPolicy(req *pb.PolicyCheckRequest) inputEvaluateRequest {
+	meta := req.GetMeta()
+	evalReq := inputEvaluateRequest{
+		tenant:      tenantFromPolicyRequest(req),
+		topic:       strings.TrimSpace(req.GetTopic()),
+		contentType: strings.TrimSpace(req.GetInputContentType()),
+		content:     inputContentFromPolicyRequest(req),
+		inputSize:   req.GetInputSizeBytes(),
+	}
+	if meta != nil {
+		evalReq.capabilities = append(evalReq.capabilities, meta.GetCapability())
+		evalReq.riskTags = append(evalReq.riskTags, meta.GetRiskTags()...)
+	}
+	return evalReq
+}
+
+func outputEvalRequestFromPolicy(req *pb.PolicyCheckRequest) *OutputEvaluateRequest {
+	return &OutputEvaluateRequest{
+		JobID:           strings.TrimSpace(req.GetJobId()),
+		Topic:           strings.TrimSpace(req.GetTopic()),
+		Tenant:          tenantFromPolicyRequest(req),
+		Labels:          req.GetLabels(),
+		OutputContent:   inputContentFromPolicyRequest(req),
+		OutputSizeBytes: req.GetInputSizeBytes(),
+		ContentType:     strings.TrimSpace(req.GetInputContentType()),
+	}
+}
+
+func policyInputFromRequest(req *pb.PolicyCheckRequest) config.PolicyInput {
+	input := config.PolicyInput{
+		Tenant:     tenantFromPolicyRequest(req),
+		Topic:      strings.TrimSpace(req.GetTopic()),
+		Labels:     req.GetLabels(),
+		Meta:       policyMetaFromRequest(req),
+		MCP:        extractMCPRequest(req.GetLabels()),
+		Delegation: delegationContextFromRequest(req),
+	}
+	input.SecretsPresent = secretsPresent(input.Meta, req.GetLabels())
+	return input
+}
+
+func inputContentFromPolicyRequest(req *pb.PolicyCheckRequest) []byte {
+	content := req.GetInputContent()
+	if len(content) > 0 {
+		return content
+	}
+	if prompt, ok := req.GetLabels()["_content.prompt"]; ok && prompt != "" {
+		return []byte(prompt)
+	}
+	return nil
+}
+
+func tenantFromPolicyRequest(req *pb.PolicyCheckRequest) string {
+	tenant := strings.TrimSpace(req.GetTenant())
+	if tenant != "" {
+		return tenant
+	}
+	if meta := req.GetMeta(); meta != nil {
+		return strings.TrimSpace(meta.GetTenantId())
+	}
+	return ""
+}
+
+func jobContextFromRequest(req *pb.PolicyCheckRequest) JobContext {
+	workflowID, jobID := resolvePolicyScope(req)
+	return JobContext{
+		Tenant:     tenantFromPolicyRequest(req),
+		WorkflowID: workflowID,
+		JobID:      jobID,
+	}
+}
+
+func (s *server) scannerSnapshot() map[string]OutputScanner {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]OutputScanner, len(s.scanners))
+	for name, scanner := range s.scanners {
+		out[name] = scanner
+	}
+	return out
+}
+
+func emitRuleDecision(
+	ctx context.Context,
+	rule policy.Rule,
+	decisionType policy.DecisionType,
+	reason string,
+	inputRef string,
+	outputRef string,
+) policy.Decision {
+	trace := []policy.TraceStep{{
+		RuleID:       strings.TrimSpace(rule.ID),
+		DecisionType: decisionType,
+		Reason:       strings.TrimSpace(reason),
+		Timestamp:    time.Now().UTC(),
+	}}
+	return EmitDecision(ctx, rule, decisionType, trace, inputRef, outputRef, "")
+}
+
+func inputDecisionTypes(decision string) (pb.DecisionType, policy.DecisionType) {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "require_approval", "require-approval", "require_human":
+		return pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN, policy.DecisionRequireHuman
+	default:
+		return pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionDeny
+	}
+}
+
+func outputDecisionTypes(decision pb.OutputDecision) (pb.DecisionType, policy.DecisionType) {
+	switch decision {
+	case pb.OutputDecision_OUTPUT_DECISION_REDACT:
+		return pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionRedact
+	case pb.OutputDecision_OUTPUT_DECISION_QUARANTINE:
+		return pb.DecisionType_DECISION_TYPE_DENY, policy.DecisionQuarantine
+	default:
+		return pb.DecisionType_DECISION_TYPE_ALLOW, policy.DecisionAllow
+	}
+}
+
+func responseFromPolicyDecision(decision config.PolicyDecision) *pb.PolicyCheckResponse {
+	pbDecision := pb.DecisionType_DECISION_TYPE_ALLOW
+	switch decision.Decision {
+	case "deny":
+		pbDecision = pb.DecisionType_DECISION_TYPE_DENY
+	case "require_approval":
+		pbDecision = pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN
+	case "throttle":
+		pbDecision = pb.DecisionType_DECISION_TYPE_THROTTLE
+	case "allow_with_constraints":
+		pbDecision = pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS
+	}
+	return &pb.PolicyCheckResponse{
+		Decision:    pbDecision,
+		Reason:      strings.TrimSpace(decision.Reason),
+		RuleId:      strings.TrimSpace(decision.RuleID),
+		Constraints: toProtoConstraints(decision.Constraints),
+	}
+}
+
+func unifiedDecisionFromLegacy(decision string) policy.DecisionType {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "deny":
+		return policy.DecisionDeny
+	case "require_approval", "require_human":
+		return policy.DecisionRequireHuman
+	case "throttle":
+		return policy.DecisionThrottle
+	case "allow_with_constraints":
+		return policy.DecisionAllowWithConstraints
+	default:
+		return policy.DecisionAllow
+	}
+}

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -5,10 +5,11 @@ Unified Rule, Decision, and Bundle shapes for Cordum's Policy Studio surface
 (input/output/velocity) and edge-side authoring surfaces under one envelope
 with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
 
-## Consumers (in follow-up tasks)
+## Consumers
 
-- `core/safetykernel/` — will consume `Rule` and emit `Decision` for job
-  evaluation paths (Backend 3 + Backend 5).
+- `core/controlplane/safetykernel/` — consumes `Rule` through adapter
+  functions and emits job-source `Decision` values alongside the legacy Safety
+  Kernel responses during Backend 3's transition window.
 - `core/edge/` — same migration; joins the unified audit-chain (Backend 4).
 - `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -27,15 +27,63 @@ via one of four configurable backends.
 
 ## 2. Event Types
 
-The audit subsystem defines these event types (from `core/audit/exporter.go`):
+The audit subsystem defines these event types (from `core/audit/exporter.go`
+and migration helpers in `core/audit/config.go`):
 
 | Constant | Value | Description |
 |----------|-------|-------------|
 | `EventSafetyDecision` | `safety.decision` | Safety kernel allow/deny/throttle decisions |
+| `EventPolicyDecisionV2` | `policy.decision.v2` | Unified Policy Studio `Decision` event emitted during the job-policy migration window |
 | `EventSafetyApproval` | `safety.approval` | Human approval or rejection of gated jobs |
 | `EventPolicyChange` | `safety.policy_change` | Policy configuration changes |
 | `EventSafetyViolation` | `safety.violation` | Safety policy violations |
 | `EventSystemAuth` | `system.auth` | Authentication events (login, key creation, user management) |
+
+### Policy Studio unified decisions (Backend 3)
+
+Job-side Safety Kernel decisions are migrating from the legacy
+`safety.decision` shape to the unified `core/policy.Decision` shape used by
+Policy Studio. During the transition, matched-rule job decisions can be
+written in both shapes through the existing SIEM and hash-chain machinery.
+
+`policy.decision.v2` uses the same `SIEMEvent` envelope so existing exporters
+and chain verification continue to work. The normalized fields are:
+
+| Field | Mapping |
+|-------|---------|
+| `event_type` | `policy.decision.v2` |
+| `decision` | Unified `Decision.Type` (`allow`, `deny`, `require_human`, `throttle`, `allow_with_constraints`, `quarantine`, `redact`) |
+| `matched_rule` | Unified `Decision.RuleID` |
+| `policy_version` | Unified `Decision.BundleVersion` when present, otherwise the legacy policy snapshot |
+| `reason` | First trace reason, falling back to the legacy reason |
+| `extra.source` | Unified `Decision.Source` (`job` for Safety Kernel decisions) |
+| `extra.bundle_id` / `extra.bundle_version` | Optional bundle binding metadata |
+| `extra.input_ref` / `extra.output_ref` | Optional blob references for inputs/outputs |
+| `extra.audit_hash` | Optional unified decision audit hash |
+
+Emission mode is controlled by `AUDIT_UNIFIED_DECISION_MODE`:
+
+| Value | Behavior |
+|-------|----------|
+| unset / `dual` | Default. Emit legacy `safety.decision` first, then `policy.decision.v2` for matched-rule job decisions. |
+| `legacy` | Emit only the legacy `safety.decision` shape. Use for rollback if downstream SIEM rules are not ready for v2. |
+| `unified` | Emit only `policy.decision.v2` for matched-rule job decisions. Use after downstream consumers cut over. |
+
+Values are case-insensitive. Invalid values safely default to `dual` and are
+logged once. Decisions without a matched rule remain legacy-only until the
+unified evaluator can provide a stable rule/default identifier; this avoids
+inventing unverifiable rule ids in the audit chain.
+
+Rollback/cutover guidance:
+
+1. Start with the default `dual` mode and update SIEM dashboards/alerts to read
+   `policy.decision.v2` while keeping legacy queries active.
+2. If a downstream consumer breaks, set `AUDIT_UNIFIED_DECISION_MODE=legacy`
+   and restart the affected producer; no data migration is required because
+   both shapes use the same chain/export pipeline.
+3. After all consumers read v2, set `AUDIT_UNIFIED_DECISION_MODE=unified`.
+   Keep legacy parsing code for at least one retention window so historical
+   audit-chain verification can still display old events.
 
 ### Output Policy events (added 2026-04)
 
@@ -157,6 +205,7 @@ The gateway records fine-grained audit entries via `appendAuditEntryNamed` for:
 | `CORDUM_AUDIT_EXPORT_TYPE` | Export backend: `webhook`, `syslog`, `datadog`, `cloudwatch`, or `none` |
 | `CORDUM_AUDIT_BUFFER_SIZE` | Async buffer size for export batching |
 | `CORDUM_AUDIT_EXPORT_MAX_RETRIES` | Max retry attempts for failed exports |
+| `AUDIT_UNIFIED_DECISION_MODE` | Job-policy decision shape: `dual` (default), `legacy`, or `unified` |
 
 ### Webhook
 


### PR DESCRIPTION
## Summary

Backend 3 for Policy Studio Rewrite: Safety Kernel now has an additive unified-policy boundary on top of the existing legacy evaluator contracts.

- Add `policy.Rule` adapters for input/output/velocity rules without mutating legacy config types.
- Add job-source `policy.Decision` emission via a stateless builder and additive `server.EvaluateRule` path.
- Add transition-window audit dual emission: legacy `safety.decision` plus `policy.decision.v2` in `dual` mode, and explicit `legacy` / `unified` modes.
- Document the audit mode and Policy Studio Backend 3 migration.

Stacked PR: base is `policy-studio-backend`. Blocked from merge until the coordinated Policy Studio wave.

## DoD evidence

1. **Unified Rule consumption + Decision emission** — `core/controlplane/safetykernel/policy_adapter.go`, `policy_adapter_wire.go`, `decision_emitter.go`, and `unified_rule.go`; tests in `policy_adapter_test.go`, `decision_emitter_test.go`, `kernel_unified_test.go`, `kernel_unified_helpers_test.go`.
2. **Audit chain unified Decision shape + legacy transition** — `core/audit/config.go`, `core/controlplane/gateway/policybundles/audit.go`, and `handlers_policy_bundles.go`; tests in `core/audit/dual_emit_test.go` and `core/controlplane/gateway/policybundles/audit_test.go`.
3. **Existing job-policy tests + new boundary tests pass** — full `make test` rerun passed; safetykernel/audit count=3 passed.
4. **Coverage caveat** — 100% safetykernel coverage is not reproducible on this branch or predecessor branch; current safetykernel package coverage is 76.4% vs 74.9% baseline on `origin/policy-studio-backend`, so it did not drop.

## Verification

- `make build` via WSL (`bash -lc 'make build'`) — EXIT=0 (1.2s); functional build equivalent `go build ./cmd/...` — EXIT=0 (2.8s).
- `make test` via WSL — first run hit flaky pre-existing `TestRedisCircuitBreaker_RedisFallback`; focused reruns passed; fresh full rerun EXIT=0 (57.6s).
- `make openapi` — N/A; no OpenAPI/proto/API schema surface changed.
- `go test -count=3 -timeout 240s ./core/controlplane/safetykernel/...` — EXIT=0 (`ok ... 13.227s`).
- `go test -count=3 -timeout 240s ./core/audit/...` — EXIT=0 (`ok ... 34.184s`).
- `go test ./core/controlplane/gateway/policybundles -run 'TestAuditEntryToSIEMEvents' -count=1` — EXIT=0 (`ok ... 0.100s`).
- `go test ./core/controlplane/gateway -run 'Test.*PolicyAudit|Test.*Audit' -count=1` — EXIT=0 (`ok ... 3.997s`).
- Safetykernel coverage equivalent: `go test ./core/controlplane/safetykernel "-coverprofile=cov_safetykernel.out" -covermode=count` + `go tool cover "-func=cov_safetykernel.out"` — total 76.4% (baseline 74.9%).
- `git diff --check` / `git diff --cached --check` — EXIT=0.

## Notes

- Existing Safety Kernel gRPC caller contracts are unchanged.
- `AUDIT_UNIFIED_DECISION_MODE` defaults to `dual`; invalid values default to dual and log once.
- Dual audit ordering is deterministic: legacy event first, then `policy.decision.v2`.