### PR TITLE
Backend 4: unify edge rules and decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,28 @@ Studio migration:
   by unified `policy.decision.v2`; `legacy` writes only the old shape; and
   `unified` writes only the new shape for matched-rule decisions.
 
+#### Policy Studio Rewrite — Backend 4 (epic-d9a6c0a1)
+
+Cordum Edge now participates in the unified Policy Studio decision stream
+without removing the legacy Edge evidence path:
+
+- Added a pure `policy.Rule{Type: edge}` adapter that compiles unified edge
+  Match/Decide JSON into the existing legacy Edge/Safety Kernel policy rule
+  shape.
+- Added an additive `policy.Decision{Source: edge}` emitter for Edge
+  decisions, mapping legacy Edge outcomes into unified decision types:
+  `ALLOW -> allow`, `DENY -> deny`, `REQUIRE_APPROVAL -> require_human`,
+  `THROTTLE -> throttle`, `CONSTRAIN -> redact`, and `RECORDED -> allow`
+  with an observation trace marker.
+- Edge evaluate and agentd decision-evidence paths now use Backend 3's shared
+  `AUDIT_UNIFIED_DECISION_MODE` transition helper. Default `dual` mode writes
+  legacy Edge audit first and `policy.decision.v2` second; `legacy` and
+  `unified` modes are honored by the same parser used for job decisions.
+- Edge policy mode resolution can read per-bundle `metadata.edge_mode` when a
+  session is bound to a policy bundle, while preserving the existing
+  session/global `EdgePolicyMode` fallback for operators that have not yet run
+  migration tooling.
+
 #### Cordum Edge P0 (2026-04-30)
 
 EDGE epic shipped 32 P0 tasks for the Compliance Firewall surface — local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ without removing the legacy Edge evidence path:
 - Added a pure `policy.Rule{Type: edge}` adapter that compiles unified edge
   Match/Decide JSON into the existing legacy Edge/Safety Kernel policy rule
   shape.
+- Gateway `/api/v1/edge/evaluate` now consumes bound unified edge bundles in
+  production: published `Rule{Type: edge}` entries from the latest bundle
+  `versions[].rule_snapshot` are scope-checked, adapted, and evaluated before
+  falling back to the legacy Safety Kernel path when no unified rule matches.
 - Added an additive `policy.Decision{Source: edge}` emitter for Edge
   decisions, mapping legacy Edge outcomes into unified decision types:
   `ALLOW -> allow`, `DENY -> deny`, `REQUIRE_APPROVAL -> require_human`,
@@ -82,6 +86,10 @@ without removing the legacy Edge evidence path:
   `AUDIT_UNIFIED_DECISION_MODE` transition helper. Default `dual` mode writes
   legacy Edge audit first and `policy.decision.v2` second; `legacy` and
   `unified` modes are honored by the same parser used for job decisions.
+- Fresh agentd evidence remains persisted as a distinct local evidence event,
+  but carries a verified Gateway event reference so `/edge/events` suppresses
+  duplicate policy-decision audit emission when `/edge/evaluate` already wrote
+  the shared decision record for that action.
 - Edge policy mode resolution can read per-bundle `metadata.edge_mode` when a
   session is bound to a policy bundle, while preserving the existing
   session/global `EdgePolicyMode` fallback for operators that have not yet run

--- a/core/audit/edge_dual_emit_test.go
+++ b/core/audit/edge_dual_emit_test.go
@@ -1,0 +1,78 @@
+package audit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecisionEventsForModeDualEmitsLegacyEdgeAndUnifiedV2(t *testing.T) {
+	ts := time.Date(2026, 5, 9, 14, 0, 0, 0, time.UTC)
+	legacy := SIEMEvent{
+		Timestamp:     ts,
+		EventType:     EventEdgePolicyDecision,
+		Severity:      SeverityHigh,
+		TenantID:      "tenant-edge",
+		Action:        "bash.exec",
+		Decision:      "deny",
+		MatchedRule:   "edge.deny.shell",
+		Reason:        "destructive shell",
+		PolicyVersion: "bundle-v4",
+		Extra:         map[string]string{"session_id": "edge_sess_1"},
+	}
+	decision := policy.Decision{
+		Source:        policy.DecisionSourceEdge,
+		RuleID:        "edge.deny.shell",
+		BundleID:      "bundle-edge-main",
+		BundleVersion: "bundle-v4",
+		Type:          policy.DecisionDeny,
+		InputRef:      "artifact://edge/input",
+		AuditHash:     "sha256:edge-audit",
+		Timestamp:     ts,
+	}
+
+	got, err := DecisionEventsForMode(UnifiedDecisionModeDual, legacy, decision)
+
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, EventEdgePolicyDecision, got[0].EventType)
+	require.Equal(t, EventPolicyDecisionV2, got[1].EventType)
+	require.Equal(t, "edge", got[1].Extra["source"])
+	require.Equal(t, "bundle-edge-main", got[1].Extra["bundle_id"])
+	require.Equal(t, "artifact://edge/input", got[1].Extra["input_ref"])
+	require.Equal(t, "sha256:edge-audit", got[1].Extra["audit_hash"])
+	require.Equal(t, "deny", got[1].Decision)
+	require.Equal(t, "edge.deny.shell", got[1].MatchedRule)
+}
+
+func TestFoldPolicyDecisionEventsIncludesJobAndEdgeSources(t *testing.T) {
+	events := []SIEMEvent{
+		{
+			EventType:   EventPolicyDecisionV2,
+			TenantID:    "tenant-a",
+			Decision:    "allow",
+			MatchedRule: "job.allow",
+			Extra:       map[string]string{"source": "job"},
+		},
+		{
+			EventType:   EventPolicyDecisionV2,
+			TenantID:    "tenant-a",
+			Decision:    "redact",
+			MatchedRule: "edge.redact",
+			Extra:       map[string]string{"source": "edge"},
+		},
+	}
+
+	got, err := FoldPolicyDecisionEvents(events)
+
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, policy.DecisionSourceJob, got[0].Source)
+	require.Equal(t, policy.DecisionAllow, got[0].Decision)
+	require.Equal(t, "job.allow", got[0].RuleID)
+	require.Equal(t, policy.DecisionSourceEdge, got[1].Source)
+	require.Equal(t, policy.DecisionRedact, got[1].Decision)
+	require.Equal(t, "edge.redact", got[1].RuleID)
+}

--- a/core/audit/policy_decision_stream.go
+++ b/core/audit/policy_decision_stream.go
@@ -1,0 +1,55 @@
+package audit
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cordum/cordum/core/policy"
+)
+
+// PolicyDecisionAuditRecord is the folded reader shape for unified v2
+// decisions emitted by job and edge evaluators.
+type PolicyDecisionAuditRecord struct {
+	Source   policy.DecisionSource
+	Decision policy.DecisionType
+	RuleID   string
+	Event    SIEMEvent
+}
+
+// FoldPolicyDecisionEvents filters a mixed audit stream to policy.decision.v2
+// records and parses the shared Source/Decision fields for downstream readers.
+func FoldPolicyDecisionEvents(events []SIEMEvent) ([]PolicyDecisionAuditRecord, error) {
+	out := make([]PolicyDecisionAuditRecord, 0, len(events))
+	for _, event := range events {
+		if event.EventType != EventPolicyDecisionV2 {
+			continue
+		}
+		record, err := foldPolicyDecisionEvent(event)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, record)
+	}
+	return out, nil
+}
+
+func foldPolicyDecisionEvent(event SIEMEvent) (PolicyDecisionAuditRecord, error) {
+	source, err := policy.ParseDecisionSource(strings.TrimSpace(event.Extra["source"]))
+	if err != nil {
+		return PolicyDecisionAuditRecord{}, fmt.Errorf("fold policy decision source: %w", err)
+	}
+	decision, err := policy.ParseDecisionType(strings.TrimSpace(event.Decision))
+	if err != nil {
+		return PolicyDecisionAuditRecord{}, fmt.Errorf("fold policy decision type: %w", err)
+	}
+	ruleID := strings.TrimSpace(event.MatchedRule)
+	if ruleID == "" {
+		return PolicyDecisionAuditRecord{}, fmt.Errorf("fold policy decision: rule_id is required")
+	}
+	return PolicyDecisionAuditRecord{
+		Source:   source,
+		Decision: decision,
+		RuleID:   ruleID,
+		Event:    cloneSIEMEvent(event),
+	}, nil
+}

--- a/core/controlplane/gateway/edge_decision_audit.go
+++ b/core/controlplane/gateway/edge_decision_audit.go
@@ -1,14 +1,18 @@
 package gateway
 
 import (
+	"context"
 	"strings"
 
 	"github.com/cordum/cordum/core/audit"
 	edgecore "github.com/cordum/cordum/core/edge"
 )
 
-func (s *server) emitEdgeDecisionAuditEvents(event edgecore.AgentActionEvent) {
+func (s *server) emitEdgeDecisionAuditEvents(ctx context.Context, store edgecore.Store, event edgecore.AgentActionEvent) {
 	if event.Kind != edgecore.EventKindHookPolicyDecision {
+		return
+	}
+	if edgeDecisionAuditAlreadyEmittedByGateway(ctx, store, event) {
 		return
 	}
 	legacy := edgecore.SIEMEventForAction(event)
@@ -29,9 +33,63 @@ func (s *server) emitEdgeDecisionAuditEvents(event edgecore.AgentActionEvent) {
 
 func edgeDecisionEmitOptions(event edgecore.AgentActionEvent) edgecore.EdgeDecisionEmitOptions {
 	return edgecore.EdgeDecisionEmitOptions{
-		BundleVersion: strings.TrimSpace(event.PolicySnapshot),
+		BundleID:      edgeDecisionBundleID(event),
+		BundleVersion: edgeDecisionBundleVersion(event),
 		InputRef:      edgeDecisionInputRef(event),
 	}
+}
+
+func edgeDecisionAuditAlreadyEmittedByGateway(ctx context.Context, store edgecore.Store, event edgecore.AgentActionEvent) bool {
+	if store == nil || event.Labels == nil {
+		return false
+	}
+	if strings.TrimSpace(event.AgentProduct) != "cordum-agentd" {
+		return false
+	}
+	if strings.TrimSpace(event.Labels[edgecore.LabelDecisionAuditEmittedBy]) != edgecore.LabelDecisionAuditEmittedByGateway {
+		return false
+	}
+	gatewayEventID := strings.TrimSpace(event.Labels[edgecore.LabelGatewayDecisionEventID])
+	if gatewayEventID == "" {
+		return false
+	}
+	page, err := store.ListEvents(ctx, edgecore.ListEventsQuery{
+		TenantID:    strings.TrimSpace(event.TenantID),
+		ExecutionID: strings.TrimSpace(event.ExecutionID),
+		Kind:        edgecore.EventKindHookPolicyDecision,
+		Limit:       200,
+	})
+	if err != nil {
+		return false
+	}
+	for _, prior := range page.Items {
+		if prior.EventID != gatewayEventID {
+			continue
+		}
+		return prior.Kind == edgecore.EventKindHookPolicyDecision &&
+			strings.TrimSpace(prior.AgentProduct) != "cordum-agentd" &&
+			strings.TrimSpace(prior.RuleID) == strings.TrimSpace(event.RuleID) &&
+			strings.TrimSpace(prior.InputHash) == strings.TrimSpace(event.InputHash)
+	}
+	return false
+}
+
+func edgeDecisionBundleID(event edgecore.AgentActionEvent) string {
+	for _, key := range []string{"policy.bundle_id", "policy_bundle_id", "bundle_id"} {
+		if value := strings.TrimSpace(event.Labels[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func edgeDecisionBundleVersion(event edgecore.AgentActionEvent) string {
+	for _, key := range []string{"policy.bundle_version", "policy_bundle_version", "bundle_version"} {
+		if value := strings.TrimSpace(event.Labels[key]); value != "" {
+			return value
+		}
+	}
+	return strings.TrimSpace(event.PolicySnapshot)
 }
 
 func edgeDecisionInputRef(event edgecore.AgentActionEvent) string {

--- a/core/controlplane/gateway/edge_decision_audit.go
+++ b/core/controlplane/gateway/edge_decision_audit.go
@@ -1,0 +1,44 @@
+package gateway
+
+import (
+	"strings"
+
+	"github.com/cordum/cordum/core/audit"
+	edgecore "github.com/cordum/cordum/core/edge"
+)
+
+func (s *server) emitEdgeDecisionAuditEvents(event edgecore.AgentActionEvent) {
+	if event.Kind != edgecore.EventKindHookPolicyDecision {
+		return
+	}
+	legacy := edgecore.SIEMEventForAction(event)
+	decision, err := edgecore.EmitDecisionForEdgeEvent(event, edgeDecisionEmitOptions(event))
+	if err != nil {
+		edgecore.SendSIEMEvent(s.auditExporter, legacy)
+		return
+	}
+	events, err := audit.DecisionEventsForMode(audit.UnifiedDecisionModeFromEnv(), legacy, decision)
+	if err != nil {
+		edgecore.SendSIEMEvent(s.auditExporter, legacy)
+		return
+	}
+	for _, item := range events {
+		edgecore.SendSIEMEvent(s.auditExporter, item)
+	}
+}
+
+func edgeDecisionEmitOptions(event edgecore.AgentActionEvent) edgecore.EdgeDecisionEmitOptions {
+	return edgecore.EdgeDecisionEmitOptions{
+		BundleVersion: strings.TrimSpace(event.PolicySnapshot),
+		InputRef:      edgeDecisionInputRef(event),
+	}
+}
+
+func edgeDecisionInputRef(event edgecore.AgentActionEvent) string {
+	for _, ptr := range event.ArtifactPointers {
+		if strings.TrimSpace(ptr.URI) != "" {
+			return strings.TrimSpace(ptr.URI)
+		}
+	}
+	return ""
+}

--- a/core/controlplane/gateway/edge_evaluate_test.go
+++ b/core/controlplane/gateway/edge_evaluate_test.go
@@ -1649,10 +1649,10 @@ func TestGatewayEdgeEvaluateRejectsBodyOverMaxBytesWithoutOrphanKeys(t *testing.
 }
 
 func TestBuildEdgeEvaluatePolicyInputUsesClassifierAndMapper(t *testing.T) {
-	_, handler := newEdgeEvaluateTestServer(t, &edgeEvaluateStubSafetyClient{response: &pb.PolicyCheckResponse{Decision: pb.DecisionType_DECISION_TYPE_ALLOW}})
+	s, handler := newEdgeEvaluateTestServer(t, &edgeEvaluateStubSafetyClient{response: &pb.PolicyCheckResponse{Decision: pb.DecisionType_DECISION_TYPE_ALLOW}})
 	session := createEdgeRouteSession(t, handler)
 
-	input, err := buildEdgeEvaluatePolicyInput(edgeEvaluateContext{
+	input, err := s.buildEdgeEvaluatePolicyInput(context.Background(), edgeEvaluateContext{
 		req: edgeEvaluateRequest{
 			TenantID:          edgeRouteTenant,
 			PrincipalID:       "principal-edge-a",

--- a/core/controlplane/gateway/edge_evaluate_unified_test.go
+++ b/core/controlplane/gateway/edge_evaluate_unified_test.go
@@ -1,0 +1,130 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cordum/cordum/core/audit"
+	edgecore "github.com/cordum/cordum/core/edge"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+func TestGatewayEdgeEvaluateDualEmitsLegacyAndUnifiedDecision(t *testing.T) {
+	t.Setenv(audit.EnvUnifiedDecisionMode, string(audit.UnifiedDecisionModeDual))
+
+	stub := &edgeEvaluateStubSafetyClient{response: &pb.PolicyCheckResponse{
+		Decision:       pb.DecisionType_DECISION_TYPE_DENY,
+		Reason:         "destructive shell",
+		RuleId:         "edge.deny.shell",
+		PolicySnapshot: "bundle-v4",
+	}}
+	s, handler := newEdgeEvaluateTestServer(t, stub)
+	sink := &testAuditSender{}
+	s.auditExporter = sink
+	session := createEdgeRouteSession(t, handler)
+	before := sink.Len()
+
+	rec := edgeRoutePOST(t, handler, "/api/v1/edge/evaluate", edgeEvaluateBody(
+		session.SessionID,
+		session.ExecutionID,
+		edgeRouteTenant,
+		"Bash",
+		map[string]any{"command": "rm -rf /tmp/demo"},
+	))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("evaluate status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := sink.Len() - before; got != 2 {
+		t.Fatalf("audit events emitted = %d, want legacy edge + policy.decision.v2", got)
+	}
+	legacy := sink.Get(before)
+	unified := sink.Get(before + 1)
+	if legacy.EventType != audit.EventEdgeActionDenied {
+		t.Fatalf("legacy event type = %q, want %q", legacy.EventType, audit.EventEdgeActionDenied)
+	}
+	if unified.EventType != audit.EventPolicyDecisionV2 {
+		t.Fatalf("unified event type = %q, want %q", unified.EventType, audit.EventPolicyDecisionV2)
+	}
+	if unified.Extra["source"] != "edge" || unified.Decision != "deny" || unified.MatchedRule != "edge.deny.shell" {
+		t.Fatalf("unified decision = type:%q source:%q decision:%q rule:%q extra:%#v",
+			unified.EventType, unified.Extra["source"], unified.Decision, unified.MatchedRule, unified.Extra)
+	}
+}
+
+func TestGatewayEdgeEventWriteDualEmitsAgentdDecisionEvidence(t *testing.T) {
+	t.Setenv(audit.EnvUnifiedDecisionMode, string(audit.UnifiedDecisionModeDual))
+
+	s, handler := newEdgeRouteTestServer(t)
+	sink := &testAuditSender{}
+	s.auditExporter = sink
+	session := createEdgeRouteSession(t, handler)
+	before := sink.Len()
+
+	rec := edgeRoutePOST(t, handler, "/api/v1/edge/events", `{
+		"event_id":"evt-agentd-unified-audit",
+		"session_id":"`+session.SessionID+`",
+		"execution_id":"`+session.ExecutionID+`",
+		"tenant_id":"`+edgeRouteTenant+`",
+		"ts":"2026-05-09T14:30:00Z",
+		"layer":"hook",
+		"kind":"hook.policy_decision",
+		"action_name":"bash.exec",
+		"capability":"exec.shell",
+		"risk_tags":["exec"],
+		"input_hash":"sha256:input-agentd",
+		"decision":"DENY",
+		"decision_reason":"agentd degraded fallback",
+		"rule_id":"edge.agentd.degraded",
+		"status":"blocked",
+		"labels":{"source":"cordum-agentd"}
+	}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("event write status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := sink.Len() - before; got != 2 {
+		t.Fatalf("audit events emitted for agentd evidence = %d, want legacy edge + policy.decision.v2", got)
+	}
+	legacy := sink.Get(before)
+	unified := sink.Get(before + 1)
+	if legacy.EventType != audit.EventEdgeActionDenied {
+		t.Fatalf("legacy event type = %q, want %q", legacy.EventType, audit.EventEdgeActionDenied)
+	}
+	if unified.EventType != audit.EventPolicyDecisionV2 ||
+		unified.Extra["source"] != "edge" ||
+		unified.Decision != "deny" ||
+		unified.MatchedRule != "edge.agentd.degraded" {
+		t.Fatalf("unified agentd event = type:%q source:%q decision:%q rule:%q extra:%#v",
+			unified.EventType, unified.Extra["source"], unified.Decision, unified.MatchedRule, unified.Extra)
+	}
+}
+
+func TestGatewayEdgeEventWriteDoesNotAuditNonDecisionEvents(t *testing.T) {
+	s, handler := newEdgeRouteTestServer(t)
+	sink := &testAuditSender{}
+	s.auditExporter = sink
+	session := createEdgeRouteSession(t, handler)
+	before := sink.Len()
+
+	rec := edgeRoutePOST(t, handler, "/api/v1/edge/events", `{
+		"event_id":"evt-non-decision-no-audit",
+		"session_id":"`+session.SessionID+`",
+		"execution_id":"`+session.ExecutionID+`",
+		"tenant_id":"`+edgeRouteTenant+`",
+		"ts":"2026-05-09T14:31:00Z",
+		"layer":"hook",
+		"kind":"hook.post_tool_use",
+		"tool_name":"Bash",
+		"input_redacted":{"summary":"done"},
+		"decision":"`+string(edgecore.DecisionAllow)+`",
+		"status":"ok"
+	}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("event write status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := sink.Len() - before; got != 0 {
+		t.Fatalf("non-decision audit events = %d, want 0", got)
+	}
+}

--- a/core/controlplane/gateway/edge_evaluate_unified_test.go
+++ b/core/controlplane/gateway/edge_evaluate_unified_test.go
@@ -1,13 +1,89 @@
 package gateway
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/configsvc"
+	"github.com/cordum/cordum/core/controlplane/gateway/packs"
 	edgecore "github.com/cordum/cordum/core/edge"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 )
+
+func TestGatewayEdgeEvaluateConsumesBoundUnifiedEdgeRule(t *testing.T) {
+	t.Setenv(audit.EnvUnifiedDecisionMode, string(audit.UnifiedDecisionModeDual))
+
+	stub := &edgeEvaluateStubSafetyClient{response: &pb.PolicyCheckResponse{
+		Decision:       pb.DecisionType_DECISION_TYPE_ALLOW,
+		Reason:         "legacy safety fallback",
+		RuleId:         "legacy.allow",
+		PolicySnapshot: "legacy-snapshot",
+	}}
+	s, handler := newEdgeEvaluateTestServer(t, stub)
+	sink := &testAuditSender{}
+	s.auditExporter = sink
+	seedUnifiedEdgeBundle(t, s, "secops/edge-unified", map[string]any{
+		"id":            "secops/edge-unified",
+		"name":          "Unified edge bundle",
+		"scope_binding": map[string]any{"kind": "global"},
+		"metadata":      map[string]any{"edge_mode": "enforce"},
+		"versions": []any{map[string]any{
+			"version":     "edge-bundle-v9",
+			"deployed_at": "2026-05-09T14:45:00Z",
+			"rule_snapshot": []any{map[string]any{
+				"id":      "unified.edge.deny.shell",
+				"name":    "Deny shell from unified edge rule",
+				"type":    "edge",
+				"scope":   map[string]any{"kind": "global"},
+				"status":  "published",
+				"version": "v1",
+				"audit":   map[string]any{"created_at": "2026-05-09T14:44:00Z", "created_by": "secops"},
+				"match":   map[string]any{"capabilities": []any{"exec.shell"}},
+				"decide":  map[string]any{"decision": "deny", "reason": "unified shell deny"},
+			}},
+		}},
+	})
+	session := createUnifiedEdgeBundleSession(t, handler, "secops/edge-unified")
+	before := sink.Len()
+
+	rec := edgeRoutePOST(t, handler, "/api/v1/edge/evaluate", edgeEvaluateBody(
+		session.SessionID,
+		session.ExecutionID,
+		edgeRouteTenant,
+		"Bash",
+		map[string]any{"command": "rm -rf /tmp/demo"},
+	))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("evaluate status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp edgeEvaluateResponseJSON
+	decodeEdgeRouteJSON(t, rec, &resp)
+	if resp.Decision != string(edgecore.DecisionDeny) ||
+		resp.RuleID != "unified.edge.deny.shell" ||
+		resp.PolicySnapshot != "edge-bundle-v9" {
+		t.Fatalf("response = decision:%q rule:%q snapshot:%q body=%s",
+			resp.Decision, resp.RuleID, resp.PolicySnapshot, rec.Body.String())
+	}
+	if got := len(stub.capturedRequests()); got != 0 {
+		t.Fatalf("legacy safety calls = %d, want 0 because bound unified edge rule matched", got)
+	}
+	if got := sink.Len() - before; got != 2 {
+		t.Fatalf("audit events = %d, want legacy edge + policy.decision.v2", got)
+	}
+	unified := sink.Get(before + 1)
+	if unified.EventType != audit.EventPolicyDecisionV2 ||
+		unified.Extra["source"] != "edge" ||
+		unified.Extra["bundle_id"] != "secops/edge-unified" ||
+		unified.Decision != "deny" ||
+		unified.MatchedRule != "unified.edge.deny.shell" {
+		t.Fatalf("unified audit = type:%q source:%q bundle:%q decision:%q rule:%q extra:%#v",
+			unified.EventType, unified.Extra["source"], unified.Extra["bundle_id"],
+			unified.Decision, unified.MatchedRule, unified.Extra)
+	}
+}
 
 func TestGatewayEdgeEvaluateDualEmitsLegacyAndUnifiedDecision(t *testing.T) {
 	t.Setenv(audit.EnvUnifiedDecisionMode, string(audit.UnifiedDecisionModeDual))
@@ -49,6 +125,79 @@ func TestGatewayEdgeEvaluateDualEmitsLegacyAndUnifiedDecision(t *testing.T) {
 	if unified.Extra["source"] != "edge" || unified.Decision != "deny" || unified.MatchedRule != "edge.deny.shell" {
 		t.Fatalf("unified decision = type:%q source:%q decision:%q rule:%q extra:%#v",
 			unified.EventType, unified.Extra["source"], unified.Decision, unified.MatchedRule, unified.Extra)
+	}
+}
+
+func TestGatewaySkipsAgentdFreshEvidenceWhenGatewayEvaluateAlreadyAudited(t *testing.T) {
+	t.Setenv(audit.EnvUnifiedDecisionMode, string(audit.UnifiedDecisionModeDual))
+
+	stub := &edgeEvaluateStubSafetyClient{response: &pb.PolicyCheckResponse{
+		Decision:       pb.DecisionType_DECISION_TYPE_DENY,
+		Reason:         "fresh deny",
+		RuleId:         "edge.deny.fresh",
+		PolicySnapshot: "snap-fresh",
+	}}
+	s, handler := newEdgeEvaluateTestServer(t, stub)
+	sink := &testAuditSender{}
+	s.auditExporter = sink
+	session := createEdgeRouteSession(t, handler)
+	before := sink.Len()
+
+	eval := edgeRoutePOST(t, handler, "/api/v1/edge/evaluate", edgeEvaluateBody(
+		session.SessionID,
+		session.ExecutionID,
+		edgeRouteTenant,
+		"Bash",
+		map[string]any{"command": "rm -rf /tmp/demo"},
+	))
+	if eval.Code != http.StatusOK {
+		t.Fatalf("evaluate status = %d body=%s", eval.Code, eval.Body.String())
+	}
+	if got := sink.Len() - before; got != 2 {
+		t.Fatalf("audit events after evaluate = %d, want 2", got)
+	}
+	events := listEdgeEvaluateEvents(t, s, session.SessionID, session.ExecutionID)
+	if len(events) != 1 {
+		t.Fatalf("persisted events after evaluate = %d, want 1: %#v", len(events), events)
+	}
+	gatewayEvent := events[0]
+
+	rec := edgeRoutePOST(t, handler, "/api/v1/edge/events", `{
+		"event_id":"agentd-fresh-evidence",
+		"session_id":"`+session.SessionID+`",
+		"execution_id":"`+session.ExecutionID+`",
+		"tenant_id":"`+edgeRouteTenant+`",
+		"ts":"2026-05-09T14:40:00Z",
+		"layer":"hook",
+		"kind":"hook.policy_decision",
+		"agent_product":"cordum-agentd",
+		"tool_name":"Bash",
+		"action_name":"bash.exec",
+		"capability":"exec.shell",
+		"risk_tags":["exec"],
+		"input_redacted":{"command":"rm -rf /tmp/demo"},
+		"input_hash":"`+gatewayEvent.InputHash+`",
+		"decision":"DENY",
+		"decision_reason":"fresh deny",
+		"rule_id":"edge.deny.fresh",
+		"policy_snapshot":"snap-fresh",
+		"status":"blocked",
+		"labels":{
+			"source":"cordum-agentd",
+			"`+edgecore.LabelDecisionAuditEmittedBy+`":"`+edgecore.LabelDecisionAuditEmittedByGateway+`",
+			"`+edgecore.LabelGatewayDecisionEventID+`":"`+gatewayEvent.EventID+`"
+		}
+	}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("event write status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := sink.Len() - before; got != 2 {
+		t.Fatalf("audit events after agentd fresh evidence = %d, want still 2 (no duplicate)", got)
+	}
+	events = listEdgeEvaluateEvents(t, s, session.SessionID, session.ExecutionID)
+	if len(events) != 2 {
+		t.Fatalf("persisted events after agentd evidence = %d, want gateway + agentd evidence", len(events))
 	}
 }
 
@@ -127,4 +276,41 @@ func TestGatewayEdgeEventWriteDoesNotAuditNonDecisionEvents(t *testing.T) {
 	if got := sink.Len() - before; got != 0 {
 		t.Fatalf("non-decision audit events = %d, want 0", got)
 	}
+}
+
+func seedUnifiedEdgeBundle(t *testing.T, s *server, bundleID string, bundle map[string]any) {
+	t.Helper()
+	if bundle == nil {
+		bundle = map[string]any{}
+	}
+	bundle["enabled"] = true
+	err := s.configSvc.Set(context.Background(), &configsvc.Document{
+		Scope:   configsvc.Scope(packs.PolicyConfigScope),
+		ScopeID: packs.PolicyConfigID,
+		Data: map[string]any{
+			packs.PolicyConfigKey: map[string]any{
+				bundleID: bundle,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed unified edge bundle: %v", err)
+	}
+}
+
+func createUnifiedEdgeBundleSession(t *testing.T, handler http.Handler, bundleID string) edgeSessionCreateResponseJSON {
+	t.Helper()
+	rec := edgeRoutePOST(t, handler, "/api/v1/edge/sessions", `{
+		"agent_product":"claude-code",
+		"mode":"local-dev",
+		"policy_snapshot":"snap-edge-unified",
+		"policy_mode":"observe",
+		"labels":{"policy.bundle_id":"`+bundleID+`"}
+	}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create unified bundle session status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var session edgeSessionCreateResponseJSON
+	decodeEdgeRouteJSON(t, rec, &session)
+	return session
 }

--- a/core/controlplane/gateway/edge_policy_mode.go
+++ b/core/controlplane/gateway/edge_policy_mode.go
@@ -1,0 +1,101 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	edgecore "github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/policy"
+)
+
+const (
+	edgePolicyModeSourceBundle       = "bundle"
+	edgePolicyModeSourceLegacyGlobal = "legacy_global"
+)
+
+type edgeEvaluatePolicyModeResolution struct {
+	Mode     edgecore.PolicyMode
+	Source   string
+	BundleID string
+}
+
+func (s *server) resolveEdgeEvaluatePolicyMode(ctx context.Context, session edgecore.EdgeSession) edgeEvaluatePolicyModeResolution {
+	if edgeEvaluateBoundBundleID(session.Labels) == "" {
+		return edgeEvaluatePolicyModeFromBundles(session, nil)
+	}
+	if s == nil || s.configSvc == nil {
+		return edgeEvaluatePolicyModeFromBundles(session, nil)
+	}
+	bundles, _, err := s.loadPolicyBundles(ctx)
+	if err != nil {
+		return edgeEvaluatePolicyModeFromBundles(session, nil)
+	}
+	return edgeEvaluatePolicyModeFromBundles(session, bundles)
+}
+
+func edgeEvaluatePolicyModeFromBundles(session edgecore.EdgeSession, bundles map[string]any) edgeEvaluatePolicyModeResolution {
+	fallback := edgeEvaluateLegacyPolicyMode(session.PolicyMode)
+	bundleID := edgeEvaluateBoundBundleID(session.Labels)
+	if bundleID == "" || len(bundles) == 0 {
+		return edgeEvaluatePolicyModeResolution{Mode: fallback, Source: edgePolicyModeSourceLegacyGlobal}
+	}
+	mode, ok := edgeBundlePolicyMode(bundles[bundleID], fallback)
+	if !ok {
+		return edgeEvaluatePolicyModeResolution{Mode: fallback, Source: edgePolicyModeSourceLegacyGlobal}
+	}
+	return edgeEvaluatePolicyModeResolution{Mode: mode, Source: edgePolicyModeSourceBundle, BundleID: bundleID}
+}
+
+func edgeEvaluateLegacyPolicyMode(mode edgecore.PolicyMode) edgecore.PolicyMode {
+	if mode == "" {
+		return edgecore.PolicyModeObserve
+	}
+	return mode
+}
+
+func edgeEvaluateBoundBundleID(labels edgecore.Labels) string {
+	for _, key := range []string{"policy.bundle_id", "policy_bundle_id", "bundle_id"} {
+		if value := strings.TrimSpace(labels[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func edgeBundlePolicyMode(raw any, fallback edgecore.PolicyMode) (edgecore.PolicyMode, bool) {
+	bundle, ok := raw.(map[string]any)
+	if !ok || bundle == nil {
+		return fallback, false
+	}
+	rawMode := edgeBundleModeValue(bundle)
+	if strings.TrimSpace(rawMode) == "" {
+		return fallback, false
+	}
+	mode, err := policy.ParseEdgeMode(rawMode)
+	if err != nil {
+		return fallback, false
+	}
+	return edgecore.PolicyModeFromBundleMetadata(policy.Bundle{
+		Metadata: policy.BundleMetadata{EdgeMode: mode},
+	}, fallback), true
+}
+
+func edgeBundleModeValue(bundle map[string]any) string {
+	if metadata, ok := bundle["metadata"].(map[string]any); ok {
+		if raw := strings.TrimSpace(policyBundleString(metadata["edge_mode"])); raw != "" {
+			return raw
+		}
+	}
+	return strings.TrimSpace(policyBundleString(bundle["edge_mode"]))
+}
+
+func policyBundleString(value any) string {
+	if value == nil {
+		return ""
+	}
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return fmt.Sprint(value)
+}

--- a/core/controlplane/gateway/edge_policy_mode_test.go
+++ b/core/controlplane/gateway/edge_policy_mode_test.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"testing"
+
+	edgecore "github.com/cordum/cordum/core/edge"
+)
+
+func TestEdgeEvaluatePolicyModeFromBundlesUsesBoundBundleMetadata(t *testing.T) {
+	session := edgecore.EdgeSession{
+		PolicyMode: edgecore.PolicyModeObserve,
+		Labels:     edgecore.Labels{"policy.bundle_id": "secops/edge-strict"},
+	}
+	bundles := map[string]any{
+		"secops/edge-strict": map[string]any{
+			"metadata": map[string]any{"edge_mode": "enterprise-strict"},
+		},
+	}
+
+	got := edgeEvaluatePolicyModeFromBundles(session, bundles)
+
+	if got.Mode != edgecore.PolicyModeEnterpriseStrict {
+		t.Fatalf("mode = %q, want enterprise-strict", got.Mode)
+	}
+	if got.Source != "bundle" || got.BundleID != "secops/edge-strict" {
+		t.Fatalf("source/bundle = %q/%q, want bundle/secops/edge-strict", got.Source, got.BundleID)
+	}
+}
+
+func TestEdgeEvaluatePolicyModeFromBundlesFallsBackToLegacyGlobal(t *testing.T) {
+	session := edgecore.EdgeSession{
+		PolicyMode: edgecore.PolicyModeEnforce,
+		Labels:     edgecore.Labels{"policy.bundle_id": "secops/edge-empty"},
+	}
+	bundles := map[string]any{
+		"secops/edge-empty": map[string]any{"metadata": map[string]any{}},
+	}
+
+	got := edgeEvaluatePolicyModeFromBundles(session, bundles)
+
+	if got.Mode != edgecore.PolicyModeEnforce {
+		t.Fatalf("mode = %q, want enforce fallback", got.Mode)
+	}
+	if got.Source != "legacy_global" || got.BundleID != "" {
+		t.Fatalf("source/bundle = %q/%q, want legacy_global/empty", got.Source, got.BundleID)
+	}
+}

--- a/core/controlplane/gateway/edge_unified_policy.go
+++ b/core/controlplane/gateway/edge_unified_policy.go
@@ -1,0 +1,155 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/policybundles"
+	edgecore "github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+func (s *server) evaluateBoundUnifiedEdgeRules(
+	ctx context.Context,
+	evalCtx edgeEvaluateContext,
+	event *edgecore.AgentActionEvent,
+	req *pb.PolicyCheckRequest,
+) *pb.PolicyCheckResponse {
+	if s == nil || event == nil || req == nil {
+		return nil
+	}
+	bundleID := edgeUnifiedBoundBundleID(evalCtx, event)
+	if bundleID == "" || s.configSvc == nil {
+		return nil
+	}
+	bundle, ok := s.loadUnifiedEdgeBundle(ctx, bundleID)
+	if !ok {
+		return nil
+	}
+	adapted, snapshot := edgeAdaptedRulesFromBundle(bundle, edgeUnifiedRuleScope(*event), evalCtx.policyMode)
+	if len(adapted) == 0 {
+		return nil
+	}
+	resp := edgeEvaluateAdaptedRules(adapted, snapshot, req)
+	if strings.TrimSpace(resp.GetRuleId()) == "" {
+		return nil
+	}
+	edgeAttachUnifiedBundleLabels(event, bundle, snapshot)
+	return resp
+}
+
+func edgeUnifiedBoundBundleID(evalCtx edgeEvaluateContext, event *edgecore.AgentActionEvent) string {
+	bundleID := edgeEvaluateBoundBundleID(event.Labels)
+	if bundleID == "" && evalCtx.session != nil {
+		bundleID = edgeEvaluateBoundBundleID(evalCtx.session.Labels)
+	}
+	return bundleID
+}
+
+func (s *server) loadUnifiedEdgeBundle(ctx context.Context, bundleID string) (policy.Bundle, bool) {
+	bundles, _, err := s.loadPolicyBundles(ctx)
+	if err != nil {
+		slog.Warn("edge unified rule lookup failed; using legacy safety path", "error", err, "bundle_id", bundleID)
+		return policy.Bundle{}, false
+	}
+	bundle, ok, err := edgeUnifiedBundleFromRaw(bundleID, bundles[bundleID])
+	if err != nil {
+		slog.Warn("edge unified bundle decode failed; using legacy safety path", "error", err, "bundle_id", bundleID)
+		return policy.Bundle{}, false
+	}
+	return bundle, ok
+}
+
+func edgeUnifiedRuleScope(event edgecore.AgentActionEvent) edgecore.EdgeRuleScopeContext {
+	return edgecore.EdgeRuleScopeContext{
+		TenantID:    event.TenantID,
+		PrincipalID: event.PrincipalID,
+		FleetID:     edgeUnifiedFleetID(event),
+	}
+}
+
+func edgeEvaluateAdaptedRules(adapted []edgecore.AdaptedEdgeRule, snapshot string, req *pb.PolicyCheckRequest) *pb.PolicyCheckResponse {
+	rules := make([]config.PolicyRule, 0, len(adapted))
+	for _, rule := range adapted {
+		rules = append(rules, rule.Rule)
+	}
+	return policybundles.EvaluatePolicyCheck(&config.SafetyPolicy{
+		Rules:           rules,
+		DefaultDecision: "allow",
+	}, snapshot, req)
+}
+
+func edgeAttachUnifiedBundleLabels(event *edgecore.AgentActionEvent, bundle policy.Bundle, snapshot string) {
+	if event.Labels == nil {
+		event.Labels = edgecore.Labels{}
+	}
+	event.Labels["policy.bundle_id"] = strings.TrimSpace(bundle.ID)
+	if strings.TrimSpace(snapshot) != "" {
+		event.Labels["policy.bundle_version"] = strings.TrimSpace(snapshot)
+	}
+}
+
+func edgeUnifiedBundleFromRaw(bundleID string, raw any) (policy.Bundle, bool, error) {
+	bundleMap, ok := raw.(map[string]any)
+	if !ok || bundleMap == nil || !policybundles.BundleEnabled(bundleMap) {
+		return policy.Bundle{}, false, nil
+	}
+	if _, hasVersions := bundleMap["versions"]; !hasVersions {
+		return policy.Bundle{}, false, nil
+	}
+	payload, err := json.Marshal(bundleMap)
+	if err != nil {
+		return policy.Bundle{}, false, err
+	}
+	var bundle policy.Bundle
+	if err := json.Unmarshal(payload, &bundle); err != nil {
+		return policy.Bundle{}, false, err
+	}
+	if strings.TrimSpace(bundle.ID) == "" {
+		bundle.ID = strings.TrimSpace(bundleID)
+	}
+	return bundle, true, nil
+}
+
+func edgeAdaptedRulesFromBundle(bundle policy.Bundle, ctx edgecore.EdgeRuleScopeContext, fallback edgecore.PolicyMode) ([]edgecore.AdaptedEdgeRule, string) {
+	if len(bundle.Versions) == 0 {
+		return nil, ""
+	}
+	version := bundle.Versions[len(bundle.Versions)-1]
+	out := make([]edgecore.AdaptedEdgeRule, 0, len(version.RuleSnapshot))
+	for _, rule := range version.RuleSnapshot {
+		if rule.Type != policy.RuleTypeEdge || rule.Status != policy.RuleStatusPublished {
+			continue
+		}
+		if !edgecore.RuleScopeMatchesEdge(rule.Scope, ctx) {
+			continue
+		}
+		adapted, err := edgecore.AdaptUnifiedEdgeRule(rule, edgecore.EdgeRuleAdapterOptions{
+			Bundle:       &bundle,
+			FallbackMode: fallback,
+		})
+		if err != nil {
+			slog.Warn("edge unified rule adapter rejected rule; skipping", "error", err, "rule_id", rule.ID, "bundle_id", bundle.ID)
+			continue
+		}
+		out = append(out, adapted)
+	}
+	snapshot := strings.TrimSpace(version.Version)
+	if snapshot == "" {
+		snapshot = strings.TrimSpace(bundle.ID)
+	}
+	return out, snapshot
+}
+
+func edgeUnifiedFleetID(event edgecore.AgentActionEvent) string {
+	for _, key := range []string{"edge.fleet_id", "fleet_id", "edge.fleet", "fleet"} {
+		if value := strings.TrimSpace(event.Labels[key]); value != "" {
+			return value
+		}
+	}
+	return strings.TrimSpace(event.AgentProduct)
+}

--- a/core/controlplane/gateway/handlers_edge_evaluate.go
+++ b/core/controlplane/gateway/handlers_edge_evaluate.go
@@ -147,22 +147,26 @@ func (s *server) handleEdgeEvaluate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	policyInput, err := buildEdgeEvaluatePolicyInput(evalCtx)
+	policyInput, err := s.buildEdgeEvaluatePolicyInput(r.Context(), evalCtx)
 	if err != nil {
 		writeEdgeEventRequestError(w, r, err, "invalid edge evaluate request")
 		return
 	}
-	safetyResp, err := s.evaluateEdgeSafety(r.Context(), policyInput.policyRequest)
-	if err != nil {
-		outcome := edgeEvaluateOutcomeFromSafetyUnavailable(policyInput.event.EventID, evalCtx.policyMode, policyInput.classification)
-		appended, appendErr := s.appendEdgeEvaluateOutcome(r.Context(), evalCtx.store, policyInput.event, outcome, edgeEvaluateDurationMS(started))
-		if appendErr != nil {
-			writeEdgeEventStoreError(w, r, appendErr, "append edge evaluate degraded event")
+	safetyResp := policyInput.unifiedPolicyResponse
+	if safetyResp == nil {
+		var err error
+		safetyResp, err = s.evaluateEdgeSafety(r.Context(), policyInput.policyRequest)
+		if err != nil {
+			outcome := edgeEvaluateOutcomeFromSafetyUnavailable(policyInput.event.EventID, evalCtx.policyMode, policyInput.classification)
+			appended, appendErr := s.appendEdgeEvaluateOutcome(r.Context(), evalCtx.store, policyInput.event, outcome, edgeEvaluateDurationMS(started))
+			if appendErr != nil {
+				writeEdgeEventStoreError(w, r, appendErr, "append edge evaluate degraded event")
+				return
+			}
+			outcome.response.EventID = appended.EventID
+			writeJSON(w, outcome.response)
 			return
 		}
-		outcome.response.EventID = appended.EventID
-		writeJSON(w, outcome.response)
-		return
 	}
 	outcome := edgeEvaluateOutcomeFromSafety(policyInput.event.EventID, safetyResp)
 	outcome = s.decorateEdgeEvaluateTierEvidence(r.Context(), policyInput.event.Labels, outcome)
@@ -416,9 +420,10 @@ func isTerminalEdgeSessionStatus(status edgecore.SessionStatus) bool {
 }
 
 type edgeEvaluatePolicyInput struct {
-	event          edgecore.AgentActionEvent
-	classification edgecore.ActionClassification
-	policyRequest  *pb.PolicyCheckRequest
+	event                 edgecore.AgentActionEvent
+	classification        edgecore.ActionClassification
+	policyRequest         *pb.PolicyCheckRequest
+	unifiedPolicyResponse *pb.PolicyCheckResponse
 }
 
 type edgeEvaluateDecisionOutcome struct {
@@ -1237,7 +1242,7 @@ func (s *server) appendEdgeEvaluateOutcome(ctx context.Context, store edgecore.S
 	// require_approval -> approval_requested, throttle -> action_denied
 	// medium). Best-effort: nil-safe + panic-recovering, so audit
 	// failures never change the response.
-	s.emitEdgeDecisionAuditEvents(appended)
+	s.emitEdgeDecisionAuditEvents(ctx, store, appended)
 	return appended, nil
 }
 
@@ -1259,7 +1264,7 @@ func defaultEdgeEvaluateReason(value, fallback string) string {
 	return fallback
 }
 
-func buildEdgeEvaluatePolicyInput(evalCtx edgeEvaluateContext) (edgeEvaluatePolicyInput, error) {
+func (s *server) buildEdgeEvaluatePolicyInput(ctx context.Context, evalCtx edgeEvaluateContext) (edgeEvaluatePolicyInput, error) {
 	req := evalCtx.req
 	if err := rejectRawEdgeEventPayload(edgeEventWriteRequest{
 		ToolInput:     req.ToolInput,
@@ -1339,11 +1344,13 @@ func buildEdgeEvaluatePolicyInput(evalCtx edgeEvaluateContext) (edgeEvaluatePoli
 	if err != nil {
 		return edgeEvaluatePolicyInput{}, edgeEventRequestError{status: http.StatusBadRequest, message: "invalid edge evaluate request"}
 	}
+	unifiedPolicyResponse := s.evaluateBoundUnifiedEdgeRules(ctx, evalCtx, &event, policyRequest)
 
 	return edgeEvaluatePolicyInput{
-		event:          event,
-		classification: classification,
-		policyRequest:  policyRequest,
+		event:                 event,
+		classification:        classification,
+		policyRequest:         policyRequest,
+		unifiedPolicyResponse: unifiedPolicyResponse,
 	}, nil
 }
 

--- a/core/controlplane/gateway/handlers_edge_evaluate.go
+++ b/core/controlplane/gateway/handlers_edge_evaluate.go
@@ -154,7 +154,7 @@ func (s *server) handleEdgeEvaluate(w http.ResponseWriter, r *http.Request) {
 	}
 	safetyResp, err := s.evaluateEdgeSafety(r.Context(), policyInput.policyRequest)
 	if err != nil {
-		outcome := edgeEvaluateOutcomeFromSafetyUnavailable(policyInput.event.EventID, evalCtx.session.PolicyMode, policyInput.classification)
+		outcome := edgeEvaluateOutcomeFromSafetyUnavailable(policyInput.event.EventID, evalCtx.policyMode, policyInput.classification)
 		appended, appendErr := s.appendEdgeEvaluateOutcome(r.Context(), evalCtx.store, policyInput.event, outcome, edgeEvaluateDurationMS(started))
 		if appendErr != nil {
 			writeEdgeEventStoreError(w, r, appendErr, "append edge evaluate degraded event")
@@ -300,6 +300,9 @@ type edgeEvaluateContext struct {
 	principalID string
 	session     *edgecore.EdgeSession
 	execution   *edgecore.AgentExecution
+	policyMode  edgecore.PolicyMode
+	modeSource  string
+	modeBundle  string
 }
 
 func (s *server) prepareEdgeEvaluateContext(w http.ResponseWriter, r *http.Request) (edgeEvaluateContext, bool) {
@@ -381,6 +384,14 @@ func (s *server) prepareEdgeEvaluateContext(w http.ResponseWriter, r *http.Reque
 	req.ExecutionID = executionID
 	req.TenantID = tenantID
 	req.PrincipalID = principalID
+	mode := s.resolveEdgeEvaluatePolicyMode(r.Context(), *session)
+	slog.Debug("edge evaluate policy mode resolved",
+		"tenant_id", tenantID,
+		"session_id", sessionID,
+		"mode", string(mode.Mode),
+		"source", mode.Source,
+		"bundle_id", mode.BundleID,
+	)
 	return edgeEvaluateContext{
 		req:         req,
 		store:       store,
@@ -389,6 +400,9 @@ func (s *server) prepareEdgeEvaluateContext(w http.ResponseWriter, r *http.Reque
 		principalID: principalID,
 		session:     session,
 		execution:   execution,
+		policyMode:  mode.Mode,
+		modeSource:  mode.Source,
+		modeBundle:  mode.BundleID,
 	}, true
 }
 
@@ -1223,7 +1237,7 @@ func (s *server) appendEdgeEvaluateOutcome(ctx context.Context, store edgecore.S
 	// require_approval -> approval_requested, throttle -> action_denied
 	// medium). Best-effort: nil-safe + panic-recovering, so audit
 	// failures never change the response.
-	edgecore.SendSIEMEvent(s.auditExporter, edgecore.SIEMEventForAction(appended))
+	s.emitEdgeDecisionAuditEvents(appended)
 	return appended, nil
 }
 

--- a/core/controlplane/gateway/handlers_edge_events.go
+++ b/core/controlplane/gateway/handlers_edge_events.go
@@ -140,7 +140,7 @@ func (s *server) handleCreateEdgeEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.forwardPersistedEdgeEvent(appended)
-	s.emitEdgeDecisionAuditEvents(appended)
+	s.emitEdgeDecisionAuditEvents(r.Context(), store, appended)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_, _ = w.Write(responseBody)
@@ -217,7 +217,7 @@ func (s *server) handleCreateEdgeEventsBatch(w http.ResponseWriter, r *http.Requ
 	}
 	for _, event := range appended {
 		s.forwardPersistedEdgeEvent(event)
-		s.emitEdgeDecisionAuditEvents(event)
+		s.emitEdgeDecisionAuditEvents(r.Context(), store, event)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -245,7 +245,7 @@ func (s *server) appendEdgeEventWithIdempotency(w http.ResponseWriter, r *http.R
 		return
 	}
 	s.forwardPersistedEdgeEvent(result.Events[0])
-	s.emitEdgeDecisionAuditEvents(result.Events[0])
+	s.emitEdgeDecisionAuditEvents(r.Context(), store, result.Events[0])
 	writeEdgeIdempotencyReplay(w, r, result.Record)
 }
 
@@ -265,7 +265,7 @@ func (s *server) appendEdgeEventBatchWithIdempotency(w http.ResponseWriter, r *h
 	}
 	for _, event := range result.Events {
 		s.forwardPersistedEdgeEvent(event)
-		s.emitEdgeDecisionAuditEvents(event)
+		s.emitEdgeDecisionAuditEvents(r.Context(), store, event)
 	}
 	writeEdgeIdempotencyReplay(w, r, result.Record)
 }

--- a/core/controlplane/gateway/handlers_edge_events.go
+++ b/core/controlplane/gateway/handlers_edge_events.go
@@ -140,6 +140,7 @@ func (s *server) handleCreateEdgeEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.forwardPersistedEdgeEvent(appended)
+	s.emitEdgeDecisionAuditEvents(appended)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_, _ = w.Write(responseBody)
@@ -216,6 +217,7 @@ func (s *server) handleCreateEdgeEventsBatch(w http.ResponseWriter, r *http.Requ
 	}
 	for _, event := range appended {
 		s.forwardPersistedEdgeEvent(event)
+		s.emitEdgeDecisionAuditEvents(event)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -243,6 +245,7 @@ func (s *server) appendEdgeEventWithIdempotency(w http.ResponseWriter, r *http.R
 		return
 	}
 	s.forwardPersistedEdgeEvent(result.Events[0])
+	s.emitEdgeDecisionAuditEvents(result.Events[0])
 	writeEdgeIdempotencyReplay(w, r, result.Record)
 }
 
@@ -262,6 +265,7 @@ func (s *server) appendEdgeEventBatchWithIdempotency(w http.ResponseWriter, r *h
 	}
 	for _, event := range result.Events {
 		s.forwardPersistedEdgeEvent(event)
+		s.emitEdgeDecisionAuditEvents(event)
 	}
 	writeEdgeIdempotencyReplay(w, r, result.Record)
 }

--- a/core/edge/agentd/evaluator.go
+++ b/core/edge/agentd/evaluator.go
@@ -163,13 +163,16 @@ func (e *Evaluator) evaluateFreshDecision(evalCtx context.Context, req claude.Ag
 	// record — reusing resp.EventID would collide with the gateway-written
 	// event when the events/batch flush hits loadEventByIDInTx.
 	freshResp := *resp
+	gatewayEventID := strings.TrimSpace(freshResp.EventID)
 	freshResp.EventID = ""
 	if err := e.recordDecisionEvidence(writer, requireEvidence, decision, evalReq, DecisionEvidence{
-		State:      e.state,
-		Request:    req,
-		Response:   freshResp,
-		CacheMiss:  e.cache != nil,
-		DurationMS: req.DurationMS,
+		State:               e.state,
+		Request:             req,
+		Response:            freshResp,
+		CacheMiss:           e.cache != nil,
+		DurationMS:          req.DurationMS,
+		GatewayEventID:      gatewayEventID,
+		GatewayAuditEmitted: gatewayEventID != "",
 	}); err != nil {
 		return decision, err
 	}

--- a/core/edge/agentd/evaluator_test.go
+++ b/core/edge/agentd/evaluator_test.go
@@ -91,6 +91,10 @@ func TestEvaluatorCallsGatewayAndRecordsDecisionEvidence(t *testing.T) {
 	if event.Kind != edgecore.EventKindHookPolicyDecision || event.Decision != edgecore.DecisionAllow {
 		t.Fatalf("decision event = %#v", event)
 	}
+	if event.Labels[edgecore.LabelDecisionAuditEmittedBy] != edgecore.LabelDecisionAuditEmittedByGateway ||
+		event.Labels[edgecore.LabelGatewayDecisionEventID] != "evt-eval-decision" {
+		t.Fatalf("fresh gateway audit labels = %#v, want emitted_by=gateway and gateway event id", event.Labels)
+	}
 	payload, _ := json.Marshal(event)
 	for _, forbidden := range []string{"raw-evaluator-secret", "evaluator-secret", "secret-transcript", `C:\\Users\\yaron`} {
 		if strings.Contains(string(payload), forbidden) {

--- a/core/edge/agentd/evaluator_unified_test.go
+++ b/core/edge/agentd/evaluator_unified_test.go
@@ -1,0 +1,53 @@
+package agentd
+
+import (
+	"testing"
+
+	edgecore "github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/edge/claude"
+	"github.com/cordum/cordum/core/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentdDecisionEvidenceCanEmitUnifiedEdgeDecision(t *testing.T) {
+	event, err := BuildDecisionEvidenceEvent(DecisionEvidence{
+		State: evidenceTestState(edgecore.PolicyModeEnterpriseStrict),
+		Request: claude.AgentdRequest{
+			EventName:     "PreToolUse",
+			SessionID:     "edge_sess_unified",
+			ExecutionID:   "edge_exec_unified",
+			TenantID:      "tenant-unified",
+			PrincipalID:   "principal-unified",
+			ToolName:      "Bash",
+			InputRedacted: map[string]any{"command": "rm -rf /tmp/project"},
+			InputHash:     "sha256:input-unified",
+			ActionHash:    "sha256:action-unified",
+			RiskTags:      []string{"destructive", "filesystem"},
+		},
+		Response: edgecoreDecisionResponse(edgecore.DecisionDeny),
+		Degraded: true,
+	})
+	require.NoError(t, err)
+
+	got, err := edgecore.EmitDecisionForEdgeEvent(event, edgecore.EdgeDecisionEmitOptions{
+		BundleID:      "agentd-local-cache",
+		BundleVersion: "degraded",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, policy.DecisionSourceEdge, got.Source)
+	require.Equal(t, policy.DecisionDeny, got.Type)
+	require.Equal(t, event.RuleID, got.RuleID)
+	require.Equal(t, "agentd-local-cache", got.BundleID)
+	require.Equal(t, "degraded", got.BundleVersion)
+}
+
+func edgecoreDecisionResponse(decision edgecore.EdgeDecision) EvaluateResponse {
+	return EvaluateResponse{
+		Decision:       string(decision),
+		EventID:        "evt-agentd-unified",
+		Reason:         "agentd degraded fallback",
+		RuleID:         "edge.agentd.degraded",
+		PolicySnapshot: "snap-agentd",
+	}
+}

--- a/core/edge/agentd/events.go
+++ b/core/edge/agentd/events.go
@@ -29,6 +29,13 @@ type DecisionEvidence struct {
 	ErrorCode    string
 	ErrorMessage string
 	DurationMS   int
+
+	// GatewayEventID is set only for fresh Gateway evaluate responses whose
+	// policy-decision audit was already emitted by /edge/evaluate. The agentd
+	// evidence event is still persisted, but Gateway /edge/events can suppress
+	// duplicate audit emission after verifying this referenced event exists.
+	GatewayEventID      string
+	GatewayAuditEmitted bool
 }
 
 // RecordDecisionEvidence writes a best-effort policy decision event and returns
@@ -224,6 +231,12 @@ func decisionEvidenceLabels(req claude.AgentdRequest, state SessionState, eviden
 		labels["action_hash"] = sanitizeEventText(evidence.Response.ActionHash)
 	} else if req.ActionHash != "" {
 		labels["action_hash"] = sanitizeEventText(req.ActionHash)
+	}
+	if evidence.GatewayAuditEmitted {
+		labels[edgecore.LabelDecisionAuditEmittedBy] = edgecore.LabelDecisionAuditEmittedByGateway
+	}
+	if strings.TrimSpace(evidence.GatewayEventID) != "" {
+		labels[edgecore.LabelGatewayDecisionEventID] = sanitizeEventText(evidence.GatewayEventID)
 	}
 	if tier := decisionEvidenceRuleTier(evidence.Response); tier != "" {
 		labels["tier"] = tier

--- a/core/edge/decision_emitter.go
+++ b/core/edge/decision_emitter.go
@@ -1,0 +1,91 @@
+package edge
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+)
+
+// EdgeDecisionEmitOptions carries optional context for unified edge decisions.
+type EdgeDecisionEmitOptions struct {
+	BundleID       string
+	BundleVersion  string
+	InputRef       string
+	OutputRef      string
+	AuditHash      string
+	Classification *ActionClassification
+}
+
+// EmitDecisionForEdgeEvent converts a persisted edge policy-decision event into
+// the shared policy.Decision shape without changing the legacy EdgeDecision.
+func EmitDecisionForEdgeEvent(event AgentActionEvent, opts EdgeDecisionEmitOptions) (policy.Decision, error) {
+	ruleID := strings.TrimSpace(event.RuleID)
+	if ruleID == "" {
+		return policy.Decision{}, fmt.Errorf("edge policy decision requires rule_id")
+	}
+	decisionType, err := policyDecisionTypeForEdge(event.Decision)
+	if err != nil {
+		return policy.Decision{}, err
+	}
+	timestamp := edgeDecisionTimestamp(event.Timestamp)
+	trace := []policy.TraceStep{{
+		RuleID:       ruleID,
+		DecisionType: decisionType,
+		Reason:       edgeDecisionTraceReason(event, opts.Classification),
+		Timestamp:    timestamp,
+	}}
+	return policy.Decision{
+		Source:        policy.DecisionSourceEdge,
+		RuleID:        ruleID,
+		BundleID:      strings.TrimSpace(opts.BundleID),
+		BundleVersion: strings.TrimSpace(opts.BundleVersion),
+		Type:          decisionType,
+		Trace:         trace,
+		InputRef:      strings.TrimSpace(opts.InputRef),
+		OutputRef:     strings.TrimSpace(opts.OutputRef),
+		AuditHash:     strings.TrimSpace(opts.AuditHash),
+		Timestamp:     timestamp,
+	}, nil
+}
+
+func policyDecisionTypeForEdge(decision EdgeDecision) (policy.DecisionType, error) {
+	switch decision {
+	case DecisionAllow:
+		return policy.DecisionAllow, nil
+	case DecisionDeny:
+		return policy.DecisionDeny, nil
+	case DecisionRequireApproval:
+		return policy.DecisionRequireHuman, nil
+	case DecisionThrottle:
+		return policy.DecisionThrottle, nil
+	case DecisionConstrain:
+		return policy.DecisionRedact, nil
+	case DecisionRecorded:
+		return policy.DecisionAllow, nil
+	default:
+		return "", fmt.Errorf("unsupported edge decision %q", strings.TrimSpace(string(decision)))
+	}
+}
+
+func edgeDecisionTimestamp(eventTime time.Time) time.Time {
+	if eventTime.IsZero() {
+		return time.Now().UTC()
+	}
+	return eventTime.UTC()
+}
+
+func edgeDecisionTraceReason(event AgentActionEvent, classification *ActionClassification) string {
+	reason := strings.TrimSpace(event.DecisionReason)
+	if reason == "" && classification != nil {
+		reason = strings.TrimSpace(classification.ActionName)
+	}
+	if reason == "" {
+		reason = strings.TrimSpace(string(event.Decision))
+	}
+	if event.Decision == DecisionRecorded && !strings.Contains(strings.ToLower(reason), "recorded") {
+		return "recorded: " + reason
+	}
+	return reason
+}

--- a/core/edge/decision_emitter_test.go
+++ b/core/edge/decision_emitter_test.go
@@ -1,0 +1,111 @@
+package edge
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmitDecisionForEdgeEventMapsEveryEdgeDecision(t *testing.T) {
+	cases := []struct {
+		name         string
+		edgeDecision EdgeDecision
+		want         policy.DecisionType
+		wantMarker   string
+	}{
+		{"allow", DecisionAllow, policy.DecisionAllow, ""},
+		{"deny", DecisionDeny, policy.DecisionDeny, ""},
+		{"require approval", DecisionRequireApproval, policy.DecisionRequireHuman, ""},
+		{"throttle", DecisionThrottle, policy.DecisionThrottle, ""},
+		{"constrain", DecisionConstrain, policy.DecisionRedact, ""},
+		{"recorded", DecisionRecorded, policy.DecisionAllow, "recorded"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := unifiedDecisionTestEvent(tc.edgeDecision)
+			got, err := EmitDecisionForEdgeEvent(event, EdgeDecisionEmitOptions{
+				BundleID:      "bundle-edge-main",
+				BundleVersion: "bundle-v3",
+				InputRef:      "artifact://tenant-a/input",
+				OutputRef:     "artifact://tenant-a/output",
+				AuditHash:     "sha256:audit-edge",
+				Classification: &ActionClassification{
+					ActionName: "bash.exec",
+					Capability: "exec.shell",
+					RiskTags:   []string{"exec", "filesystem"},
+				},
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, policy.DecisionSourceEdge, got.Source)
+			require.Equal(t, event.RuleID, got.RuleID)
+			require.Equal(t, "bundle-edge-main", got.BundleID)
+			require.Equal(t, "bundle-v3", got.BundleVersion)
+			require.Equal(t, tc.want, got.Type)
+			require.Equal(t, "artifact://tenant-a/input", got.InputRef)
+			require.Equal(t, "artifact://tenant-a/output", got.OutputRef)
+			require.Equal(t, "sha256:audit-edge", got.AuditHash)
+			require.False(t, got.Timestamp.IsZero())
+			require.Equal(t, got.Timestamp.UTC(), got.Timestamp)
+			require.Len(t, got.Trace, 1)
+			require.Equal(t, event.RuleID, got.Trace[0].RuleID)
+			require.Equal(t, tc.want, got.Trace[0].DecisionType)
+			require.Contains(t, got.Trace[0].Reason, event.DecisionReason)
+			if tc.wantMarker != "" {
+				require.Contains(t, strings.ToLower(got.Trace[0].Reason), tc.wantMarker)
+			}
+		})
+	}
+}
+
+func TestEmitDecisionForEdgeEventHandlesNilClassificationAndBundleContext(t *testing.T) {
+	event := unifiedDecisionTestEvent(DecisionAllow)
+
+	got, err := EmitDecisionForEdgeEvent(event, EdgeDecisionEmitOptions{})
+
+	require.NoError(t, err)
+	require.Equal(t, policy.DecisionSourceEdge, got.Source)
+	require.Equal(t, policy.DecisionAllow, got.Type)
+	require.Equal(t, event.RuleID, got.RuleID)
+	require.Empty(t, got.BundleID)
+	require.Empty(t, got.BundleVersion)
+	require.Empty(t, got.InputRef)
+	require.NotEmpty(t, got.Trace)
+}
+
+func TestEmitDecisionForEdgeEventRejectsMissingRuleAndUnknownDecision(t *testing.T) {
+	missingRule := unifiedDecisionTestEvent(DecisionDeny)
+	missingRule.RuleID = ""
+	_, err := EmitDecisionForEdgeEvent(missingRule, EdgeDecisionEmitOptions{})
+	require.ErrorContains(t, err, "rule")
+
+	unknown := unifiedDecisionTestEvent(EdgeDecision("EXPLODE"))
+	_, err = EmitDecisionForEdgeEvent(unknown, EdgeDecisionEmitOptions{})
+	require.ErrorContains(t, err, "decision")
+}
+
+func unifiedDecisionTestEvent(decision EdgeDecision) AgentActionEvent {
+	return AgentActionEvent{
+		EventID:        "evt-unified-edge",
+		SessionID:      "sess-unified-edge",
+		ExecutionID:    "exec-unified-edge",
+		TenantID:       "tenant-a",
+		PrincipalID:    "principal-a",
+		Timestamp:      time.Date(2026, 5, 9, 12, 30, 0, 0, time.UTC),
+		Layer:          LayerHook,
+		Kind:           EventKindHookPolicyDecision,
+		ActionName:     "bash.exec",
+		Capability:     "exec.shell",
+		RiskTags:       []string{"exec"},
+		Decision:       decision,
+		DecisionReason: "matched edge rule",
+		RuleID:         "edge.rule." + strings.ToLower(strings.ReplaceAll(string(decision), "_", "-")),
+		RuleTier:       "edge",
+		PolicySnapshot: "snap-edge",
+		InputHash:      "sha256:input-edge",
+	}
+}

--- a/core/edge/labels.go
+++ b/core/edge/labels.go
@@ -10,6 +10,16 @@ const (
 	// LabelPolicyAttachmentID carries the synthetic bundle key used to scope a
 	// job/session-specific policy override at Safety Kernel evaluate time.
 	LabelPolicyAttachmentID = policylabels.PolicyAttachmentID
+
+	// LabelDecisionAuditEmittedBy marks agentd evidence whose fresh Gateway
+	// evaluate response already emitted the shared policy decision audit record.
+	LabelDecisionAuditEmittedBy = "policy.audit_emitted_by"
+	// LabelDecisionAuditEmittedByGateway is the value used when Gateway
+	// evaluate already emitted the policy decision audit record.
+	LabelDecisionAuditEmittedByGateway = "gateway"
+	// LabelGatewayDecisionEventID links the agentd evidence event to the
+	// Gateway-persisted hook.policy_decision event that already emitted audit.
+	LabelGatewayDecisionEventID = "policy.gateway_event_id"
 )
 
 // JobPolicyAttachmentID returns the synthetic bundle key for a Cordum job.

--- a/core/edge/policy_adapter.go
+++ b/core/edge/policy_adapter.go
@@ -1,0 +1,232 @@
+package edge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+)
+
+// EdgeRuleAdapterOptions carries bundle-level context for unified edge rules.
+type EdgeRuleAdapterOptions struct {
+	Bundle       *policy.Bundle
+	FallbackMode PolicyMode
+}
+
+// AdaptedEdgeRule is the legacy edge policy shape plus unified bundle context.
+type AdaptedEdgeRule struct {
+	Rule          config.PolicyRule
+	PolicyMode    PolicyMode
+	BundleID      string
+	BundleVersion string
+}
+
+// EdgeRuleScopeContext is the runtime identity used to match edge rule scopes.
+type EdgeRuleScopeContext struct {
+	TenantID    string
+	PrincipalID string
+	FleetID     string
+}
+
+// AdaptUnifiedEdgeRule converts a unified edge Rule into the legacy policy
+// rule shape consumed by the current edge/Safety Kernel compatibility path.
+func AdaptUnifiedEdgeRule(rule policy.Rule, opts EdgeRuleAdapterOptions) (AdaptedEdgeRule, error) {
+	if rule.Type != policy.RuleTypeEdge {
+		return AdaptedEdgeRule{}, fmt.Errorf("edge rule adapter requires type edge, got %q", rule.Type)
+	}
+	match, err := parseEdgeRuleMatch(rule.Match)
+	if err != nil {
+		return AdaptedEdgeRule{}, err
+	}
+	decide, err := parseEdgeRuleDecide(rule.Decide)
+	if err != nil {
+		return AdaptedEdgeRule{}, err
+	}
+	legacy := config.PolicyRule{
+		ID:          strings.TrimSpace(rule.ID),
+		Tier:        config.PolicyTierGlobal,
+		Match:       match.toPolicyMatch(),
+		Decision:    decide.decision,
+		Reason:      strings.TrimSpace(decide.reason),
+		Constraints: config.PolicyConstraints{RedactionLevel: strings.TrimSpace(decide.redactionLevel)},
+	}
+	bundle := edgeBundleMetadata(opts.Bundle)
+	return AdaptedEdgeRule{
+		Rule:          legacy,
+		PolicyMode:    PolicyModeFromBundleMetadata(bundle, opts.FallbackMode),
+		BundleID:      strings.TrimSpace(bundle.ID),
+		BundleVersion: latestBundleVersion(bundle),
+	}, nil
+}
+
+// RuleScopeMatchesEdge reports whether a unified rule scope applies to an
+// edge evaluation context. Job-only scopes intentionally never match edge.
+func RuleScopeMatchesEdge(scope policy.RuleScope, ctx EdgeRuleScopeContext) bool {
+	value := strings.TrimSpace(scope.Value)
+	switch scope.Kind {
+	case policy.RuleScopeGlobal:
+		return true
+	case policy.RuleScopeTenant:
+		return value != "" && value == strings.TrimSpace(ctx.TenantID)
+	case policy.RuleScopeEdgeFleet:
+		return value != "" && value == strings.TrimSpace(ctx.FleetID)
+	case policy.RuleScopeEdgeUser:
+		return value != "" && value == strings.TrimSpace(ctx.PrincipalID)
+	default:
+		return false
+	}
+}
+
+// PolicyModeFromBundleMetadata resolves per-bundle edge mode, falling back to
+// the legacy session/global mode while migration tooling backfills bundles.
+func PolicyModeFromBundleMetadata(bundle policy.Bundle, fallback PolicyMode) PolicyMode {
+	switch bundle.Metadata.EdgeMode {
+	case policy.EdgeModeObserve:
+		return PolicyModeObserve
+	case policy.EdgeModeEnforce:
+		return PolicyModeEnforce
+	case policy.EdgeModeEnterpriseStrict:
+		return PolicyModeEnterpriseStrict
+	default:
+		return fallback
+	}
+}
+
+type edgeRuleMatchPayload struct {
+	Tenants        []string            `json:"tenants"`
+	Topics         []string            `json:"topics"`
+	Capabilities   []string            `json:"capabilities"`
+	RiskTags       []string            `json:"risk_tags"`
+	Labels         map[string]string   `json:"labels"`
+	LabelAllowlist map[string][]string `json:"label_allowlist"`
+	LabelThreshold map[string]float64  `json:"label_threshold"`
+}
+
+func parseEdgeRuleMatch(raw json.RawMessage) (edgeRuleMatchPayload, error) {
+	if len(raw) == 0 {
+		return edgeRuleMatchPayload{}, fmt.Errorf("edge rule match is required")
+	}
+	var match edgeRuleMatchPayload
+	if err := json.Unmarshal(raw, &match); err != nil {
+		return edgeRuleMatchPayload{}, fmt.Errorf("parse edge rule match: %w", err)
+	}
+	if len(match.Topics) == 0 {
+		match.Topics = []string{EdgePolicyTopic}
+	}
+	return match, nil
+}
+
+func (m edgeRuleMatchPayload) toPolicyMatch() config.PolicyMatch {
+	return config.PolicyMatch{
+		Tenants:        trimSlice(m.Tenants),
+		Topics:         trimSlice(m.Topics),
+		Capabilities:   trimSlice(m.Capabilities),
+		RiskTags:       trimSlice(m.RiskTags),
+		Labels:         cloneRuleStringMap(m.Labels),
+		LabelAllowlist: cloneRuleStringSliceMap(m.LabelAllowlist),
+		LabelThreshold: cloneRuleFloatMap(m.LabelThreshold),
+	}
+}
+
+type edgeRuleDecidePayload struct {
+	decision       string
+	reason         string
+	redactionLevel string
+}
+
+func parseEdgeRuleDecide(raw json.RawMessage) (edgeRuleDecidePayload, error) {
+	if len(raw) == 0 {
+		return edgeRuleDecidePayload{}, fmt.Errorf("edge rule decide is required")
+	}
+	var wire struct {
+		Decision    string `json:"decision"`
+		Reason      string `json:"reason"`
+		Constraints struct {
+			RedactionLevel string `json:"redaction_level"`
+		} `json:"constraints"`
+	}
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return edgeRuleDecidePayload{}, fmt.Errorf("parse edge rule decide: %w", err)
+	}
+	decision, err := normalizeEdgeRuleDecision(wire.Decision)
+	if err != nil {
+		return edgeRuleDecidePayload{}, err
+	}
+	return edgeRuleDecidePayload{decision: decision, reason: wire.Reason, redactionLevel: wire.Constraints.RedactionLevel}, nil
+}
+
+func normalizeEdgeRuleDecision(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "allow":
+		return "allow", nil
+	case "deny":
+		return "deny", nil
+	case "require_approval", "require_human":
+		return "require_approval", nil
+	case "throttle":
+		return "throttle", nil
+	case "constrain", "allow_with_constraints":
+		return "allow_with_constraints", nil
+	default:
+		return "", fmt.Errorf("unsupported edge rule decision %q", strings.TrimSpace(raw))
+	}
+}
+
+func edgeBundleMetadata(bundle *policy.Bundle) policy.Bundle {
+	if bundle == nil {
+		return policy.Bundle{}
+	}
+	return *bundle
+}
+
+func latestBundleVersion(bundle policy.Bundle) string {
+	if len(bundle.Versions) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(bundle.Versions[len(bundle.Versions)-1].Version)
+}
+
+func trimSlice(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func cloneRuleStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return out
+}
+
+func cloneRuleStringSliceMap(values map[string][]string) map[string][]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(values))
+	for key, value := range values {
+		out[strings.TrimSpace(key)] = trimSlice(value)
+	}
+	return out
+}
+
+func cloneRuleFloatMap(values map[string]float64) map[string]float64 {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]float64, len(values))
+	for key, value := range values {
+		out[strings.TrimSpace(key)] = value
+	}
+	return out
+}

--- a/core/edge/policy_adapter_test.go
+++ b/core/edge/policy_adapter_test.go
@@ -1,0 +1,173 @@
+package edge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdaptUnifiedEdgeRuleMapsRuleToLegacyPolicyRule(t *testing.T) {
+	rule := policy.Rule{
+		ID:      "edge.deny.shell",
+		Name:    "Deny destructive shell",
+		Type:    policy.RuleTypeEdge,
+		Scope:   policy.RuleScope{Kind: policy.RuleScopeEdgeFleet, Value: "claude-code"},
+		Status:  policy.RuleStatusPublished,
+		Version: "rule-v7",
+		Match: edgeRuleRawJSON(t, map[string]any{
+			"capabilities": []string{"exec.shell"},
+			"risk_tags":    []string{"destructive", "filesystem"},
+			"labels":       map[string]string{"command.class": "destructive"},
+			"label_allowlist": map[string][]string{
+				"agent.product": {"claude-code"},
+			},
+		}),
+		Decide: edgeRuleRawJSON(t, map[string]any{
+			"decision": "deny",
+			"reason":   "destructive shell command",
+			"constraints": map[string]any{
+				"redaction_level": "strict",
+			},
+		}),
+	}
+	bundle := &policy.Bundle{
+		ID:       "bundle-edge-main",
+		Metadata: policy.BundleMetadata{EdgeMode: policy.EdgeModeEnforce},
+		Versions: []policy.BundleVersion{{Version: "bundle-v3"}},
+	}
+
+	got, err := AdaptUnifiedEdgeRule(rule, EdgeRuleAdapterOptions{
+		Bundle:       bundle,
+		FallbackMode: PolicyModeObserve,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, PolicyModeEnforce, got.PolicyMode)
+	require.Equal(t, "bundle-edge-main", got.BundleID)
+	require.Equal(t, "bundle-v3", got.BundleVersion)
+
+	legacy := got.Rule
+	require.Equal(t, rule.ID, legacy.ID)
+	require.Equal(t, config.PolicyTierGlobal, legacy.Tier)
+	require.Equal(t, "deny", legacy.Decision)
+	require.Equal(t, "destructive shell command", legacy.Reason)
+	require.Equal(t, []string{EdgePolicyTopic}, legacy.Match.Topics)
+	require.Equal(t, []string{"exec.shell"}, legacy.Match.Capabilities)
+	require.Equal(t, []string{"destructive", "filesystem"}, legacy.Match.RiskTags)
+	require.Equal(t, map[string]string{"command.class": "destructive"}, legacy.Match.Labels)
+	require.Equal(t, map[string][]string{"agent.product": {"claude-code"}}, legacy.Match.LabelAllowlist)
+	require.Equal(t, "strict", legacy.Constraints.RedactionLevel)
+}
+
+func TestAdaptUnifiedEdgeRuleRejectsWrongTypeMissingAndCorruptPayloads(t *testing.T) {
+	base := policy.Rule{
+		ID:     "edge.bad",
+		Type:   policy.RuleTypeEdge,
+		Scope:  policy.RuleScope{Kind: policy.RuleScopeGlobal},
+		Status: policy.RuleStatusPublished,
+		Match:  edgeRuleRawJSON(t, map[string]any{"capabilities": []string{"exec.shell"}}),
+		Decide: edgeRuleRawJSON(t, map[string]any{"decision": "deny"}),
+	}
+
+	for _, tc := range []struct {
+		name       string
+		mutate     func(*policy.Rule)
+		wantErrSub string
+	}{
+		{
+			name: "wrong type",
+			mutate: func(rule *policy.Rule) {
+				rule.Type = policy.RuleTypeInput
+			},
+			wantErrSub: "type edge",
+		},
+		{
+			name: "missing match",
+			mutate: func(rule *policy.Rule) {
+				rule.Match = nil
+			},
+			wantErrSub: "match",
+		},
+		{
+			name: "corrupt match",
+			mutate: func(rule *policy.Rule) {
+				rule.Match = json.RawMessage(`{"capabilities":`)
+			},
+			wantErrSub: "match",
+		},
+		{
+			name: "missing decide",
+			mutate: func(rule *policy.Rule) {
+				rule.Decide = nil
+			},
+			wantErrSub: "decide",
+		},
+		{
+			name: "unsupported decision",
+			mutate: func(rule *policy.Rule) {
+				rule.Decide = edgeRuleRawJSON(t, map[string]any{"decision": "explode"})
+			},
+			wantErrSub: "decision",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := base
+			tc.mutate(&rule)
+
+			_, err := AdaptUnifiedEdgeRule(rule, EdgeRuleAdapterOptions{})
+
+			require.Error(t, err)
+			require.Contains(t, strings.ToLower(err.Error()), tc.wantErrSub)
+		})
+	}
+}
+
+func TestRuleScopeMatchesEdge(t *testing.T) {
+	ctx := EdgeRuleScopeContext{
+		TenantID:    "tenant-a",
+		PrincipalID: "principal-7",
+		FleetID:     "claude-code",
+	}
+
+	for _, tc := range []struct {
+		name  string
+		scope policy.RuleScope
+		want  bool
+	}{
+		{"global", policy.RuleScope{Kind: policy.RuleScopeGlobal}, true},
+		{"tenant match", policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-a"}, true},
+		{"tenant mismatch", policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-b"}, false},
+		{"fleet match", policy.RuleScope{Kind: policy.RuleScopeEdgeFleet, Value: "claude-code"}, true},
+		{"fleet mismatch", policy.RuleScope{Kind: policy.RuleScopeEdgeFleet, Value: "other-fleet"}, false},
+		{"user match", policy.RuleScope{Kind: policy.RuleScopeEdgeUser, Value: "principal-7"}, true},
+		{"user mismatch", policy.RuleScope{Kind: policy.RuleScopeEdgeUser, Value: "principal-8"}, false},
+		{"job workflow scope never matches edge", policy.RuleScope{Kind: policy.RuleScopeWorkflow, Value: "wf-1"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, RuleScopeMatchesEdge(tc.scope, ctx))
+		})
+	}
+}
+
+func TestPolicyModeFromBundleMetadataFallsBackToLegacyMode(t *testing.T) {
+	require.Equal(t, PolicyModeEnterpriseStrict, PolicyModeFromBundleMetadata(
+		policy.Bundle{Metadata: policy.BundleMetadata{EdgeMode: policy.EdgeModeEnterpriseStrict}},
+		PolicyModeObserve,
+	))
+	require.Equal(t, PolicyModeObserve, PolicyModeFromBundleMetadata(policy.Bundle{}, PolicyModeObserve))
+	require.Equal(t, PolicyModeEnforce, PolicyModeFromBundleMetadata(
+		policy.Bundle{Metadata: policy.BundleMetadata{EdgeMode: policy.EdgeModeEnforce}},
+		PolicyModeEnterpriseStrict,
+	))
+}
+
+func edgeRuleRawJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return data
+}

--- a/core/edge/policy_mapper.go
+++ b/core/edge/policy_mapper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cordum/cordum/core/policy"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 )
 
@@ -66,6 +67,28 @@ func MapEventToPolicyCheckRequest(event AgentActionEvent, classification ActionC
 		InputContentType: strings.TrimSpace(classification.InputContentType),
 		InputSizeBytes:   classification.InputSizeBytes,
 	}, nil
+}
+
+// MapEventToPolicyCheckRequestWithDecision preserves the legacy Safety Kernel
+// request while also constructing the additive unified edge decision.
+func MapEventToPolicyCheckRequestWithDecision(
+	event AgentActionEvent,
+	classification ActionClassification,
+	opts PolicyMappingOptions,
+	emitOpts EdgeDecisionEmitOptions,
+) (*pb.PolicyCheckRequest, policy.Decision, error) {
+	req, err := MapEventToPolicyCheckRequest(event, classification, opts)
+	if err != nil {
+		return nil, policy.Decision{}, err
+	}
+	if emitOpts.Classification == nil {
+		emitOpts.Classification = &classification
+	}
+	decision, err := EmitDecisionForEdgeEvent(event, emitOpts)
+	if err != nil {
+		return nil, policy.Decision{}, err
+	}
+	return req, decision, nil
 }
 
 func mapLabelsForPolicy(event AgentActionEvent, classification ActionClassification) map[string]string {

--- a/core/edge/policy_mapper_unified_test.go
+++ b/core/edge/policy_mapper_unified_test.go
@@ -1,0 +1,62 @@
+package edge
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapEventToPolicyCheckRequestWithDecisionPreservesLegacyRequestAndEmitsEdgeDecision(t *testing.T) {
+	event := AgentActionEvent{
+		EventID:        "evt-map-unified",
+		SessionID:      "sess-map-unified",
+		ExecutionID:    "exec-map-unified",
+		TenantID:       "tenant-map",
+		PrincipalID:    "principal-map",
+		Timestamp:      time.Date(2026, 5, 9, 13, 0, 0, 0, time.UTC),
+		Layer:          LayerHook,
+		Kind:           EventKindHookPolicyDecision,
+		ToolName:       "Bash",
+		AgentProduct:   "claude-code",
+		Decision:       DecisionDeny,
+		DecisionReason: "blocked by edge rule",
+		RuleID:         "edge.deny.shell",
+		Status:         ActionStatusBlocked,
+		Labels:         Labels{"custom.team": "platform"},
+	}
+	classification := ActionClassification{
+		ActionName:       "bash.exec",
+		Capability:       "exec.shell",
+		RiskTags:         []string{"destructive", "exec"},
+		Labels:           Labels{"command.class": "destructive"},
+		InputContent:     []byte(`{"command":"rm -rf /tmp/demo"}`),
+		InputContentType: "application/json",
+		InputSizeBytes:   31,
+	}
+	mapping := PolicyMappingOptions{
+		ActorID:   "actor-edge",
+		ActorType: pb.ActorType_ACTOR_TYPE_HUMAN,
+	}
+
+	legacyOnly, err := MapEventToPolicyCheckRequest(event, classification, mapping)
+	require.NoError(t, err)
+
+	legacyWithDecision, decision, err := MapEventToPolicyCheckRequestWithDecision(
+		event,
+		classification,
+		mapping,
+		EdgeDecisionEmitOptions{BundleID: "bundle-edge-main", BundleVersion: "bundle-v4"},
+	)
+
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(legacyOnly, legacyWithDecision), "legacy request changed:\nwant=%#v\ngot=%#v", legacyOnly, legacyWithDecision)
+	require.Equal(t, policy.DecisionSourceEdge, decision.Source)
+	require.Equal(t, policy.DecisionDeny, decision.Type)
+	require.Equal(t, event.RuleID, decision.RuleID)
+	require.Equal(t, "bundle-edge-main", decision.BundleID)
+	require.Equal(t, "bundle-v4", decision.BundleVersion)
+}

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -10,8 +10,9 @@ with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
 - `core/controlplane/safetykernel/` — consumes `Rule` through adapter
   functions and emits job-source `Decision` values alongside the legacy Safety
   Kernel responses during Backend 3's transition window.
-- `core/edge/` — consumes `Rule{Type: edge}` through an adapter, keeps legacy
-  `EdgeDecision` persistence for compatibility, and emits
+- `core/edge/` and Gateway `/edge/evaluate` — consume bound bundle
+  `Rule{Type: edge}` snapshots through the Edge adapter, keep legacy
+  `EdgeDecision` persistence for compatibility, and emit
   `Decision{Source: edge}` into the shared audit-chain stream (Backend 4).
 - `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
 

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -10,7 +10,9 @@ with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
 - `core/controlplane/safetykernel/` — consumes `Rule` through adapter
   functions and emits job-source `Decision` values alongside the legacy Safety
   Kernel responses during Backend 3's transition window.
-- `core/edge/` — same migration; joins the unified audit-chain (Backend 4).
+- `core/edge/` — consumes `Rule{Type: edge}` through an adapter, keeps legacy
+  `EdgeDecision` persistence for compatibility, and emits
+  `Decision{Source: edge}` into the shared audit-chain stream (Backend 4).
 - `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
 
 ## Match / Decide contract

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -77,6 +77,14 @@ inventing unverifiable rule ids in the audit chain. The shared reader helper
 folds job and Edge `policy.decision.v2` events into one stream by parsing
 `extra.source`.
 
+Edge has two persisted evidence paths during the migration window:
+Gateway `/edge/evaluate` and agentd `/edge/events` decision evidence. Fresh
+agentd evidence that is derived from a Gateway evaluate response carries the
+Gateway decision event id; the Gateway verifies that referenced event in the
+same execution before suppressing duplicate audit emission. Cache-hit,
+degraded, and local-only agentd evidence has no such verified reference and
+continues to emit audit normally.
+
 Rollback/cutover guidance:
 
 1. Start with the default `dual` mode and update SIEM dashboards/alerts to read

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -33,18 +33,19 @@ and migration helpers in `core/audit/config.go`):
 | Constant | Value | Description |
 |----------|-------|-------------|
 | `EventSafetyDecision` | `safety.decision` | Safety kernel allow/deny/throttle decisions |
-| `EventPolicyDecisionV2` | `policy.decision.v2` | Unified Policy Studio `Decision` event emitted during the job-policy migration window |
+| `EventPolicyDecisionV2` | `policy.decision.v2` | Unified Policy Studio `Decision` event emitted during the job/edge policy migration window |
 | `EventSafetyApproval` | `safety.approval` | Human approval or rejection of gated jobs |
 | `EventPolicyChange` | `safety.policy_change` | Policy configuration changes |
 | `EventSafetyViolation` | `safety.violation` | Safety policy violations |
 | `EventSystemAuth` | `system.auth` | Authentication events (login, key creation, user management) |
 
-### Policy Studio unified decisions (Backend 3)
+### Policy Studio unified decisions (Backend 3 + Backend 4)
 
-Job-side Safety Kernel decisions are migrating from the legacy
-`safety.decision` shape to the unified `core/policy.Decision` shape used by
-Policy Studio. During the transition, matched-rule job decisions can be
-written in both shapes through the existing SIEM and hash-chain machinery.
+Job-side Safety Kernel decisions and Edge policy decisions are migrating from
+their legacy shapes (`safety.decision` and `edge.*`) to the unified
+`core/policy.Decision` shape used by Policy Studio. During the transition,
+matched-rule decisions can be written in both shapes through the existing SIEM
+and hash-chain machinery.
 
 `policy.decision.v2` uses the same `SIEMEvent` envelope so existing exporters
 and chain verification continue to work. The normalized fields are:
@@ -56,7 +57,7 @@ and chain verification continue to work. The normalized fields are:
 | `matched_rule` | Unified `Decision.RuleID` |
 | `policy_version` | Unified `Decision.BundleVersion` when present, otherwise the legacy policy snapshot |
 | `reason` | First trace reason, falling back to the legacy reason |
-| `extra.source` | Unified `Decision.Source` (`job` for Safety Kernel decisions) |
+| `extra.source` | Unified `Decision.Source` (`job` for Safety Kernel decisions, `edge` for Edge classifier decisions) |
 | `extra.bundle_id` / `extra.bundle_version` | Optional bundle binding metadata |
 | `extra.input_ref` / `extra.output_ref` | Optional blob references for inputs/outputs |
 | `extra.audit_hash` | Optional unified decision audit hash |
@@ -65,14 +66,16 @@ Emission mode is controlled by `AUDIT_UNIFIED_DECISION_MODE`:
 
 | Value | Behavior |
 |-------|----------|
-| unset / `dual` | Default. Emit legacy `safety.decision` first, then `policy.decision.v2` for matched-rule job decisions. |
-| `legacy` | Emit only the legacy `safety.decision` shape. Use for rollback if downstream SIEM rules are not ready for v2. |
-| `unified` | Emit only `policy.decision.v2` for matched-rule job decisions. Use after downstream consumers cut over. |
+| unset / `dual` | Default. Emit the legacy decision event first (`safety.decision` for jobs or the matching `edge.*` event for Edge), then `policy.decision.v2` for matched-rule decisions. |
+| `legacy` | Emit only the legacy decision shape. Use for rollback if downstream SIEM rules are not ready for v2. |
+| `unified` | Emit only `policy.decision.v2` for matched-rule decisions. Use after downstream consumers cut over. |
 
 Values are case-insensitive. Invalid values safely default to `dual` and are
 logged once. Decisions without a matched rule remain legacy-only until the
 unified evaluator can provide a stable rule/default identifier; this avoids
-inventing unverifiable rule ids in the audit chain.
+inventing unverifiable rule ids in the audit chain. The shared reader helper
+folds job and Edge `policy.decision.v2` events into one stream by parsing
+`extra.source`.
 
 Rollback/cutover guidance:
 
@@ -84,6 +87,16 @@ Rollback/cutover guidance:
 3. After all consumers read v2, set `AUDIT_UNIFIED_DECISION_MODE=unified`.
    Keep legacy parsing code for at least one retention window so historical
    audit-chain verification can still display old events.
+
+Edge-specific notes:
+
+- `ALLOW`, `DENY`, `REQUIRE_APPROVAL`, `THROTTLE`, `CONSTRAIN`, and
+  `RECORDED` continue to be persisted on `AgentActionEvent` for compatibility.
+- Unified Edge decisions use `extra.source=edge`; `RECORDED` maps to
+  `Decision.Type=allow` with a trace marker that it was observation-only.
+- Gateway evaluate decisions and agentd local/cache/degraded decision evidence
+  both bridge into this shared transition path, while non-decision Edge events
+  remain outside the policy decision stream.
 
 ### Output Policy events (added 2026-04)
 
@@ -142,6 +155,10 @@ kind, tool name, hashes, policy snapshot, approval ref, artifact type/result,
 mode/component, and stable reason codes. Raw prompts, tool payloads, signed URLs,
 approval reason text, `InputRedacted` maps, arbitrary labels, bearer tokens, and
 API keys must never be placed in SIEM `extra`.
+
+Matched Edge decisions additionally emit `policy.decision.v2` according to
+`AUDIT_UNIFIED_DECISION_MODE`; legacy Edge event ordering is preserved in dual
+mode.
 
 See [Edge observability](edge-observability.md) for the full metric, log, and
 audit contract.

--- a/docs/edge-claude-code.md
+++ b/docs/edge-claude-code.md
@@ -71,6 +71,12 @@ session/global `CORDUM_EDGE_POLICY_MODE` behavior is unchanged. The local
 agentd still sends its configured mode during session creation so older
 gateways and non-bundled sessions keep the same fallback semantics.
 
+Bound unified Edge bundles also participate in fresh evaluate calls. Gateway
+consumes the latest published `Rule{Type: edge}` snapshot for the bound bundle,
+scope-checks it against the Edge session/action context, adapts it to the
+legacy policy evaluator shape, and only calls the legacy Safety Kernel path
+when no unified Edge rule matches.
+
 Malformed hook input fails closed with redacted stderr. Hook timeout must stay
 below Claude Code's 5s command-hook deadline.
 
@@ -81,6 +87,9 @@ Matched policy decisions also enter the unified Policy Studio audit stream as
 `policy.decision.v2` with `extra.source=edge`. During the default dual-write
 transition, SIEM/export consumers see the legacy Edge audit event first and the
 unified decision second, preserving chain order while dashboards migrate.
+Fresh agentd evidence for that same Gateway evaluate response is still
+persisted, but it carries the verified Gateway event id so `/edge/events` does
+not emit a second pair of policy-decision audit records for one action.
 
 ## Token tradeoffs
 

--- a/docs/edge-claude-code.md
+++ b/docs/edge-claude-code.md
@@ -64,8 +64,23 @@ decision; it does not edit command content.
 | `enforce` | Allow known-safe degraded actions only; deny risky/unknown actions. |
 | `enterprise-strict` | Fail closed when Cordum governance is unavailable. |
 
+For Policy Studio v2 bundles, Gateway may resolve the fail mode from the bound
+bundle's `metadata.edge_mode` before applying the degraded-path logic. If no
+bundle is bound, or if the bundle omits Edge mode metadata, the existing
+session/global `CORDUM_EDGE_POLICY_MODE` behavior is unchanged. The local
+agentd still sends its configured mode during session creation so older
+gateways and non-bundled sessions keep the same fallback semantics.
+
 Malformed hook input fails closed with redacted stderr. Hook timeout must stay
 below Claude Code's 5s command-hook deadline.
+
+## Audit stream
+
+Claude Code decisions remain visible as Edge session/execution/action events.
+Matched policy decisions also enter the unified Policy Studio audit stream as
+`policy.decision.v2` with `extra.source=edge`. During the default dual-write
+transition, SIEM/export consumers see the legacy Edge audit event first and the
+unified decision second, preserving chain order while dashboards migrate.
 
 ## Token tradeoffs
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -97,6 +97,13 @@ existing session/global `EdgePolicyMode` behavior exactly. Backend migration
 tooling owns populating bundle bindings; operators without an Edge bundle do
 not need to change configuration.
 
+When a session is bound to a unified Edge bundle, `/api/v1/edge/evaluate`
+loads the latest `versions[].rule_snapshot`, filters published
+`Rule{Type: edge}` entries by Edge scope, adapts their `Match`/`Decide`
+payloads to the legacy evaluator shape, and evaluates them before falling back
+to the existing Safety Kernel path. Unmatched or unbound sessions keep the
+pre-migration behavior.
+
 ## Unified policy decisions
 
 Edge continues to persist legacy `AgentActionEvent.Decision` values for
@@ -120,6 +127,12 @@ Legacy-to-unified outcome mapping is:
 legacy Edge audit followed by `policy.decision.v2`, `legacy` emits only the
 old Edge shape, and `unified` emits only `policy.decision.v2` when a stable
 rule id is present.
+
+Fresh agentd evidence events remain persisted separately so local cache/timing
+metadata is not lost. Agentd marks evidence produced from a fresh Gateway
+evaluate response with the Gateway event id; `/edge/events` verifies the
+referenced event in the same execution before suppressing duplicate audit
+emission. Cache/degraded/local-only agentd evidence still emits audit normally.
 
 ## Retention and artifacts
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -89,6 +89,38 @@ stable hashes, and artifact pointer metadata.
 | `enterprise-strict` | Managed enterprise rollout. | Fail closed. |
 | `requires-edge-governance` | Production workflow action requiring Edge. | Fail closed on Gateway miss regardless of session mode. |
 
+During the Policy Studio v2 migration, Edge can also read enforcement posture
+from a bound policy bundle's unified `Bundle.Metadata.EdgeMode` (`observe`,
+`enforce`, or `enterprise-strict`). The Gateway resolves that bundle metadata
+when the session carries a bundle binding label, and otherwise preserves the
+existing session/global `EdgePolicyMode` behavior exactly. Backend migration
+tooling owns populating bundle bindings; operators without an Edge bundle do
+not need to change configuration.
+
+## Unified policy decisions
+
+Edge continues to persist legacy `AgentActionEvent.Decision` values for
+dashboard, approvals, and export compatibility. In parallel, matched Edge
+policy decisions now emit a unified `core/policy.Decision` with
+`Source=edge` into the same `policy.decision.v2` audit stream used by job-side
+Safety Kernel decisions.
+
+Legacy-to-unified outcome mapping is:
+
+| Edge decision | Unified `Decision.Type` |
+| --- | --- |
+| `ALLOW` | `allow` |
+| `DENY` | `deny` |
+| `REQUIRE_APPROVAL` | `require_human` |
+| `THROTTLE` | `throttle` |
+| `CONSTRAIN` | `redact` |
+| `RECORDED` | `allow` with a trace marker that the decision was observation-only |
+
+`AUDIT_UNIFIED_DECISION_MODE` controls the transition window: `dual` emits
+legacy Edge audit followed by `policy.decision.v2`, `legacy` emits only the
+old Edge shape, and `unified` emits only `policy.decision.v2` when a stable
+rule id is present.
+
 ## Retention and artifacts
 
 Edge stores bounded session/event metadata in Gateway stores. Large evidence


### PR DESCRIPTION
## Summary

Backend 4 of Policy Studio stacked on `policy-studio-safetykernel`.

- Adds a pure `policy.Rule{Type: edge}` adapter for existing edge/Safety Kernel rule consumption.
- Adds additive `policy.Decision{Source: edge}` emission for persisted edge decisions while preserving legacy `EdgeDecision` persistence and response behavior.
- Bridges gateway evaluate and agentd decision-evidence writes into Backend3 `AUDIT_UNIFIED_DECISION_MODE` (`dual` = legacy first, `policy.decision.v2` second).
- Adds per-bundle `metadata.edge_mode` resolution for edge evaluate with legacy session/global fallback.
- Documents edge unified decisions and audit-stream behavior.

## Verification

From `D:/Cordum/policy-studio-work/cordum` on `policy-studio-edge`:

- `bash -lc "cd /mnt/d/Cordum/policy-studio-work/cordum && make build"` — EXIT=0 (`make[1]: Nothing to be done for 'build-all'.`; no generated/proto diff).
- `bash -lc "cd /mnt/d/Cordum/policy-studio-work/cordum && make test"` — EXIT=0 (`go test ./...`; touched packages include `core/audit` ok 11.383s, `core/controlplane/gateway` ok 38.779s, `core/edge` ok 7.787s, `core/edge/agentd` ok 2.096s, `core/edge/claude` ok 4.774s, `core/edge/safeexec` ok 0.071s).
- `go test -count=3 -timeout 240s ./core/edge/...` — EXIT=0 (`core/edge` ok 31.900s; `agentd` ok 6.346s; `claude` ok 15.535s; `safeexec` ok 0.295s).
- `go test -count=3 -timeout 240s ./core/audit/...` — EXIT=0 (`core/audit` ok 33.268s).
- `make openapi` — N/A; no API/OpenAPI/yaml/proto surface changed.
- Coverage equivalent: `go test -cover ./core/edge/... ./core/audit/...` — EXIT=0. Current core/edge coverage 78.9% vs branch baseline 78.7% from `origin/policy-studio-safetykernel`; subpackages unchanged (`agentd` 80.0%, `claude` 79.0%, `safeexec` 78.3%).
- `gofmt -l <touched Go files>` — no output.
- `git diff --cached --check` — EXIT=0 before commit.

Note: `make coverage-core` exits non-zero on both current and baseline due pre-existing global 80% threshold failures in unrelated core packages. The approved plan allowed `make coverage-core` **or documented equivalent**; focused current-vs-baseline core/edge coverage is the authoritative Backend4 gate.

## DoD evidence map

1. **core/edge classifier consumes unified Rule (type=edge), emits unified Decision into shared audit-chain stream.**
   - `core/edge/policy_adapter.go` adds `AdaptUnifiedEdgeRule` for `policy.Rule{Type: edge}` -> legacy `config.PolicyRule`.
   - `core/edge/decision_emitter.go` emits `policy.Decision{Source: edge}`.
   - `core/edge/policy_mapper.go` adds additive `MapEventToPolicyCheckRequestWithDecision` without changing existing `MapEventToPolicyCheckRequest`.
   - `core/controlplane/gateway/edge_decision_audit.go` uses Backend3 `audit.DecisionEventsForMode` for persisted edge `hook.policy_decision` events.

2. **EdgePolicyMode lives on edge bundles as metadata; legacy global-switch behavior preserved via bundle migration tooling (task-7).**
   - `PolicyModeFromBundleMetadata` maps `policy.Bundle.Metadata.EdgeMode` to edge policy modes and falls back when metadata is absent/unknown.
   - `edge_policy_mode.go` resolves bound bundle `metadata.edge_mode` and otherwise uses existing `EdgeSession.PolicyMode` / observe fallback.
   - Backend7 still owns migration tooling and bundle-binding population; this PR does not delete the legacy switch.

3. **Existing edge tests pass; new tests cover unified-shape boundary.**
   - Existing edge packages pass through `make test` and `go test -count=3 ./core/edge/...`.
   - New tests: policy adapter, decision emitter, mapper wrapper, agentd evidence conversion, gateway dual-emission/non-decision filtering, bundle mode fallback.

4. **Audit-chain reader can fold both job and edge decisions into one stream.**
   - `core/audit/policy_decision_stream.go` adds `FoldPolicyDecisionEvents`.
   - `core/audit/edge_dual_emit_test.go` proves dual edge emission and one folded stream for job+edge by `extra.source`.

## EdgeMode fallback / merge wave note

This is a stacked PR with base `policy-studio-safetykernel`, not `main`, so the diff should show Backend4 only. Backend5 should start after this lands; Backend2.5/dashboard follow-ons remain parked until Backend5/6/data-shape dependencies are ready.
