### PR TITLE
feat(gateway): add unified policy evaluator entrypoint (epic-d9a6c0a1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+#### Policy Studio Rewrite — Backend 2: bundle store (epic-d9a6c0a1, task-b349524a)
+
+Redis-backed `BundleStore` for the unified Policy Studio bundles
+introduced in Backend 1. Built additively under `core/policy/`; no
+existing stores modified.
+
+- `core/policy/bundle_store.go` — BundleStore interface (10 ops: Bundle
+  CRUD + version CRUD + Deploy/Rollback/GetActive/ListHistory) +
+  Deployment record + DeploymentAction enum (deploy|rollback) + 6 typed
+  errors.
+- `core/policy/bundle_store_keys.go` — Redis schema constants + 5 key
+  constructors. Confirmed-clean prefix space at
+  `policy:bundle:*` + `policy:scope:*` (no collision with workflow's
+  `cordum:wf:*`, edge's `edge:session:*`, registry's `sys:workers:*`).
+- `core/policy/bundle_store_redis.go` — `BundleRedisStore` impl with
+  atomic Lua scripts for the multi-key Deploy/Rollback paths. Per
+  memory `mem-12f1ceeb` go-redis WATCH+TxPipelined corrupts the
+  connection pool when miniredis returns errors, so single Lua EVAL is
+  the only safe pattern. Chained rollbacks unwind one step per call
+  (v3→v2→v1) by locating the deploy entry that established the current
+  active and walking past it.
+- `core/policy/bundle_store_keys_test.go` + `bundle_store_redis_test.go`
+  — 22 tests (6 key tests + 16 store tests) covering happy-path CRUD,
+  version idempotency, deploy lifecycle, rollback chain, scope
+  isolation, concurrent-deploy serialization, and 8 nil/empty-id
+  branches. miniredis-backed via the canonical pattern from
+  `core/workflow/store_redis_test.go`.
+- `docs/policy-bundle-store.md` — full Redis schema + CRUD/atomicity
+  table + bounded-history rationale + open questions for v3.
+
+`go build ./...` clean; `go test ./core/policy/... -count=3 -cover
+-timeout 240s` clean at coverage 80.2% (clears DoD #3 80% bar).
+
 #### Policy Studio Rewrite — Backend 1 (epic-d9a6c0a1)
 
 Foundation shapes for the Job + Edge unified policy surface. New shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+#### Policy Studio Rewrite — Backend 2 reopen #1 (epic-d9a6c0a1, task-b349524a)
+
+QA caught two correctness defects + two test gaps in the initial Backend
+2 ship; this entry covers the fix landed on top of PR #252.
+
+- `core/policy/bundle_store_redis.go` rollback semantics — the original
+  rollback walked history for "next deploy entry after the deploy
+  matching current active". After `deploy v1, deploy v2, rollback (→
+  v1), deploy v3, rollback`, the second rollback returned **v2** (the
+  raw second-most-recent deploy) instead of the active state
+  immediately before v3 was deployed (v1). Fix: each deploy event now
+  records the active pair at deploy-time as `prev_bundle_id` +
+  `prev_version` (read inside the same Lua script that writes the
+  event, so concurrent deploys serialize correctly). Rollback locates
+  the deploy event matching the current active pair and restores from
+  its `prev_*` fields. The `Deployment` Go struct gains matching
+  `PrevBundleID` + `PrevVersion` fields with `omitempty` JSON tags
+  so old golden fixtures continue to deserialize.
+- `core/policy/bundle_store_redis.go` `CreateBundleVersion` parent check
+  — the original `SETNX` pipeline accepted writes for non-existent
+  parent bundles, allowing orphan version blobs +
+  `policy:bundle:{id}:versions` index entries. Fix: `EXISTS
+  policy:bundle:{id}` precheck before the `SETNX`+`ZADD` pipeline
+  returns `ErrBundleNotFound` for missing parents. Safe non-atomic
+  precheck because the interface defines no `DeleteBundle`, so a
+  parent that exists at check-time still exists at write-time.
+- `core/policy/bundle_store_redis_test.go` — added
+  `TestDeployAfterRollback` (the QA repro permanently locked in:
+  asserts the prev-active fields on each deploy + that rollback after
+  deploy-after-rollback restores v1 with explicit regression error
+  text), `TestCreateBundleVersion_OrphanRejected` (orphan write
+  returns `ErrBundleNotFound` and the index ZSET stays empty), and
+  `TestDeploymentHistoryCapEnforced` (105 deploys → `len(hist) == 100`,
+  binding the LTRIM cap inside the deploy Lua).
+
+`go build ./...` clean. `go test ./core/policy/... -count=3 -cover
+-timeout 240s` clean at 80.3% coverage. `go test ./core/workflow/...
+./core/edge/...` clean (no neighboring-store regression).
+
 ### Added
 
 #### Policy Studio Rewrite — Backend 2: bundle store (epic-d9a6c0a1, task-b349524a)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,44 @@ QA caught two correctness defects + two test gaps in the initial Backend
 -timeout 240s` clean at 80.3% coverage. `go test ./core/workflow/...
 ./core/edge/...` clean (no neighboring-store regression).
 
+### Deprecated
+
+#### Policy Studio Rewrite — Backend 5 migration window (epic-d9a6c0a1, task-aadaec4a)
+
+- Legacy evaluator surfaces remain functional but are marked deprecated while
+  clients migrate to unified `POST /api/v1/policy/evaluate` with
+  `PolicyEvaluateRequest`: `POST /api/v1/policy/simulate`,
+  `POST /api/v1/policy/explain`, legacy `PolicyCheckRequest` bodies on
+  `POST /api/v1/policy/evaluate`, and `POST /api/v1/edge/evaluate`.
+  Deprecated/legacy responses include `Deprecation: true` plus a
+  `Link: </api/v1/policy/evaluate>; rel="successor-version"` header. Removal
+  is deferred until the later Policy Studio cut-over after backend and
+  dashboard clients have moved to the unified evaluator.
+
 ### Added
+
+#### Policy Studio Rewrite — Backend 5: unified evaluator entry-point (epic-d9a6c0a1, task-aadaec4a)
+
+- Added canonical HTTP `POST /api/v1/policy/evaluate` unified evaluator for
+  both job and Edge policy contexts. Unified requests accept either an inline
+  `Rule` or `bundle_id` + `scope`, plus exactly one of `job_context` or
+  `edge_context`, and return the shared `Decision` envelope.
+- Added gRPC `PolicyEvaluator.EvaluateUnified` using the same evaluator helper
+  as HTTP, including tenant resolution, role checks, validation, and typed
+  status-code mapping.
+- Added Rule.type dispatch: `input` / `output` / `velocity` route to the
+  Safety Kernel adapters; `edge` routes to the Edge classifier adapter.
+  Type-confusion requests fail before downstream dispatch.
+- Added BundleStore-backed lifecycle gateway routes for immutable bundle
+  versions, deploy, deployment history, and rollback. These routes back the
+  OpenAPI paths used by the unified evaluator; no YAML-only endpoints were
+  introduced.
+- Added shared `policy.decision.v2` audit emission for unified evaluator
+  results while preserving transition-window dual emission with legacy audit
+  records.
+- Added [`docs/policy-evaluate-api.md`](docs/policy-evaluate-api.md) covering
+  HTTP/gRPC usage, dispatch rules, bundle resolution, error mapping, audit
+  behavior, and old-endpoint migration.
 
 #### Policy Studio Rewrite — Backend 2: bundle store (epic-d9a6c0a1, task-b349524a)
 

--- a/core/controlplane/gateway/edge_evaluate_unified_test.go
+++ b/core/controlplane/gateway/edge_evaluate_unified_test.go
@@ -111,6 +111,7 @@ func TestGatewayEdgeEvaluateDualEmitsLegacyAndUnifiedDecision(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("evaluate status = %d body=%s", rec.Code, rec.Body.String())
 	}
+	requireDeprecatedEndpointHeaders(t, rec, "/api/v1/policy/evaluate")
 	if got := sink.Len() - before; got != 2 {
 		t.Fatalf("audit events emitted = %d, want legacy edge + policy.decision.v2", got)
 	}

--- a/core/controlplane/gateway/gateway.go
+++ b/core/controlplane/gateway/gateway.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cordum/cordum/core/infra/tlsreload"
 	"github.com/cordum/cordum/core/licensing"
 	"github.com/cordum/cordum/core/model"
+	"github.com/cordum/cordum/core/policy"
 	"github.com/cordum/cordum/core/policyshadow"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 	"github.com/cordum/cordum/core/telemetry"
@@ -124,6 +125,7 @@ const (
 
 type server struct {
 	pb.UnimplementedCordumApiServer
+	pb.UnimplementedPolicyEvaluatorServer
 	memStore              store.Store
 	jobStore              *store.RedisJobStore // Typed for ListRecentJobs
 	edgeStore             edgecore.Store
@@ -196,6 +198,7 @@ type server struct {
 
 	legalHoldStore    *audit.LegalHoldStore
 	statusCacheObj    *statusCache
+	policyBundleStore policy.BundleStore
 	policyShadowStore *policyshadow.Store
 	mcpDenyRing       *denyEventRing
 	sessionIssuer     *scheduler.SessionTokenIssuer
@@ -691,6 +694,7 @@ func RunWithAuth(cfg *config.Config, provider auth.AuthProvider, entitlementReso
 		edgeRecorder:           edgeRecorder,
 		legalHoldStore:         initLegalHoldStore(cfg.RedisURL),
 		statusCacheObj:         newStatusCache(2 * time.Second),
+		policyBundleStore:      policy.NewRedisBundleStoreFromClient(jobStore.Client()),
 		policyShadowStore:      policyshadow.NewStore(configSvc),
 		mcpDenyRing:            newDenyEventRing(500),
 		trustResolver:          scheduler.NewTrustResolver(jobStore.Client()),
@@ -824,6 +828,7 @@ func RunWithAuth(cfg *config.Config, provider auth.AuthProvider, entitlementReso
 		),
 	)
 	pb.RegisterCordumApiServer(grpcServer, s)
+	pb.RegisterPolicyEvaluatorServer(grpcServer, s)
 	if env.Bool(env.EnvGRPCReflection) {
 		if env.IsProduction() && !env.Bool("CORDUM_GRPC_REFLECTION_FORCE") {
 			slog.Error("gRPC reflection blocked in production mode (exposes service definitions). Set CORDUM_GRPC_REFLECTION_FORCE=1 to override.")
@@ -1418,10 +1423,13 @@ func (s *server) registerRoutes(mux *http.ServeMux) error {
 	s.registerRoute(mux, "GET /api/v1/policy/global", s.instrumented("/api/v1/policy/global", s.handleGetPolicyGlobal))
 	s.registerRoute(mux, "PUT /api/v1/policy/global", s.instrumented("/api/v1/policy/global", s.handlePutPolicyGlobal))
 	s.registerRoute(mux, "GET /api/v1/policy/bundles", s.instrumented("/api/v1/policy/bundles", s.handlePolicyBundles))
+	s.registerRoute(mux, "GET /api/v1/policy/bundles/deployments", s.instrumented("/api/v1/policy/bundles/deployments", s.handleListPolicyBundleDeployments))
+	s.registerRoute(mux, "POST /api/v1/policy/bundles/deployments/rollback", s.instrumented("/api/v1/policy/bundles/deployments/rollback", s.handleRollbackPolicyBundleDeployment))
 	s.registerRoute(mux, "GET /api/v1/policy/bundles/{id}", s.instrumented("/api/v1/policy/bundles/{id}", s.handleGetPolicyBundle))
 	s.registerRoute(mux, "PUT /api/v1/policy/bundles/{id}", s.instrumented("/api/v1/policy/bundles/{id}", s.handlePutPolicyBundle))
 	s.registerRoute(mux, "DELETE /api/v1/policy/bundles/{id}", s.instrumented("/api/v1/policy/bundles/{id}", s.handleDeletePolicyBundle))
 	s.registerRoute(mux, "POST /api/v1/policy/bundles/{id}/simulate", s.instrumented("/api/v1/policy/bundles/{id}/simulate", s.handleSimulatePolicyBundle))
+	s.registerRoute(mux, "/api/v1/policy/bundles/", s.instrumented("/api/v1/policy/bundles/*", s.handlePolicyBundleLifecycleSubroutes))
 	// Policy shadow (task-44807b2c) — shadow-evaluation surface for a bundle.
 	// PUT upserts the shadow policy, GET fetches current status, DELETE removes it.
 	// The three results endpoints expose dashboard analytics (summary counters,

--- a/core/controlplane/gateway/handlers_deprecation.go
+++ b/core/controlplane/gateway/handlers_deprecation.go
@@ -1,0 +1,8 @@
+package gateway
+
+import "net/http"
+
+func markDeprecatedEndpoint(w http.ResponseWriter, successor string) {
+	w.Header().Set("Deprecation", "true")
+	w.Header().Add("Link", "<"+successor+">; rel=\"successor-version\"")
+}

--- a/core/controlplane/gateway/handlers_edge_evaluate.go
+++ b/core/controlplane/gateway/handlers_edge_evaluate.go
@@ -143,6 +143,7 @@ type edgeEvaluateResponse struct {
 
 func (s *server) handleEdgeEvaluate(w http.ResponseWriter, r *http.Request) {
 	started := time.Now()
+	markDeprecatedEndpoint(w, "/api/v1/policy/evaluate")
 	evalCtx, ok := s.prepareEdgeEvaluateContext(w, r)
 	if !ok {
 		return

--- a/core/controlplane/gateway/handlers_policy.go
+++ b/core/controlplane/gateway/handlers_policy.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *server) handlePolicyEvaluate(w http.ResponseWriter, r *http.Request) {
-	s.handlePolicyCheck(w, r, "evaluate")
+	s.handlePolicyEvaluateDispatch(w, r)
 }
 
 func (s *server) handlePolicySimulate(w http.ResponseWriter, r *http.Request) {
@@ -50,6 +50,7 @@ func (s *server) handlePolicySnapshots(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handlePolicyCheck(w http.ResponseWriter, r *http.Request, mode string) {
+	markDeprecatedEndpoint(w, "/api/v1/policy/evaluate")
 	if !s.requirePermissionOrRole(w, r, auth.PermPolicyWrite, "admin") {
 		return
 	}

--- a/core/controlplane/gateway/handlers_policy_bundle_lifecycle.go
+++ b/core/controlplane/gateway/handlers_policy_bundle_lifecycle.go
@@ -1,0 +1,292 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/policy"
+)
+
+type policyBundleVersionRequest struct {
+	Version      string        `json:"version"`
+	RuleSnapshot []policy.Rule `json:"rule_snapshot"`
+	DeployedAt   time.Time     `json:"deployed_at"`
+	AuditHash    string        `json:"audit_hash"`
+}
+
+type policyBundleDeployRequest struct {
+	Version string           `json:"version"`
+	Scope   policy.RuleScope `json:"scope"`
+}
+
+type policyBundleRollbackRequest struct {
+	Scope policy.RuleScope `json:"scope"`
+}
+
+const policyBundleRoutePrefix = "/api/v1/policy/bundles/"
+
+func (s *server) handlePolicyBundleLifecycleSubroutes(w http.ResponseWriter, r *http.Request) {
+	subpath := strings.Trim(strings.TrimPrefix(r.URL.Path, policyBundleRoutePrefix), "/")
+	if subpath == "" {
+		http.NotFound(w, r)
+		return
+	}
+	parts := strings.Split(subpath, "/")
+	switch {
+	case len(parts) == 1 && parts[0] == "deployments":
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		s.handleListPolicyBundleDeployments(w, r)
+	case len(parts) == 2 && parts[0] == "deployments" && parts[1] == "rollback":
+		if r.Method != http.MethodPost {
+			writeMethodNotAllowed(w, http.MethodPost)
+			return
+		}
+		s.handleRollbackPolicyBundleDeployment(w, r)
+	case len(parts) == 2 && parts[1] == "versions":
+		r.SetPathValue("id", parts[0])
+		s.handlePolicyBundleVersionsByMethod(w, r)
+	case len(parts) == 3 && parts[1] == "versions":
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		r.SetPathValue("id", parts[0])
+		r.SetPathValue("version", parts[2])
+		s.handleGetPolicyBundleVersion(w, r)
+	case len(parts) == 2 && parts[1] == "deploy":
+		if r.Method != http.MethodPost {
+			writeMethodNotAllowed(w, http.MethodPost)
+			return
+		}
+		r.SetPathValue("id", parts[0])
+		s.handleDeployPolicyBundleVersion(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *server) handlePolicyBundleVersionsByMethod(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleListPolicyBundleVersions(w, r)
+	case http.MethodPost:
+		s.handleCreatePolicyBundleVersion(w, r)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
+	}
+}
+
+func (s *server) handleCreatePolicyBundleVersion(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePolicyBundleStore(w, r, auth.PermPolicyWrite) {
+		return
+	}
+	bundleID := strings.TrimSpace(r.PathValue("id"))
+	var body policyBundleVersionRequest
+	if err := decodeJSONBody(w, r, &body); err != nil {
+		writeJSONDecodeError(w, err, "invalid json")
+		return
+	}
+	version := policy.BundleVersion{
+		Version:      strings.TrimSpace(body.Version),
+		RuleSnapshot: append([]policy.Rule{}, body.RuleSnapshot...),
+		DeployedAt:   body.DeployedAt,
+		AuditHash:    strings.TrimSpace(body.AuditHash),
+	}
+	if version.DeployedAt.IsZero() {
+		version.DeployedAt = time.Now().UTC()
+	}
+	if err := validatePolicyBundleIDVersion(bundleID, version.Version); err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := s.policyBundleStore.CreateBundleVersion(r.Context(), bundleID, &version); err != nil {
+		writePolicyBundleStoreError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, map[string]any{"bundle_id": bundleID, "version": version})
+}
+
+func (s *server) handleListPolicyBundleVersions(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePolicyBundleStore(w, r, auth.PermPolicyRead) {
+		return
+	}
+	bundleID := strings.TrimSpace(r.PathValue("id"))
+	if bundleID == "" {
+		writeErrorJSON(w, http.StatusBadRequest, "bundle id required")
+		return
+	}
+	versions, err := s.policyBundleStore.ListBundleVersions(r.Context(), bundleID)
+	if err != nil {
+		writePolicyBundleStoreError(w, r, err)
+		return
+	}
+	writeJSON(w, map[string]any{"bundle_id": bundleID, "items": versions})
+}
+
+func (s *server) handleGetPolicyBundleVersion(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePolicyBundleStore(w, r, auth.PermPolicyRead) {
+		return
+	}
+	bundleID := strings.TrimSpace(r.PathValue("id"))
+	version := strings.TrimSpace(r.PathValue("version"))
+	if err := validatePolicyBundleIDVersion(bundleID, version); err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	got, err := s.policyBundleStore.GetBundleVersion(r.Context(), bundleID, version)
+	if err != nil {
+		writePolicyBundleStoreError(w, r, err)
+		return
+	}
+	writeJSON(w, map[string]any{"bundle_id": bundleID, "version": got})
+}
+
+func (s *server) handleDeployPolicyBundleVersion(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePolicyBundleStore(w, r, auth.PermPolicyWrite) {
+		return
+	}
+	bundleID := strings.TrimSpace(r.PathValue("id"))
+	var body policyBundleDeployRequest
+	if err := decodeJSONBody(w, r, &body); err != nil {
+		writeJSONDecodeError(w, err, "invalid json")
+		return
+	}
+	if !s.requirePolicyBundleScopeAccess(w, r, body.Scope) {
+		return
+	}
+	deployment, err := s.deployPolicyBundleVersion(r, bundleID, body)
+	if err != nil {
+		writePolicyBundleStoreError(w, r, err)
+		return
+	}
+	writeJSON(w, map[string]any{"deployment": deployment})
+}
+
+func (s *server) handleListPolicyBundleDeployments(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePolicyBundleStore(w, r, auth.PermPolicyRead) {
+		return
+	}
+	scope, err := policyBundleScopeFromQuery(r)
+	if err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if !s.requirePolicyBundleScopeAccess(w, r, scope) {
+		return
+	}
+	history, err := s.policyBundleStore.ListDeploymentHistory(r.Context(), scope, policyBundleHistoryLimit(r))
+	if err != nil {
+		writePolicyBundleStoreError(w, r, err)
+		return
+	}
+	writeJSON(w, map[string]any{"scope": scope, "items": history})
+}
+
+func (s *server) handleRollbackPolicyBundleDeployment(w http.ResponseWriter, r *http.Request) {
+	if !s.requirePolicyBundleStore(w, r, auth.PermPolicyWrite) {
+		return
+	}
+	var body policyBundleRollbackRequest
+	if err := decodeJSONBody(w, r, &body); err != nil {
+		writeJSONDecodeError(w, err, "invalid json")
+		return
+	}
+	if !s.requirePolicyBundleScopeAccess(w, r, body.Scope) {
+		return
+	}
+	deployment, err := s.policyBundleStore.RollbackDeployment(r.Context(), body.Scope)
+	if err != nil {
+		writePolicyBundleStoreError(w, r, err)
+		return
+	}
+	writeJSON(w, map[string]any{"deployment": deployment})
+}
+
+func (s *server) deployPolicyBundleVersion(r *http.Request, bundleID string, body policyBundleDeployRequest) (*policy.Deployment, error) {
+	version := strings.TrimSpace(body.Version)
+	if err := validatePolicyBundleIDVersion(bundleID, version); err != nil {
+		return nil, err
+	}
+	if err := validatePolicyBundleScope(body.Scope); err != nil {
+		return nil, err
+	}
+	return s.policyBundleStore.DeployVersionToScope(r.Context(), bundleID, version, body.Scope)
+}
+
+func (s *server) requirePolicyBundleStore(w http.ResponseWriter, r *http.Request, permission string) bool {
+	return s.requireStoreAndPermissionOrRole(w, r, permission, []string{"admin"}, s.policyBundleStore)
+}
+
+func (s *server) requirePolicyBundleScopeAccess(w http.ResponseWriter, r *http.Request, scope policy.RuleScope) bool {
+	if err := validatePolicyBundleScope(scope); err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+		return false
+	}
+	if scope.Kind == policy.RuleScopeTenant {
+		if err := s.requireTenantAccess(r, scope.Value); err != nil {
+			writeForbidden(w, r, err)
+			return false
+		}
+	}
+	return true
+}
+
+func policyBundleScopeFromQuery(r *http.Request) (policy.RuleScope, error) {
+	scope := policy.RuleScope{
+		Kind:  policy.RuleScopeKind(strings.TrimSpace(r.URL.Query().Get("scope_kind"))),
+		Value: strings.TrimSpace(r.URL.Query().Get("scope_value")),
+	}
+	return scope, validatePolicyBundleScope(scope)
+}
+
+func validatePolicyBundleScope(scope policy.RuleScope) error {
+	if _, err := policy.ParseRuleScopeKind(scope.Kind.String()); err != nil {
+		return err
+	}
+	if scope.Kind != policy.RuleScopeGlobal && strings.TrimSpace(scope.Value) == "" {
+		return errors.New("scope value required")
+	}
+	return nil
+}
+
+func validatePolicyBundleIDVersion(bundleID, version string) error {
+	if strings.TrimSpace(bundleID) == "" {
+		return errors.New("bundle id required")
+	}
+	if strings.TrimSpace(version) == "" {
+		return errors.New("version required")
+	}
+	return nil
+}
+
+func policyBundleHistoryLimit(r *http.Request) int {
+	limit := 100
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 && parsed < limit {
+			limit = parsed
+		}
+	}
+	return limit
+}
+
+func writePolicyBundleStoreError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, policy.ErrBundleExists), errors.Is(err, policy.ErrBundleVersionExists):
+		writeErrorJSON(w, http.StatusConflict, err.Error())
+	case errors.Is(err, policy.ErrBundleNotFound), errors.Is(err, policy.ErrBundleVersionNotFound),
+		errors.Is(err, policy.ErrNoDeploymentForScope), errors.Is(err, policy.ErrNoRollbackTarget):
+		writeErrorJSON(w, http.StatusNotFound, err.Error())
+	case strings.Contains(err.Error(), "required"):
+		writeErrorJSON(w, http.StatusBadRequest, err.Error())
+	default:
+		writeInternalError(w, r, "policy bundle lifecycle", err)
+	}
+}

--- a/core/controlplane/gateway/handlers_policy_evaluate.go
+++ b/core/controlplane/gateway/handlers_policy_evaluate.go
@@ -1,0 +1,222 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/policy"
+)
+
+type policyEvaluateHTTPPayload struct {
+	Rule        json.RawMessage            `json:"rule"`
+	BundleID    string                     `json:"bundle_id"`
+	Scope       *policy.RuleScope          `json:"scope"`
+	JobContext  *jobEvaluationHTTPContext  `json:"job_context"`
+	EdgeContext *edgeEvaluationHTTPContext `json:"edge_context"`
+}
+
+type jobEvaluationHTTPContext struct {
+	TenantID    string                  `json:"tenant_id"`
+	JobID       string                  `json:"job_id"`
+	WorkflowID  string                  `json:"workflow_id"`
+	Topic       string                  `json:"topic"`
+	PrincipalID string                  `json:"principal_id"`
+	Labels      map[string]string       `json:"labels"`
+	MemoryID    string                  `json:"memory_id"`
+	Capability  string                  `json:"capability"`
+	RiskTags    []string                `json:"risk_tags"`
+	Input       *jobEvaluationHTTPInput `json:"input"`
+}
+
+type jobEvaluationHTTPInput struct {
+	Content     string `json:"content"`
+	ContentType string `json:"content_type"`
+	SizeBytes   int64  `json:"size_bytes"`
+}
+
+type edgeEvaluationHTTPContext struct {
+	TenantID          string            `json:"tenant_id"`
+	PrincipalID       string            `json:"principal_id"`
+	SessionID         string            `json:"session_id"`
+	ExecutionID       string            `json:"execution_id"`
+	AgentProduct      string            `json:"agent_product"`
+	ToolName          string            `json:"tool_name"`
+	ToolInputRedacted map[string]any    `json:"tool_input_redacted"`
+	InputHash         string            `json:"input_hash"`
+	ToolInputHash     string            `json:"tool_input_hash"`
+	Labels            map[string]string `json:"labels"`
+	RiskTags          []string          `json:"risk_tags"`
+}
+
+type policyRuleHTTP struct {
+	ID          string               `json:"id"`
+	Name        string               `json:"name"`
+	Type        string               `json:"type"`
+	Scope       policy.RuleScope     `json:"scope"`
+	Status      string               `json:"status"`
+	Version     string               `json:"version"`
+	Audit       policy.AuditMetadata `json:"audit"`
+	Match       json.RawMessage      `json:"match"`
+	Decide      json.RawMessage      `json:"decide"`
+	Description string               `json:"description"`
+}
+
+func (s *server) handlePolicyEvaluateDispatch(w http.ResponseWriter, r *http.Request) {
+	body, err := readPolicyEvaluateBody(w, r)
+	if err != nil {
+		writeJSONDecodeError(w, err, "invalid json")
+		return
+	}
+	if !policyEvaluateBodyLooksUnified(body) {
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		s.handlePolicyCheck(w, r, "evaluate")
+		return
+	}
+	if !s.requirePermissionOrRole(w, r, auth.PermPolicyWrite, "admin") {
+		return
+	}
+	req, err := decodePolicyEvaluateHTTPRequest(body)
+	if err != nil {
+		writePolicyEvaluateHTTPError(w, err)
+		return
+	}
+	if err := s.authorizePolicyEvaluateHTTPRequest(r, &req); err != nil {
+		writeForbidden(w, r, err)
+		return
+	}
+	result, err := s.evaluateUnifiedPolicy(r.Context(), req)
+	if err != nil {
+		writePolicyEvaluateHTTPError(w, err)
+		return
+	}
+	writeJSON(w, policyEvaluateHTTPResponse{Decision: result.Decision})
+}
+
+type policyEvaluateHTTPResponse struct {
+	Decision policy.Decision `json:"decision"`
+}
+
+func readPolicyEvaluateBody(w http.ResponseWriter, r *http.Request) ([]byte, error) {
+	limit := maxJSONBodyBytes()
+	if requestLimit, ok := requestBodyLimitFromContext(r.Context()); ok && requestLimit > 0 {
+		limit = requestLimit
+	}
+	reader := r.Body
+	if limit > 0 {
+		reader = http.MaxBytesReader(w, r.Body, limit)
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return nil, tierLimitFromMaxBytes(int64(maxErr.Limit))
+		}
+		return nil, err
+	}
+	return body, nil
+}
+
+func policyEvaluateBodyLooksUnified(body []byte) bool {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(body, &top); err != nil {
+		return false
+	}
+	for _, key := range []string{"rule", "bundle_id", "scope", "job_context", "edge_context"} {
+		if _, ok := top[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func decodePolicyEvaluateHTTPRequest(body []byte) (policyEvaluationRequest, error) {
+	var payload policyEvaluateHTTPPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return policyEvaluationRequest{}, newPolicyEvaluateError(policyEvaluateValidation, "invalid json", err)
+	}
+	rule, err := decodePolicyEvaluateHTTPRule(payload.Rule)
+	if err != nil {
+		return policyEvaluationRequest{}, err
+	}
+	return policyEvaluationRequest{Rule: rule, BundleID: payload.BundleID, Scope: payload.Scope, JobContext: payload.JobContext.toInternal(), EdgeContext: payload.EdgeContext.toInternal()}, nil
+}
+
+func decodePolicyEvaluateHTTPRule(raw json.RawMessage) (*policy.Rule, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var wire policyRuleHTTP
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return nil, newPolicyEvaluateError(policyEvaluateValidation, "invalid rule", err)
+	}
+	return &policy.Rule{ID: strings.TrimSpace(wire.ID), Name: strings.TrimSpace(wire.Name), Type: policy.RuleType(strings.TrimSpace(wire.Type)), Scope: wire.Scope, Status: policy.RuleStatus(strings.TrimSpace(wire.Status)), Version: strings.TrimSpace(wire.Version), Audit: wire.Audit, Match: cloneRawMessage(wire.Match), Decide: cloneRawMessage(wire.Decide), Description: strings.TrimSpace(wire.Description)}, nil
+}
+
+func (c *jobEvaluationHTTPContext) toInternal() *jobEvaluationContext {
+	if c == nil {
+		return nil
+	}
+	out := &jobEvaluationContext{TenantID: c.TenantID, JobID: c.JobID, WorkflowID: c.WorkflowID, Topic: c.Topic, PrincipalID: c.PrincipalID, Labels: clonePolicyEvalStringMap(c.Labels), MemoryID: c.MemoryID, Capability: c.Capability, RiskTags: append([]string{}, c.RiskTags...)}
+	if c.Input != nil {
+		out.Input = jobEvaluationInput{Content: c.Input.Content, ContentType: c.Input.ContentType, SizeBytes: c.Input.SizeBytes}
+	}
+	return out
+}
+
+func (c *edgeEvaluationHTTPContext) toInternal() *edgeEvaluationContext {
+	if c == nil {
+		return nil
+	}
+	return &edgeEvaluationContext{TenantID: c.TenantID, PrincipalID: c.PrincipalID, SessionID: c.SessionID, ExecutionID: c.ExecutionID, AgentProduct: c.AgentProduct, ToolName: c.ToolName, ToolInputRedacted: clonePolicyEvalAnyMap(c.ToolInputRedacted), InputHash: c.InputHash, ToolInputHash: c.ToolInputHash, Labels: clonePolicyEvalStringMap(c.Labels), RiskTags: append([]string{}, c.RiskTags...)}
+}
+
+func (s *server) authorizePolicyEvaluateHTTPRequest(r *http.Request, req *policyEvaluationRequest) error {
+	if req.JobContext != nil {
+		tenant, err := s.resolveTenant(r, req.JobContext.TenantID)
+		if err != nil {
+			return err
+		}
+		principal, err := s.resolvePrincipal(r, req.JobContext.PrincipalID)
+		if err != nil {
+			return err
+		}
+		req.JobContext.TenantID = tenant
+		req.JobContext.PrincipalID = principal
+	}
+	if req.EdgeContext != nil {
+		tenant, err := s.resolveTenant(r, req.EdgeContext.TenantID)
+		if err != nil {
+			return err
+		}
+		principal, err := s.resolvePrincipal(r, req.EdgeContext.PrincipalID)
+		if err != nil {
+			return err
+		}
+		req.EdgeContext.TenantID = tenant
+		req.EdgeContext.PrincipalID = principal
+	}
+	return nil
+}
+
+func writePolicyEvaluateHTTPError(w http.ResponseWriter, err error) {
+	var evalErr *policyEvaluateError
+	if errors.As(err, &evalErr) {
+		writeErrorJSON(w, evalErr.StatusCode(), policyEvaluateErrorMessage(evalErr))
+		return
+	}
+	writeErrorJSON(w, http.StatusInternalServerError, "internal error")
+}
+
+func cloneRawMessage(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]byte, len(raw))
+	copy(out, raw)
+	return out
+}

--- a/core/controlplane/gateway/handlers_policy_evaluate_unified_test.go
+++ b/core/controlplane/gateway/handlers_policy_evaluate_unified_test.go
@@ -1,0 +1,512 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyEvaluateUnifiedJobDispatchesToSafetyKernelAndReturnsDecision(t *testing.T) {
+	s, _, safety := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, nil)
+	auditSender := &testAuditSender{}
+	s.auditExporter = auditSender
+	safety.setResponse(&pb.PolicyCheckResponse{
+		Decision:       pb.DecisionType_DECISION_TYPE_DENY,
+		Reason:         "blocked input token",
+		RuleId:         "job-input-deny",
+		PolicySnapshot: "snap-job",
+	})
+
+	rec := postUnifiedPolicyEvaluate(t, s, unifiedJobEvaluateBody("job-input-deny"))
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	got := decodeUnifiedPolicyEvaluateResponse(t, rec)
+	require.Equal(t, policy.DecisionSourceJob, got.Decision.Source)
+	require.Equal(t, policy.DecisionDeny, got.Decision.Type)
+	require.Equal(t, "job-input-deny", got.Decision.RuleID)
+	require.NotEmpty(t, got.Decision.Trace)
+	require.Equal(t, "blocked input token", got.Decision.Trace[0].Reason)
+
+	safety.mu.Lock()
+	defer safety.mu.Unlock()
+	require.NotNil(t, safety.lastReq)
+	require.Equal(t, "job.acme.evaluate", safety.lastReq.GetTopic())
+	require.Equal(t, "tenant-acme", safety.lastReq.GetTenant())
+	require.Equal(t, []byte("contains blocked-token"), safety.lastReq.GetInputContent())
+	requirePolicyDecisionAuditOrder(t, auditSender)
+}
+
+func TestPolicyEvaluateUnifiedEdgeDispatchesToEdgeClassifierAndEmitsAudit(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, nil)
+	auditSender := &testAuditSender{}
+	s.auditExporter = auditSender
+
+	rec := postUnifiedPolicyEvaluate(t, s, unifiedEdgeEvaluateBody("edge-deny"))
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	got := decodeUnifiedPolicyEvaluateResponse(t, rec)
+	require.Equal(t, policy.DecisionSourceEdge, got.Decision.Source)
+	require.Equal(t, policy.DecisionDeny, got.Decision.Type)
+	require.Equal(t, "edge-deny", got.Decision.RuleID)
+	require.NotEmpty(t, got.Decision.Trace)
+	require.Equal(t, policy.DecisionDeny, got.Decision.Trace[0].DecisionType)
+	requirePolicyDecisionAuditOrder(t, auditSender)
+}
+
+func TestPolicyEvaluateUnifiedBundleResolvesActiveDeployment(t *testing.T) {
+	s, _, safety := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, nil)
+	safety.setResponse(&pb.PolicyCheckResponse{
+		Decision: pb.DecisionType_DECISION_TYPE_DENY,
+		Reason:   "active bundle rule denied",
+		RuleId:   "bundle-job-deny",
+	})
+	store := newMemoryPolicyBundleStore()
+	seedActivePolicyBundle(t, store, policy.RuleTypeInput)
+	s.policyBundleStore = store
+
+	rec := postUnifiedPolicyEvaluate(t, s, unifiedBundleEvaluateBody())
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	got := decodeUnifiedPolicyEvaluateResponse(t, rec)
+	require.Equal(t, policy.DecisionSourceJob, got.Decision.Source)
+	require.Equal(t, "bundle-active", got.Decision.BundleID)
+	require.Equal(t, "v2", got.Decision.BundleVersion)
+	require.Equal(t, "bundle-job-deny", got.Decision.RuleID)
+	require.Equal(t, 1, store.getActiveCalls())
+}
+
+func TestPolicyEvaluateUnifiedRejectsTypeConfusionBeforeDispatch(t *testing.T) {
+	s, _, safety := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, nil)
+
+	rec := postUnifiedPolicyEvaluate(t, s, unifiedEdgeRuleWithJobContextBody())
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	requireJSONError(t, rec, "rule type edge requires edge_context")
+	safety.mu.Lock()
+	defer safety.mu.Unlock()
+	require.Nil(t, safety.lastReq)
+}
+
+func TestPolicyEvaluateUnifiedRejectsUnknownRuleType(t *testing.T) {
+	s, _, safety := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, nil)
+
+	rec := postUnifiedPolicyEvaluate(t, s, unifiedUnknownRuleTypeBody())
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	requireJSONError(t, rec, "unsupported rule type unknown")
+	safety.mu.Lock()
+	defer safety.mu.Unlock()
+	require.Nil(t, safety.lastReq)
+}
+
+func TestPolicyEvaluateUnifiedAuthRunsBeforeBundleStoreLookup(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, nil)
+	store := newMemoryPolicyBundleStore()
+	seedActivePolicyBundle(t, store, policy.RuleTypeInput)
+	s.policyBundleStore = store
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/policy/evaluate", strings.NewReader(unifiedBundleEvaluateBody()))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "tenant-acme")
+	rec := httptest.NewRecorder()
+
+	s.handlePolicyEvaluate(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+	require.Equal(t, 0, store.getActiveCalls(), "bundle store must not be consulted before auth/RBAC succeeds")
+}
+
+func TestPolicyEvaluateLegacyEndpointResponseStaysCompatible(t *testing.T) {
+	s, _, safety := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, nil)
+	safety.setResponse(&pb.PolicyCheckResponse{
+		Decision:       pb.DecisionType_DECISION_TYPE_ALLOW,
+		Reason:         "legacy-ok",
+		PolicySnapshot: "snap-legacy",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/policy/evaluate", strings.NewReader(`{"tenant":"default","topic":"job.default"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "default")
+	req = withAuth(req, &auth.AuthContext{Tenant: "default", Role: "admin", PrincipalID: "admin-user"})
+	rec := httptest.NewRecorder()
+
+	s.handlePolicyEvaluate(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	requireDeprecatedEndpointHeaders(t, rec, "/api/v1/policy/evaluate")
+	var legacy map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &legacy))
+	require.Contains(t, legacy, "decision")
+	require.NotContains(t, legacy, "decision_source")
+	require.NotContains(t, legacy, "trace")
+}
+
+func TestPolicySimulateExplainDeprecatedEndpointsKeepLegacyResponseShape(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		path    string
+		handler func(*server, http.ResponseWriter, *http.Request)
+	}{
+		{name: "simulate", path: "/api/v1/policy/simulate", handler: (*server).handlePolicySimulate},
+		{name: "explain", path: "/api/v1/policy/explain", handler: (*server).handlePolicyExplain},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _, safety := newTestGateway(t)
+			s.auth = newBasicAuthForTest(t, nil)
+			safety.setResponse(&pb.PolicyCheckResponse{
+				Decision:       pb.DecisionType_DECISION_TYPE_ALLOW,
+				Reason:         "legacy " + tc.name,
+				PolicySnapshot: "snap-" + tc.name,
+			})
+			req := legacyPolicyCheckRequest(t, tc.path)
+			rec := httptest.NewRecorder()
+
+			tc.handler(s, rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+			requireDeprecatedEndpointHeaders(t, rec, "/api/v1/policy/evaluate")
+			var legacy map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &legacy))
+			require.Equal(t, "DECISION_TYPE_ALLOW", legacy["decision"])
+			require.NotContains(t, legacy, "source")
+			require.NotContains(t, legacy, "trace")
+		})
+	}
+}
+
+func TestPolicyBundleLifecycleRoutesUseRealBundleStore(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	s.auth = newBasicAuthForTest(t, map[string]string{
+		"CORDUM_API_KEYS": `[{"key":"test-api-key","role":"admin","principal_id":"alice","tenant":"tenant-acme"}]`,
+	})
+	store := newMemoryPolicyBundleStore()
+	require.NoError(t, store.CreateBundle(context.Background(), &policy.Bundle{
+		ID:           "bundle-route",
+		Name:         "Route bundle",
+		ScopeBinding: policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-acme"},
+	}))
+	s.policyBundleStore = store
+	handler := policyRouteHandler(t, s)
+
+	version := policyBundleLifecyclePOST(t, handler, "/api/v1/policy/bundles/bundle-route/versions", `{
+		"version":"v1",
+		"rule_snapshot":[`+unifiedJobRuleJSON("bundle-route-rule")+`]
+	}`)
+	require.Equal(t, http.StatusCreated, version.Code, version.Body.String())
+
+	deploy := policyBundleLifecyclePOST(t, handler, "/api/v1/policy/bundles/bundle-route/deploy", `{
+		"version":"v1",
+		"scope":{"kind":"tenant","value":"tenant-acme"}
+	}`)
+	require.Equal(t, http.StatusOK, deploy.Code, deploy.Body.String())
+
+	version2 := policyBundleLifecyclePOST(t, handler, "/api/v1/policy/bundles/bundle-route/versions", `{
+		"version":"v2",
+		"rule_snapshot":[`+unifiedJobRuleJSON("bundle-route-rule-v2")+`]
+	}`)
+	require.Equal(t, http.StatusCreated, version2.Code, version2.Body.String())
+
+	deploy2 := policyBundleLifecyclePOST(t, handler, "/api/v1/policy/bundles/bundle-route/deploy", `{
+		"version":"v2",
+		"scope":{"kind":"tenant","value":"tenant-acme"}
+	}`)
+	require.Equal(t, http.StatusOK, deploy2.Code, deploy2.Body.String())
+
+	rollback := policyBundleLifecyclePOST(t, handler, "/api/v1/policy/bundles/deployments/rollback", `{
+		"scope":{"kind":"tenant","value":"tenant-acme"}
+	}`)
+	require.Equal(t, http.StatusOK, rollback.Code, rollback.Body.String())
+	require.Contains(t, rollback.Body.String(), `"action":"rollback"`)
+	require.Contains(t, rollback.Body.String(), `"version":"v1"`)
+
+	history := policyBundleLifecycleGET(t, handler, "/api/v1/policy/bundles/deployments?scope_kind=tenant&scope_value=tenant-acme")
+	require.Equal(t, http.StatusOK, history.Code, history.Body.String())
+	require.Contains(t, history.Body.String(), `"bundle_id":"bundle-route"`)
+}
+
+type unifiedPolicyEvaluateResponseJSON struct {
+	Decision policy.Decision `json:"decision"`
+}
+
+func postUnifiedPolicyEvaluate(t *testing.T, s *server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/policy/evaluate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "tenant-acme")
+	req = withAuth(req, &auth.AuthContext{Tenant: "tenant-acme", Role: "admin", PrincipalID: "alice"})
+	rec := httptest.NewRecorder()
+	s.handlePolicyEvaluate(rec, req)
+	return rec
+}
+
+func decodeUnifiedPolicyEvaluateResponse(t *testing.T, rec *httptest.ResponseRecorder) unifiedPolicyEvaluateResponseJSON {
+	t.Helper()
+	var got unifiedPolicyEvaluateResponseJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got), rec.Body.String())
+	return got
+}
+
+func requireJSONError(t *testing.T, rec *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got), rec.Body.String())
+	require.Equal(t, want, got["error"])
+}
+
+func requirePolicyDecisionAuditOrder(t *testing.T, sender *testAuditSender) {
+	t.Helper()
+	require.GreaterOrEqual(t, sender.Len(), 2, "expected legacy + unified policy decision events")
+	legacy := sender.Get(sender.Len() - 2)
+	unified := sender.Get(sender.Len() - 1)
+	if legacy.EventType != audit.EventSafetyDecision || unified.EventType != audit.EventPolicyDecisionV2 {
+		t.Fatalf("audit event order = [%q,%q], want [%q,%q]",
+			legacy.EventType,
+			unified.EventType,
+			audit.EventSafetyDecision,
+			audit.EventPolicyDecisionV2,
+		)
+	}
+}
+
+func requireDeprecatedEndpointHeaders(t *testing.T, rec *httptest.ResponseRecorder, successor string) {
+	t.Helper()
+	require.Equal(t, "true", rec.Header().Get("Deprecation"))
+	require.Contains(t, rec.Header().Values("Link"), "<"+successor+">; rel=\"successor-version\"")
+}
+
+func legacyPolicyCheckRequest(t *testing.T, path string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"tenant":"default","topic":"job.default"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "default")
+	return withAuth(req, &auth.AuthContext{Tenant: "default", Role: "admin", PrincipalID: "admin-user"})
+}
+
+func policyRouteHandler(t *testing.T, s *server) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	require.NoError(t, s.registerRoutes(mux))
+	return apiKeyMiddleware(s.auth, tenantMiddleware(s.auth, maxBodyMiddleware(mux, s.entitlements)))
+}
+
+func policyBundleLifecyclePOST(t *testing.T, handler http.Handler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-ID", "tenant-acme")
+	req.Header.Set("X-API-Key", "test-api-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func policyBundleLifecycleGET(t *testing.T, handler http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("X-Tenant-ID", "tenant-acme")
+	req.Header.Set("X-API-Key", "test-api-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func unifiedJobEvaluateBody(ruleID string) string {
+	return `{"rule":` + unifiedJobRuleJSON(ruleID) + `,"job_context":{"tenant_id":"tenant-acme","job_id":"job-123","workflow_id":"wf-1","topic":"job.acme.evaluate","principal_id":"alice","input":{"content":"contains blocked-token","content_type":"text/plain"}}}`
+}
+
+func unifiedEdgeEvaluateBody(ruleID string) string {
+	return `{"rule":` + unifiedEdgeRuleJSON(ruleID) + `,"edge_context":{"tenant_id":"tenant-acme","principal_id":"alice","session_id":"sess-1","execution_id":"exec-1","agent_product":"claude-code","tool_name":"Bash","tool_input_redacted":{"command":"rm -rf build"},"labels":{"edge.fleet_id":"fleet-a"}}}`
+}
+
+func unifiedBundleEvaluateBody() string {
+	return `{"bundle_id":"bundle-active","scope":{"kind":"tenant","value":"tenant-acme"},"job_context":{"tenant_id":"tenant-acme","job_id":"job-bundle","workflow_id":"wf-1","topic":"job.acme.evaluate","principal_id":"alice","input":{"content":"contains blocked-token","content_type":"text/plain"}}}`
+}
+
+func unifiedEdgeRuleWithJobContextBody() string {
+	return `{"rule":` + unifiedEdgeRuleJSON("edge-confused") + `,"job_context":{"tenant_id":"tenant-acme","job_id":"job-123","topic":"job.acme.evaluate"}}`
+}
+
+func unifiedUnknownRuleTypeBody() string {
+	return `{"rule":{"id":"unknown-rule","name":"unknown","type":"unknown","scope":{"kind":"tenant","value":"tenant-acme"},"status":"published","version":"v1","audit":{"created_at":"2026-05-09T00:00:00Z","created_by":"alice"},"match":{},"decide":{"decision":"deny"}},"job_context":{"tenant_id":"tenant-acme","job_id":"job-123","topic":"job.acme.evaluate"}}`
+}
+
+func unifiedJobRuleJSON(ruleID string) string {
+	return `{"id":"` + ruleID + `","name":"Block input","type":"input","scope":{"kind":"tenant","value":"tenant-acme"},"status":"published","version":"v1","audit":{"created_at":"2026-05-09T00:00:00Z","created_by":"alice"},"match":{"tenants":["tenant-acme"],"topics":["job.acme.evaluate"],"keywords":["blocked-token"],"content_types":["text/plain"]},"decide":{"decision":"deny","reason":"blocked input token","severity":"high"}}`
+}
+
+func unifiedEdgeRuleJSON(ruleID string) string {
+	return `{"id":"` + ruleID + `","name":"Deny destructive shell","type":"edge","scope":{"kind":"tenant","value":"tenant-acme"},"status":"published","version":"v1","audit":{"created_at":"2026-05-09T00:00:00Z","created_by":"alice"},"match":{"topics":["edge.agent_action"],"capabilities":["exec.shell"],"risk_tags":["destructive"]},"decide":{"decision":"deny","reason":"destructive shell denied"}}`
+}
+
+func seedActivePolicyBundle(t *testing.T, store *memoryPolicyBundleStore, ruleType policy.RuleType) {
+	t.Helper()
+	rule := policy.Rule{ID: "bundle-job-deny", Name: "Bundle job deny", Type: ruleType, Scope: policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-acme"}, Status: policy.RuleStatusPublished, Version: "v2", Match: json.RawMessage(`{"topics":["job.acme.evaluate"],"keywords":["blocked-token"]}`), Decide: json.RawMessage(`{"decision":"deny","reason":"active bundle rule denied"}`)}
+	bundle := &policy.Bundle{ID: "bundle-active", Name: "Active bundle", ScopeBinding: policy.RuleScope{Kind: policy.RuleScopeTenant, Value: "tenant-acme"}}
+	require.NoError(t, store.CreateBundle(context.Background(), bundle))
+	require.NoError(t, store.CreateBundleVersion(context.Background(), bundle.ID, &policy.BundleVersion{Version: "v2", RuleSnapshot: []policy.Rule{rule}, DeployedAt: time.Now().UTC()}))
+	_, err := store.DeployVersionToScope(context.Background(), bundle.ID, "v2", bundle.ScopeBinding)
+	require.NoError(t, err)
+}
+
+type memoryPolicyBundleStore struct {
+	mu             sync.Mutex
+	bundles        map[string]*policy.Bundle
+	versions       map[string]map[string]*policy.BundleVersion
+	deployments    map[policy.RuleScope]*policy.Deployment
+	history        map[policy.RuleScope][]*policy.Deployment
+	getActiveCount int
+}
+
+func newMemoryPolicyBundleStore() *memoryPolicyBundleStore {
+	return &memoryPolicyBundleStore{bundles: map[string]*policy.Bundle{}, versions: map[string]map[string]*policy.BundleVersion{}, deployments: map[policy.RuleScope]*policy.Deployment{}, history: map[policy.RuleScope][]*policy.Deployment{}}
+}
+
+func (s *memoryPolicyBundleStore) CreateBundle(ctx context.Context, b *policy.Bundle) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.bundles[b.ID]; exists {
+		return policy.ErrBundleExists
+	}
+	cp := *b
+	s.bundles[b.ID] = &cp
+	return nil
+}
+
+func (s *memoryPolicyBundleStore) GetBundle(ctx context.Context, id string) (*policy.Bundle, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.bundles[id]
+	if !ok {
+		return nil, policy.ErrBundleNotFound
+	}
+	cp := *b
+	return &cp, nil
+}
+
+func (s *memoryPolicyBundleStore) ListBundlesByScope(ctx context.Context, scope policy.RuleScope) ([]*policy.Bundle, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*policy.Bundle
+	for _, b := range s.bundles {
+		if b.ScopeBinding == scope {
+			cp := *b
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (s *memoryPolicyBundleStore) CreateBundleVersion(ctx context.Context, bundleID string, v *policy.BundleVersion) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.bundles[bundleID]; !ok {
+		return policy.ErrBundleNotFound
+	}
+	if s.versions[bundleID] == nil {
+		s.versions[bundleID] = map[string]*policy.BundleVersion{}
+	}
+	cp := *v
+	s.versions[bundleID][v.Version] = &cp
+	return nil
+}
+
+func (s *memoryPolicyBundleStore) ListBundleVersions(ctx context.Context, bundleID string) ([]*policy.BundleVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*policy.BundleVersion
+	for _, v := range s.versions[bundleID] {
+		cp := *v
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (s *memoryPolicyBundleStore) GetBundleVersion(ctx context.Context, bundleID, version string) (*policy.BundleVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.versions[bundleID][version]
+	if !ok {
+		return nil, policy.ErrBundleVersionNotFound
+	}
+	cp := *v
+	return &cp, nil
+}
+
+func (s *memoryPolicyBundleStore) DeployVersionToScope(ctx context.Context, bundleID, version string, scope policy.RuleScope) (*policy.Deployment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.versions[bundleID][version]; !ok {
+		return nil, policy.ErrBundleVersionNotFound
+	}
+	dep := &policy.Deployment{BundleID: bundleID, Version: version, Scope: scope, DeployedAt: time.Now().UTC(), Action: policy.DeploymentActionDeploy}
+	s.deployments[scope] = dep
+	s.history[scope] = append([]*policy.Deployment{dep}, s.history[scope]...)
+	return dep, nil
+}
+
+func (s *memoryPolicyBundleStore) RollbackDeployment(ctx context.Context, scope policy.RuleScope) (*policy.Deployment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	history := s.history[scope]
+	if len(history) < 2 {
+		return nil, policy.ErrNoRollbackTarget
+	}
+	prev := history[1]
+	dep := &policy.Deployment{BundleID: prev.BundleID, Version: prev.Version, Scope: scope, DeployedAt: time.Now().UTC(), Action: policy.DeploymentActionRollback}
+	s.deployments[scope] = dep
+	s.history[scope] = append([]*policy.Deployment{dep}, history...)
+	return dep, nil
+}
+
+func (s *memoryPolicyBundleStore) GetActiveDeployment(ctx context.Context, scope policy.RuleScope) (*policy.Deployment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getActiveCount++
+	dep, ok := s.deployments[scope]
+	if !ok {
+		return nil, policy.ErrNoDeploymentForScope
+	}
+	cp := *dep
+	return &cp, nil
+}
+
+func (s *memoryPolicyBundleStore) ListDeploymentHistory(ctx context.Context, scope policy.RuleScope, limit int) ([]*policy.Deployment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	history := s.history[scope]
+	if limit > 0 && len(history) > limit {
+		history = history[:limit]
+	}
+	out := make([]*policy.Deployment, 0, len(history))
+	for _, dep := range history {
+		cp := *dep
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (s *memoryPolicyBundleStore) getActiveCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getActiveCount
+}
+
+var _ policy.BundleStore = (*memoryPolicyBundleStore)(nil)

--- a/core/controlplane/gateway/policy_evaluator.go
+++ b/core/controlplane/gateway/policy_evaluator.go
@@ -1,0 +1,281 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	edgecore "github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+type policyEvaluationRequest struct {
+	Rule        *policy.Rule
+	BundleID    string
+	Scope       *policy.RuleScope
+	JobContext  *jobEvaluationContext
+	EdgeContext *edgeEvaluationContext
+}
+
+type jobEvaluationContext struct {
+	TenantID    string             `json:"tenant_id"`
+	JobID       string             `json:"job_id"`
+	WorkflowID  string             `json:"workflow_id"`
+	Topic       string             `json:"topic"`
+	PrincipalID string             `json:"principal_id"`
+	Labels      map[string]string  `json:"labels"`
+	MemoryID    string             `json:"memory_id"`
+	Capability  string             `json:"capability"`
+	RiskTags    []string           `json:"risk_tags"`
+	Input       jobEvaluationInput `json:"input"`
+}
+
+type jobEvaluationInput struct {
+	Content     string `json:"content"`
+	ContentType string `json:"content_type"`
+	SizeBytes   int64  `json:"size_bytes"`
+}
+
+type edgeEvaluationContext struct {
+	TenantID          string            `json:"tenant_id"`
+	PrincipalID       string            `json:"principal_id"`
+	SessionID         string            `json:"session_id"`
+	ExecutionID       string            `json:"execution_id"`
+	AgentProduct      string            `json:"agent_product"`
+	ToolName          string            `json:"tool_name"`
+	ToolInputRedacted map[string]any    `json:"tool_input_redacted"`
+	InputHash         string            `json:"input_hash"`
+	ToolInputHash     string            `json:"tool_input_hash"`
+	Labels            map[string]string `json:"labels"`
+	RiskTags          []string          `json:"risk_tags"`
+}
+
+type policyEvaluateResult struct {
+	Decision policy.Decision
+}
+
+type policyEvaluateErrorKind string
+
+const (
+	policyEvaluateValidation  policyEvaluateErrorKind = "validation"
+	policyEvaluateNotFound    policyEvaluateErrorKind = "not_found"
+	policyEvaluateUnavailable policyEvaluateErrorKind = "unavailable"
+	policyEvaluateUpstream    policyEvaluateErrorKind = "upstream"
+)
+
+type policyEvaluateError struct {
+	Kind    policyEvaluateErrorKind
+	Message string
+	Err     error
+}
+
+func (e *policyEvaluateError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err != nil {
+		return e.Message + ": " + e.Err.Error()
+	}
+	return e.Message
+}
+
+func (e *policyEvaluateError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *policyEvaluateError) StatusCode() int {
+	if e == nil {
+		return http.StatusInternalServerError
+	}
+	switch e.Kind {
+	case policyEvaluateValidation:
+		return http.StatusBadRequest
+	case policyEvaluateNotFound:
+		return http.StatusNotFound
+	case policyEvaluateUnavailable:
+		return http.StatusServiceUnavailable
+	case policyEvaluateUpstream:
+		return http.StatusBadGateway
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func newPolicyEvaluateError(kind policyEvaluateErrorKind, message string, err error) *policyEvaluateError {
+	return &policyEvaluateError{Kind: kind, Message: strings.TrimSpace(message), Err: err}
+}
+
+func (s *server) evaluateUnifiedPolicy(ctx context.Context, req policyEvaluationRequest) (policyEvaluateResult, error) {
+	resolved, err := s.resolvePolicyEvaluationTarget(ctx, req)
+	if err != nil {
+		return policyEvaluateResult{}, err
+	}
+	if err := validatePolicyEvaluationContext(resolved.rule, req); err != nil {
+		return policyEvaluateResult{}, err
+	}
+	result, err := s.dispatchUnifiedPolicyRule(ctx, resolved, req)
+	if err != nil {
+		return policyEvaluateResult{}, err
+	}
+	s.emitUnifiedPolicyEvaluateAudit(ctx, req, result.Decision)
+	return result, nil
+}
+
+type resolvedPolicyEvaluationTarget struct {
+	rule    policy.Rule
+	bundle  *policy.Bundle
+	binding policyBundleBinding
+}
+
+type policyBundleBinding struct {
+	BundleID string
+	Version  string
+}
+
+func (s *server) resolvePolicyEvaluationTarget(ctx context.Context, req policyEvaluationRequest) (resolvedPolicyEvaluationTarget, error) {
+	hasRule := req.Rule != nil
+	hasBundle := strings.TrimSpace(req.BundleID) != "" || req.Scope != nil
+	if hasRule == hasBundle {
+		return resolvedPolicyEvaluationTarget{}, newPolicyEvaluateError(policyEvaluateValidation, "provide exactly one of rule or bundle_id+scope", nil)
+	}
+	if hasRule {
+		return resolvedPolicyEvaluationTarget{rule: *req.Rule}, nil
+	}
+	return s.resolvePolicyEvaluationBundle(ctx, req)
+}
+
+func (s *server) resolvePolicyEvaluationBundle(ctx context.Context, req policyEvaluationRequest) (resolvedPolicyEvaluationTarget, error) {
+	bundleID := strings.TrimSpace(req.BundleID)
+	if bundleID == "" || req.Scope == nil || req.Scope.Kind == "" {
+		return resolvedPolicyEvaluationTarget{}, newPolicyEvaluateError(policyEvaluateValidation, "bundle_id and scope are required", nil)
+	}
+	if s == nil || s.policyBundleStore == nil {
+		return resolvedPolicyEvaluationTarget{}, newPolicyEvaluateError(policyEvaluateUnavailable, "policy bundle store unavailable", nil)
+	}
+	deployment, err := s.policyBundleStore.GetActiveDeployment(ctx, *req.Scope)
+	if err != nil {
+		return resolvedPolicyEvaluationTarget{}, bundleStoreEvaluateError("resolve active deployment", err)
+	}
+	if strings.TrimSpace(deployment.BundleID) != bundleID {
+		return resolvedPolicyEvaluationTarget{}, newPolicyEvaluateError(policyEvaluateNotFound, "active deployment for scope does not match bundle_id", nil)
+	}
+	version, err := s.policyBundleStore.GetBundleVersion(ctx, deployment.BundleID, deployment.Version)
+	if err != nil {
+		return resolvedPolicyEvaluationTarget{}, bundleStoreEvaluateError("load active bundle version", err)
+	}
+	bundle, _ := s.policyBundleStore.GetBundle(ctx, deployment.BundleID)
+	return pickRuleFromBundleVersion(bundle, deployment, version, req)
+}
+
+func pickRuleFromBundleVersion(bundle *policy.Bundle, deployment *policy.Deployment, version *policy.BundleVersion, req policyEvaluationRequest) (resolvedPolicyEvaluationTarget, error) {
+	for _, rule := range version.RuleSnapshot {
+		if rule.Status != policy.RuleStatusPublished {
+			continue
+		}
+		if policyRuleContextCompatible(rule.Type, req) {
+			return resolvedPolicyEvaluationTarget{rule: rule, bundle: bundle, binding: policyBundleBinding{BundleID: deployment.BundleID, Version: deployment.Version}}, nil
+		}
+	}
+	return resolvedPolicyEvaluationTarget{}, newPolicyEvaluateError(policyEvaluateNotFound, "active bundle has no published rule for evaluation context", nil)
+}
+
+func validatePolicyEvaluationContext(rule policy.Rule, req policyEvaluationRequest) error {
+	hasJob := req.JobContext != nil
+	hasEdge := req.EdgeContext != nil
+	if hasJob == hasEdge {
+		return newPolicyEvaluateError(policyEvaluateValidation, "provide exactly one of job_context or edge_context", nil)
+	}
+	if _, err := policy.ParseRuleType(rule.Type.String()); err != nil {
+		return newPolicyEvaluateError(policyEvaluateValidation, "unsupported rule type "+rule.Type.String(), err)
+	}
+	if !policyRuleContextCompatible(rule.Type, req) {
+		if rule.Type == policy.RuleTypeEdge {
+			return newPolicyEvaluateError(policyEvaluateValidation, "rule type edge requires edge_context", nil)
+		}
+		return newPolicyEvaluateError(policyEvaluateValidation, "rule type "+rule.Type.String()+" requires job_context", nil)
+	}
+	return nil
+}
+
+func policyRuleContextCompatible(ruleType policy.RuleType, req policyEvaluationRequest) bool {
+	if ruleType == policy.RuleTypeEdge {
+		return req.EdgeContext != nil && req.JobContext == nil
+	}
+	switch ruleType {
+	case policy.RuleTypeInput, policy.RuleTypeOutput, policy.RuleTypeVelocity:
+		return req.JobContext != nil && req.EdgeContext == nil
+	default:
+		return false
+	}
+}
+
+func (s *server) dispatchUnifiedPolicyRule(ctx context.Context, target resolvedPolicyEvaluationTarget, req policyEvaluationRequest) (policyEvaluateResult, error) {
+	if target.rule.Type == policy.RuleTypeEdge {
+		return s.evaluateUnifiedEdgeRule(ctx, target, *req.EdgeContext)
+	}
+	return s.evaluateUnifiedJobRule(ctx, target, *req.JobContext)
+}
+
+func (s *server) evaluateUnifiedJobRule(ctx context.Context, target resolvedPolicyEvaluationTarget, jobCtx jobEvaluationContext) (policyEvaluateResult, error) {
+	if s == nil || s.safetyClient == nil {
+		return policyEvaluateResult{}, newPolicyEvaluateError(policyEvaluateUnavailable, "safety kernel unavailable", nil)
+	}
+	resp, err := s.safetyClient.Evaluate(ctx, policyCheckRequestFromJobContext(jobCtx))
+	if err != nil {
+		return policyEvaluateResult{}, newPolicyEvaluateError(policyEvaluateUpstream, "safety kernel evaluate failed", err)
+	}
+	decision := decisionFromPolicyCheckResponse(policy.DecisionSourceJob, target.rule, target.binding, resp)
+	return policyEvaluateResult{Decision: decision}, nil
+}
+
+func policyCheckRequestFromJobContext(ctx jobEvaluationContext) *pb.PolicyCheckRequest {
+	inputSize := ctx.Input.SizeBytes
+	if inputSize == 0 && ctx.Input.Content != "" {
+		inputSize = int64(len([]byte(ctx.Input.Content)))
+	}
+	return &pb.PolicyCheckRequest{
+		JobId:            strings.TrimSpace(ctx.JobID),
+		Topic:            strings.TrimSpace(ctx.Topic),
+		Tenant:           strings.TrimSpace(ctx.TenantID),
+		PrincipalId:      strings.TrimSpace(ctx.PrincipalID),
+		Labels:           clonePolicyEvalStringMap(ctx.Labels),
+		MemoryId:         strings.TrimSpace(ctx.MemoryID),
+		Meta:             jobMetadataFromEvaluationContext(ctx),
+		InputContent:     []byte(ctx.Input.Content),
+		InputContentType: strings.TrimSpace(ctx.Input.ContentType),
+		InputSizeBytes:   inputSize,
+	}
+}
+
+func jobMetadataFromEvaluationContext(ctx jobEvaluationContext) *pb.JobMetadata {
+	return &pb.JobMetadata{
+		TenantId:   strings.TrimSpace(ctx.TenantID),
+		ActorId:    strings.TrimSpace(ctx.PrincipalID),
+		ActorType:  pb.ActorType_ACTOR_TYPE_HUMAN,
+		Capability: strings.TrimSpace(ctx.Capability),
+		RiskTags:   append([]string{}, ctx.RiskTags...),
+		Labels:     clonePolicyEvalStringMap(ctx.Labels),
+	}
+}
+
+func (s *server) evaluateUnifiedEdgeRule(ctx context.Context, target resolvedPolicyEvaluationTarget, edgeCtx edgeEvaluationContext) (policyEvaluateResult, error) {
+	adapted, err := edgecore.AdaptUnifiedEdgeRule(target.rule, edgecore.EdgeRuleAdapterOptions{Bundle: target.bundle})
+	if err != nil {
+		return policyEvaluateResult{}, newPolicyEvaluateError(policyEvaluateValidation, "adapt edge rule", err)
+	}
+	event := edgeEventFromEvaluationContext(edgeCtx)
+	classification, err := edgecore.ClassifyEvent(event)
+	if err != nil {
+		return policyEvaluateResult{}, newPolicyEvaluateError(policyEvaluateValidation, "classify edge context", err)
+	}
+	legacyReq, err := edgecore.MapEventToPolicyCheckRequest(event, classification, edgecore.PolicyMappingOptions{ActorID: edgeCtx.PrincipalID})
+	if err != nil {
+		return policyEvaluateResult{}, newPolicyEvaluateError(policyEvaluateValidation, "map edge context", err)
+	}
+	decision := evaluateAdaptedEdgeRule(target, adapted.Rule, legacyReq)
+	return policyEvaluateResult{Decision: decision}, nil
+}

--- a/core/controlplane/gateway/policy_evaluator_audit.go
+++ b/core/controlplane/gateway/policy_evaluator_audit.go
@@ -1,0 +1,57 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/policy"
+)
+
+func (s *server) emitUnifiedPolicyEvaluateAudit(ctx context.Context, req policyEvaluationRequest, decision policy.Decision) {
+	if s == nil || s.auditExporter == nil {
+		return
+	}
+	tenant := policyEvaluationTenant(req)
+	legacy := audit.SIEMEvent{Timestamp: time.Now().UTC(), EventType: audit.EventSafetyDecision, Severity: audit.SeverityInfo, TenantID: tenant, Action: "policy.evaluate", Decision: decision.Type.String(), MatchedRule: decision.RuleID, Reason: policyDecisionReason(decision), PolicyVersion: decision.BundleVersion, Extra: policyDecisionAuditExtra(decision)}
+	events, err := audit.DecisionEventsForMode(audit.UnifiedDecisionModeFromEnv(), legacy, decision)
+	if err != nil {
+		s.auditExporter.Send(legacy)
+		return
+	}
+	for _, event := range events {
+		s.auditExporter.Send(event)
+	}
+	_ = ctx
+}
+
+func policyEvaluationTenant(req policyEvaluationRequest) string {
+	if req.JobContext != nil {
+		return strings.TrimSpace(req.JobContext.TenantID)
+	}
+	if req.EdgeContext != nil {
+		return strings.TrimSpace(req.EdgeContext.TenantID)
+	}
+	return ""
+}
+
+func policyDecisionReason(decision policy.Decision) string {
+	for _, step := range decision.Trace {
+		if reason := strings.TrimSpace(step.Reason); reason != "" {
+			return reason
+		}
+	}
+	return decision.Type.String()
+}
+
+func policyDecisionAuditExtra(decision policy.Decision) map[string]string {
+	extra := map[string]string{"source": decision.Source.String()}
+	if decision.BundleID != "" {
+		extra["bundle_id"] = decision.BundleID
+	}
+	if decision.BundleVersion != "" {
+		extra["bundle_version"] = decision.BundleVersion
+	}
+	return extra
+}

--- a/core/controlplane/gateway/policy_evaluator_decision.go
+++ b/core/controlplane/gateway/policy_evaluator_decision.go
@@ -1,0 +1,136 @@
+package gateway
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/policybundles"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func decisionFromPolicyCheckResponse(source policy.DecisionSource, rule policy.Rule, binding policyBundleBinding, resp *pb.PolicyCheckResponse) policy.Decision {
+	decisionType := policyDecisionTypeFromProto(resp.GetDecision())
+	ruleID := firstNonEmptyString(resp.GetRuleId(), rule.ID)
+	reason := strings.TrimSpace(resp.GetReason())
+	return policy.Decision{Source: source, RuleID: ruleID, BundleID: binding.BundleID, BundleVersion: binding.Version, Type: decisionType, Trace: []policy.TraceStep{{RuleID: ruleID, BundleID: binding.BundleID, DecisionType: decisionType, Reason: reason, Timestamp: time.Now().UTC(), Constraints: rawProtoConstraints(resp.GetConstraints())}}, Timestamp: time.Now().UTC()}
+}
+
+func decisionFromConfigPolicyDecision(source policy.DecisionSource, rule policy.Rule, binding policyBundleBinding, decision config.PolicyDecision) policy.Decision {
+	decisionType := policyDecisionTypeFromString(decision.Decision)
+	ruleID := firstNonEmptyString(decision.RuleID, rule.ID)
+	reason := strings.TrimSpace(decision.Reason)
+	return policy.Decision{Source: source, RuleID: ruleID, BundleID: binding.BundleID, BundleVersion: binding.Version, Type: decisionType, Trace: []policy.TraceStep{{RuleID: ruleID, BundleID: binding.BundleID, DecisionType: decisionType, Reason: reason, Timestamp: time.Now().UTC(), Constraints: rawConfigConstraints(decision.Constraints)}}, Timestamp: time.Now().UTC()}
+}
+
+func policyDecisionTypeFromProto(decision pb.DecisionType) policy.DecisionType {
+	switch decision {
+	case pb.DecisionType_DECISION_TYPE_DENY:
+		return policy.DecisionDeny
+	case pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN:
+		return policy.DecisionRequireHuman
+	case pb.DecisionType_DECISION_TYPE_THROTTLE:
+		return policy.DecisionThrottle
+	case pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS:
+		return policy.DecisionAllowWithConstraints
+	case pb.DecisionType_DECISION_TYPE_QUARANTINE:
+		return policy.DecisionQuarantine
+	case pb.DecisionType_DECISION_TYPE_REDACT:
+		return policy.DecisionRedact
+	default:
+		return policy.DecisionAllow
+	}
+}
+
+func policyDecisionTypeFromString(decision string) policy.DecisionType {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "deny", "block":
+		return policy.DecisionDeny
+	case "require_approval", "require_human":
+		return policy.DecisionRequireHuman
+	case "throttle":
+		return policy.DecisionThrottle
+	case "constrain", "allow_with_constraints":
+		return policy.DecisionAllowWithConstraints
+	case "quarantine":
+		return policy.DecisionQuarantine
+	case "redact":
+		return policy.DecisionRedact
+	default:
+		return policy.DecisionAllow
+	}
+}
+
+func rawProtoConstraints(constraints *pb.PolicyConstraints) json.RawMessage {
+	if constraints == nil {
+		return nil
+	}
+	data, err := protojson.Marshal(constraints)
+	if err != nil || string(data) == "{}" {
+		return nil
+	}
+	return json.RawMessage(data)
+}
+
+func rawConfigConstraints(constraints config.PolicyConstraints) json.RawMessage {
+	if policybundles.IsConstraintsEmpty(constraints) {
+		return nil
+	}
+	data, err := json.Marshal(constraints)
+	if err != nil || string(data) == "{}" {
+		return nil
+	}
+	return json.RawMessage(data)
+}
+
+func bundleStoreEvaluateError(action string, err error) error {
+	kind := policyEvaluateUnavailable
+	if errors.Is(err, policy.ErrBundleNotFound) || errors.Is(err, policy.ErrBundleVersionNotFound) || errors.Is(err, policy.ErrNoDeploymentForScope) {
+		kind = policyEvaluateNotFound
+	}
+	return newPolicyEvaluateError(kind, action, err)
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func clonePolicyEvalStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func clonePolicyEvalAnyMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func policyEvaluateErrorMessage(err error) string {
+	var evalErr *policyEvaluateError
+	if errors.As(err, &evalErr) && evalErr.Message != "" {
+		return evalErr.Message
+	}
+	return fmt.Sprint(err)
+}

--- a/core/controlplane/gateway/policy_evaluator_edge.go
+++ b/core/controlplane/gateway/policy_evaluator_edge.go
@@ -1,0 +1,51 @@
+package gateway
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/policybundles"
+	edgecore "github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+func edgeEventFromEvaluationContext(ctx edgeEvaluationContext) edgecore.AgentActionEvent {
+	inputHash := strings.TrimSpace(ctx.ToolInputHash)
+	if inputHash == "" {
+		inputHash = strings.TrimSpace(ctx.InputHash)
+	}
+	return edgecore.AgentActionEvent{
+		EventID:       "policy-evaluate-" + strings.TrimSpace(ctx.ExecutionID),
+		TenantID:      strings.TrimSpace(ctx.TenantID),
+		PrincipalID:   strings.TrimSpace(ctx.PrincipalID),
+		SessionID:     strings.TrimSpace(ctx.SessionID),
+		ExecutionID:   strings.TrimSpace(ctx.ExecutionID),
+		Layer:         edgecore.LayerHook,
+		Kind:          edgecore.EventKindHookPreToolUse,
+		AgentProduct:  strings.TrimSpace(ctx.AgentProduct),
+		ToolName:      strings.TrimSpace(ctx.ToolName),
+		InputRedacted: clonePolicyEvalAnyMap(ctx.ToolInputRedacted),
+		InputHash:     inputHash,
+		RiskTags:      append([]string{}, ctx.RiskTags...),
+		Labels:        edgecore.Labels(clonePolicyEvalStringMap(ctx.Labels)),
+		Timestamp:     time.Now().UTC(),
+	}
+}
+
+func evaluateAdaptedEdgeRule(target resolvedPolicyEvaluationTarget, rule config.PolicyRule, req *pb.PolicyCheckRequest) policy.Decision {
+	input := config.PolicyInput{Tenant: req.GetTenant(), Topic: edgeInputTopic(rule, req), Labels: req.GetLabels(), Meta: policybundles.PolicyMetaFromRequest(req)}
+	input.SecretsPresent = policybundles.SecretsPresent(input.Meta, req.GetLabels())
+	policyDecision := (&config.SafetyPolicy{Rules: []config.PolicyRule{rule}, DefaultDecision: "allow"}).Evaluate(input)
+	return decisionFromConfigPolicyDecision(policy.DecisionSourceEdge, target.rule, target.binding, policyDecision)
+}
+
+func edgeInputTopic(rule config.PolicyRule, req *pb.PolicyCheckRequest) string {
+	for _, topic := range rule.Match.Topics {
+		if trimmed := strings.TrimSpace(topic); trimmed != "" {
+			return trimmed
+		}
+	}
+	return strings.TrimSpace(req.GetTopic())
+}

--- a/core/controlplane/gateway/policy_evaluator_grpc.go
+++ b/core/controlplane/gateway/policy_evaluator_grpc.go
@@ -1,0 +1,128 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *server) EvaluateUnified(ctx context.Context, req *pb.PolicyEvaluateRequest) (*pb.PolicyEvaluateResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request required")
+	}
+	if err := s.requireRoleGRPC(ctx, "admin", "operator"); err != nil {
+		return nil, err
+	}
+	evalReq, err := policyEvaluationRequestFromProto(req)
+	if err != nil {
+		return nil, policyEvaluateGRPCError(err)
+	}
+	if err := s.authorizePolicyEvaluateGRPC(ctx, &evalReq); err != nil {
+		return nil, err
+	}
+	result, err := s.evaluateUnifiedPolicy(ctx, evalReq)
+	if err != nil {
+		return nil, policyEvaluateGRPCError(err)
+	}
+	return &pb.PolicyEvaluateResponse{Decision: policyDecisionToProto(result.Decision)}, nil
+}
+
+func policyEvaluationRequestFromProto(req *pb.PolicyEvaluateRequest) (policyEvaluationRequest, error) {
+	rule, err := policyRuleFromProto(req.GetRule())
+	if err != nil {
+		return policyEvaluationRequest{}, err
+	}
+	return policyEvaluationRequest{
+		Rule:        rule,
+		BundleID:    strings.TrimSpace(req.GetBundleId()),
+		Scope:       policyRuleScopeFromProto(req.GetScope()),
+		JobContext:  jobEvaluationContextFromProto(req.GetJobContext()),
+		EdgeContext: edgeEvaluationContextFromProto(req.GetEdgeContext()),
+	}, nil
+}
+
+func policyRuleFromProto(rule *pb.Rule) (*policy.Rule, error) {
+	if rule == nil {
+		return nil, nil
+	}
+	match, err := structRawMessage(rule.GetMatch())
+	if err != nil {
+		return nil, newPolicyEvaluateError(policyEvaluateValidation, "invalid rule match", err)
+	}
+	decide, err := structRawMessage(rule.GetDecide())
+	if err != nil {
+		return nil, newPolicyEvaluateError(policyEvaluateValidation, "invalid rule decide", err)
+	}
+	return &policy.Rule{
+		ID:          strings.TrimSpace(rule.GetId()),
+		Name:        strings.TrimSpace(rule.GetName()),
+		Type:        policyRuleTypeFromProto(rule.GetType()),
+		Scope:       valuePolicyRuleScopeFromProto(rule.GetScope()),
+		Status:      policyRuleStatusFromProto(rule.GetStatus()),
+		Version:     strings.TrimSpace(rule.GetVersion()),
+		Audit:       policyAuditMetadataFromProto(rule.GetAudit()),
+		Match:       match,
+		Decide:      decide,
+		Description: strings.TrimSpace(rule.GetDescription()),
+	}, nil
+}
+
+func (s *server) authorizePolicyEvaluateGRPC(ctx context.Context, req *policyEvaluationRequest) error {
+	if req.JobContext != nil {
+		tenant, err := s.resolvePolicyEvaluateGRPCTenant(ctx, req.JobContext.TenantID)
+		if err != nil {
+			return err
+		}
+		req.JobContext.TenantID = tenant
+		req.JobContext.PrincipalID = resolvePolicyEvaluateGRPCPrincipal(ctx, req.JobContext.PrincipalID)
+	}
+	if req.EdgeContext != nil {
+		tenant, err := s.resolvePolicyEvaluateGRPCTenant(ctx, req.EdgeContext.TenantID)
+		if err != nil {
+			return err
+		}
+		req.EdgeContext.TenantID = tenant
+		req.EdgeContext.PrincipalID = resolvePolicyEvaluateGRPCPrincipal(ctx, req.EdgeContext.PrincipalID)
+	}
+	return nil
+}
+
+func (s *server) resolvePolicyEvaluateGRPCTenant(ctx context.Context, requested string) (string, error) {
+	if auth.FromContext(ctx) != nil {
+		return resolveGRPCTenant(ctx, requested, s.tenant)
+	}
+	if trimmed := strings.TrimSpace(requested); trimmed != "" {
+		return trimmed, nil
+	}
+	return strings.TrimSpace(s.tenant), nil
+}
+
+func resolvePolicyEvaluateGRPCPrincipal(ctx context.Context, requested string) string {
+	if authCtx := auth.FromContext(ctx); authCtx != nil && authCtx.PrincipalID != "" {
+		return authCtx.PrincipalID
+	}
+	return strings.TrimSpace(requested)
+}
+
+func policyEvaluateGRPCError(err error) error {
+	var evalErr *policyEvaluateError
+	if !errors.As(err, &evalErr) {
+		return status.Error(codes.Internal, "internal error")
+	}
+	switch evalErr.Kind {
+	case policyEvaluateValidation:
+		return status.Error(codes.InvalidArgument, policyEvaluateErrorMessage(evalErr))
+	case policyEvaluateNotFound:
+		return status.Error(codes.NotFound, policyEvaluateErrorMessage(evalErr))
+	case policyEvaluateUnavailable, policyEvaluateUpstream:
+		return status.Error(codes.Unavailable, policyEvaluateErrorMessage(evalErr))
+	default:
+		return status.Error(codes.Internal, "internal error")
+	}
+}

--- a/core/controlplane/gateway/policy_evaluator_grpc_convert.go
+++ b/core/controlplane/gateway/policy_evaluator_grpc_convert.go
@@ -1,0 +1,241 @@
+package gateway
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func jobEvaluationContextFromProto(ctx *pb.JobEvaluationContext) *jobEvaluationContext {
+	if ctx == nil {
+		return nil
+	}
+	return &jobEvaluationContext{
+		TenantID:    strings.TrimSpace(ctx.GetTenantId()),
+		JobID:       strings.TrimSpace(ctx.GetJobId()),
+		WorkflowID:  strings.TrimSpace(ctx.GetWorkflowId()),
+		Topic:       strings.TrimSpace(ctx.GetTopic()),
+		PrincipalID: strings.TrimSpace(ctx.GetPrincipalId()),
+		Labels:      clonePolicyEvalStringMap(ctx.GetLabels()),
+		MemoryID:    strings.TrimSpace(ctx.GetMemoryId()),
+		Capability:  strings.TrimSpace(ctx.GetCapability()),
+		RiskTags:    append([]string{}, ctx.GetRiskTags()...),
+		Input: jobEvaluationInput{
+			Content:     string(ctx.GetInputContent()),
+			ContentType: strings.TrimSpace(ctx.GetInputContentType()),
+			SizeBytes:   ctx.GetInputSizeBytes(),
+		},
+	}
+}
+
+func edgeEvaluationContextFromProto(ctx *pb.EdgeEvaluationContext) *edgeEvaluationContext {
+	if ctx == nil {
+		return nil
+	}
+	return &edgeEvaluationContext{
+		TenantID:          strings.TrimSpace(ctx.GetTenantId()),
+		PrincipalID:       strings.TrimSpace(ctx.GetPrincipalId()),
+		SessionID:         strings.TrimSpace(ctx.GetSessionId()),
+		ExecutionID:       strings.TrimSpace(ctx.GetExecutionId()),
+		AgentProduct:      strings.TrimSpace(ctx.GetAgentProduct()),
+		ToolName:          strings.TrimSpace(ctx.GetToolName()),
+		ToolInputRedacted: clonePolicyEvalAnyMap(structMap(ctx.GetToolInputRedacted())),
+		InputHash:         strings.TrimSpace(ctx.GetInputHash()),
+		ToolInputHash:     strings.TrimSpace(ctx.GetToolInputHash()),
+		Labels:            clonePolicyEvalStringMap(ctx.GetLabels()),
+		RiskTags:          append([]string{}, ctx.GetRiskTags()...),
+	}
+}
+
+func policyDecisionToProto(decision policy.Decision) *pb.Decision {
+	return &pb.Decision{
+		Source:        protoDecisionSource(decision.Source),
+		RuleId:        strings.TrimSpace(decision.RuleID),
+		BundleId:      strings.TrimSpace(decision.BundleID),
+		BundleVersion: strings.TrimSpace(decision.BundleVersion),
+		Type:          protoDecisionType(decision.Type),
+		Trace:         protoTraceSteps(decision.Trace),
+		InputRef:      strings.TrimSpace(decision.InputRef),
+		OutputRef:     strings.TrimSpace(decision.OutputRef),
+		AuditHash:     strings.TrimSpace(decision.AuditHash),
+		Timestamp:     timestampFromTime(decision.Timestamp),
+	}
+}
+
+func protoTraceSteps(trace []policy.TraceStep) []*pb.TraceStep {
+	if len(trace) == 0 {
+		return nil
+	}
+	out := make([]*pb.TraceStep, 0, len(trace))
+	for _, step := range trace {
+		out = append(out, &pb.TraceStep{
+			RuleId:       strings.TrimSpace(step.RuleID),
+			BundleId:     strings.TrimSpace(step.BundleID),
+			DecisionType: protoDecisionType(step.DecisionType),
+			Reason:       strings.TrimSpace(step.Reason),
+			Timestamp:    timestampFromTime(step.Timestamp),
+			Constraints:  rawMessageStruct(step.Constraints),
+		})
+	}
+	return out
+}
+
+func policyRuleScopeFromProto(scope *pb.RuleScope) *policy.RuleScope {
+	if scope == nil {
+		return nil
+	}
+	out := valuePolicyRuleScopeFromProto(scope)
+	return &out
+}
+
+func valuePolicyRuleScopeFromProto(scope *pb.RuleScope) policy.RuleScope {
+	if scope == nil {
+		return policy.RuleScope{}
+	}
+	return policy.RuleScope{
+		Kind:  policyRuleScopeKindFromProto(scope.GetKind()),
+		Value: strings.TrimSpace(scope.GetValue()),
+	}
+}
+
+func policyAuditMetadataFromProto(audit *pb.AuditMetadata) policy.AuditMetadata {
+	if audit == nil {
+		return policy.AuditMetadata{}
+	}
+	return policy.AuditMetadata{
+		CreatedAt: timestampToTime(audit.GetCreatedAt()),
+		CreatedBy: strings.TrimSpace(audit.GetCreatedBy()),
+		UpdatedAt: timestampToTime(audit.GetUpdatedAt()),
+		UpdatedBy: strings.TrimSpace(audit.GetUpdatedBy()),
+	}
+}
+
+func structRawMessage(value *structpb.Struct) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	raw, err := protojson.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	if string(raw) == "{}" {
+		return nil, nil
+	}
+	return json.RawMessage(raw), nil
+}
+
+func rawMessageStruct(raw json.RawMessage) *structpb.Struct {
+	if len(raw) == 0 {
+		return nil
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil || len(object) == 0 {
+		return nil
+	}
+	value, err := structpb.NewStruct(object)
+	if err != nil {
+		return nil
+	}
+	return value
+}
+
+func structMap(value *structpb.Struct) map[string]any {
+	if value == nil {
+		return nil
+	}
+	return value.AsMap()
+}
+
+func timestampFromTime(value time.Time) *timestamppb.Timestamp {
+	if value.IsZero() {
+		return nil
+	}
+	return timestamppb.New(value.UTC())
+}
+
+func timestampToTime(value *timestamppb.Timestamp) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
+}
+
+func policyRuleTypeFromProto(value pb.RuleType) policy.RuleType {
+	switch value {
+	case pb.RuleType_RULE_TYPE_INPUT:
+		return policy.RuleTypeInput
+	case pb.RuleType_RULE_TYPE_OUTPUT:
+		return policy.RuleTypeOutput
+	case pb.RuleType_RULE_TYPE_VELOCITY:
+		return policy.RuleTypeVelocity
+	case pb.RuleType_RULE_TYPE_EDGE:
+		return policy.RuleTypeEdge
+	default:
+		return policy.RuleType("")
+	}
+}
+
+func policyRuleStatusFromProto(value pb.RuleStatus) policy.RuleStatus {
+	switch value {
+	case pb.RuleStatus_RULE_STATUS_DRAFT:
+		return policy.RuleStatusDraft
+	case pb.RuleStatus_RULE_STATUS_PUBLISHED:
+		return policy.RuleStatusPublished
+	case pb.RuleStatus_RULE_STATUS_DEPRECATED:
+		return policy.RuleStatusDeprecated
+	default:
+		return policy.RuleStatus("")
+	}
+}
+
+func policyRuleScopeKindFromProto(value pb.RuleScopeKind) policy.RuleScopeKind {
+	switch value {
+	case pb.RuleScopeKind_RULE_SCOPE_KIND_GLOBAL:
+		return policy.RuleScopeGlobal
+	case pb.RuleScopeKind_RULE_SCOPE_KIND_TENANT:
+		return policy.RuleScopeTenant
+	case pb.RuleScopeKind_RULE_SCOPE_KIND_WORKFLOW:
+		return policy.RuleScopeWorkflow
+	case pb.RuleScopeKind_RULE_SCOPE_KIND_EDGE_FLEET:
+		return policy.RuleScopeEdgeFleet
+	case pb.RuleScopeKind_RULE_SCOPE_KIND_EDGE_USER:
+		return policy.RuleScopeEdgeUser
+	default:
+		return policy.RuleScopeKind("")
+	}
+}
+
+func protoDecisionSource(value policy.DecisionSource) pb.DecisionSource {
+	if value == policy.DecisionSourceEdge {
+		return pb.DecisionSource_DECISION_SOURCE_EDGE
+	}
+	if value == policy.DecisionSourceJob {
+		return pb.DecisionSource_DECISION_SOURCE_JOB
+	}
+	return pb.DecisionSource_DECISION_SOURCE_UNSPECIFIED
+}
+
+func protoDecisionType(value policy.DecisionType) pb.DecisionType {
+	switch value {
+	case policy.DecisionDeny:
+		return pb.DecisionType_DECISION_TYPE_DENY
+	case policy.DecisionRequireHuman:
+		return pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN
+	case policy.DecisionThrottle:
+		return pb.DecisionType_DECISION_TYPE_THROTTLE
+	case policy.DecisionAllowWithConstraints:
+		return pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS
+	case policy.DecisionQuarantine:
+		return pb.DecisionType_DECISION_TYPE_QUARANTINE
+	case policy.DecisionRedact:
+		return pb.DecisionType_DECISION_TYPE_REDACT
+	default:
+		return pb.DecisionType_DECISION_TYPE_ALLOW
+	}
+}

--- a/core/controlplane/gateway/policy_evaluator_grpc_test.go
+++ b/core/controlplane/gateway/policy_evaluator_grpc_test.go
@@ -1,0 +1,136 @@
+package gateway
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/policy"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const policyEvaluatorBufSize = 1024 * 1024
+
+func TestPolicyEvaluatorGRPCEvaluateUnifiedMatchesHTTPJobDispatch(t *testing.T) {
+	s, _, safety := newTestGateway(t)
+	s.auth = newPolicyEvaluatorAuthProvider(t)
+	safety.setResponse(&pb.PolicyCheckResponse{
+		Decision: pb.DecisionType_DECISION_TYPE_DENY,
+		Reason:   "grpc job denied",
+		RuleId:   "grpc-job-rule",
+	})
+	client, cleanup := newPolicyEvaluatorGRPCClient(t, s)
+	defer cleanup()
+
+	resp, err := client.EvaluateUnified(policyEvaluatorAuthContext(), &pb.PolicyEvaluateRequest{
+		Rule:       grpcPolicyRule(t, "grpc-job-rule", pb.RuleType_RULE_TYPE_INPUT),
+		JobContext: grpcJobContext(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetDecision())
+	require.Equal(t, pb.DecisionSource_DECISION_SOURCE_JOB, resp.GetDecision().GetSource())
+	require.Equal(t, pb.DecisionType_DECISION_TYPE_DENY, resp.GetDecision().GetType())
+	require.Equal(t, "grpc-job-rule", resp.GetDecision().GetRuleId())
+}
+
+func TestPolicyEvaluatorGRPCEvaluateUnifiedRejectsEdgeRuleWithJobContext(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	s.auth = newPolicyEvaluatorAuthProvider(t)
+	client, cleanup := newPolicyEvaluatorGRPCClient(t, s)
+	defer cleanup()
+
+	_, err := client.EvaluateUnified(policyEvaluatorAuthContext(), &pb.PolicyEvaluateRequest{
+		Rule:       grpcPolicyRule(t, "grpc-edge-rule", pb.RuleType_RULE_TYPE_EDGE),
+		JobContext: grpcJobContext(),
+	})
+
+	require.ErrorContains(t, err, "rule type edge requires edge_context")
+}
+
+func newPolicyEvaluatorGRPCClient(t *testing.T, s *server) (pb.PolicyEvaluatorClient, func()) {
+	t.Helper()
+	listener := bufconn.Listen(policyEvaluatorBufSize)
+	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(apiKeyUnaryInterceptor(s.auth)))
+	pb.RegisterPolicyEvaluatorServer(grpcServer, s)
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithInsecure(),
+	)
+	require.NoError(t, err)
+	cleanup := func() {
+		_ = conn.Close()
+		grpcServer.Stop()
+		_ = listener.Close()
+	}
+	return pb.NewPolicyEvaluatorClient(conn), cleanup
+}
+
+func policyEvaluatorAuthContext() context.Context {
+	return metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		"x-api-key", "policy-evaluator-test-key",
+		"x-principal-id", "alice",
+	))
+}
+
+func newPolicyEvaluatorAuthProvider(t *testing.T) *auth.BasicAuthProvider {
+	t.Helper()
+	return newBasicAuthForTest(t, map[string]string{
+		"CORDUM_API_KEYS": `[{"key":"policy-evaluator-test-key","role":"admin","principal_id":"alice","tenant":"tenant-acme"}]`,
+	})
+}
+
+func grpcJobContext() *pb.JobEvaluationContext {
+	return &pb.JobEvaluationContext{
+		TenantId:         "tenant-acme",
+		JobId:            "job-grpc",
+		WorkflowId:       "wf-grpc",
+		Topic:            "job.acme.evaluate",
+		PrincipalId:      "alice",
+		InputContent:     []byte("contains blocked-token"),
+		InputContentType: "text/plain",
+	}
+}
+
+func grpcPolicyRule(t *testing.T, id string, ruleType pb.RuleType) *pb.Rule {
+	t.Helper()
+	match, err := structpb.NewStruct(map[string]any{
+		"tenants":       []any{"tenant-acme"},
+		"topics":        []any{"job.acme.evaluate"},
+		"keywords":      []any{"blocked-token"},
+		"content_types": []any{"text/plain"},
+	})
+	require.NoError(t, err)
+	decide, err := structpb.NewStruct(map[string]any{
+		"decision": "deny",
+		"reason":   "grpc job denied",
+	})
+	require.NoError(t, err)
+	return &pb.Rule{
+		Id:      id,
+		Name:    "gRPC rule",
+		Type:    ruleType,
+		Scope:   &pb.RuleScope{Kind: pb.RuleScopeKind_RULE_SCOPE_KIND_TENANT, Value: "tenant-acme"},
+		Status:  pb.RuleStatus_RULE_STATUS_PUBLISHED,
+		Version: "v1",
+		Audit:   &pb.AuditMetadata{CreatedAt: timestamppb.Now(), CreatedBy: "alice"},
+		Match:   match,
+		Decide:  decide,
+	}
+}
+
+var _ = policy.DecisionSourceJob

--- a/core/controlplane/gateway/route_coverage_test.go
+++ b/core/controlplane/gateway/route_coverage_test.go
@@ -214,11 +214,16 @@ func routeCoverageOpName(op openAPIOperation) string {
 }
 
 func isDeprecatedRouteCoverageOp(node *yaml.Node) bool {
+	return routeCoverageBoolField(node, "deprecated") && !routeCoverageBoolField(node, "x-live-route")
+}
+
+func routeCoverageBoolField(node *yaml.Node, key string) bool {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return false
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
-		if strings.EqualFold(node.Content[i].Value, "deprecated") && strings.EqualFold(node.Content[i+1].Value, "true") {
+		if strings.EqualFold(node.Content[i].Value, key) &&
+			strings.EqualFold(node.Content[i+1].Value, "true") {
 			return true
 		}
 	}

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -14,7 +14,10 @@ with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
   `Rule{Type: edge}` snapshots through the Edge adapter, keep legacy
   `EdgeDecision` persistence for compatibility, and emit
   `Decision{Source: edge}` into the shared audit-chain stream (Backend 4).
-- `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
+- `core/controlplane/gateway/` — exposes the unified evaluator
+  `POST /api/v1/policy/evaluate`, gRPC `PolicyEvaluator.EvaluateUnified`, and
+  BundleStore lifecycle HTTP routes (Backend 5). See
+  [`docs/policy-evaluate-api.md`](../../docs/policy-evaluate-api.md).
 - `BundleRedisStore` (`bundle_store_redis.go`) — Redis-backed shared
   bundle storage for job + edge consumers; Backend 5+ wires this into
   the unified evaluator entry-point. Schema documented in
@@ -36,3 +39,26 @@ preserves bit-for-bit fidelity and maps cleanly onto the proto-side
 `require_human` / `throttle` / `allow_with_constraints` / `quarantine` /
 `redact`. The last two were appended for the unified surface per CAP's
 append-only protobuf-evolution rule.
+
+## Evaluator contract
+
+The gateway evaluator accepts exactly one rule source and one context:
+
+- Inline `Rule`, or `bundle_id` + `RuleScope` active deployment.
+- `job_context`, or `edge_context`.
+
+Dispatch is driven only by `Rule.Type`:
+
+| Rule type | Context | Consumer |
+| --- | --- | --- |
+| `input` | job | Safety Kernel input adapter |
+| `output` | job | Safety Kernel output adapter |
+| `velocity` | job | Safety Kernel velocity adapter |
+| `edge` | edge | Edge classifier adapter |
+
+Requests that mix `RuleTypeEdge` with job context, or job-side rule types with
+Edge context, fail validation before downstream dispatch. Bundle evaluation
+loads the active deployment for the requested `RuleScope`, verifies the active
+bundle matches `bundle_id`, scans the active version's published
+`RuleSnapshot`, and stamps the returned `Decision` with `BundleID` +
+`BundleVersion`.

--- a/core/policy/README.md
+++ b/core/policy/README.md
@@ -11,6 +11,10 @@ with a `RuleType` discriminator and per-type `Match`/`Decide` payloads.
   evaluation paths (Backend 3 + Backend 5).
 - `core/edge/` — same migration; joins the unified audit-chain (Backend 4).
 - `core/controlplane/gateway/` — exposes `/policies/*` HTTP routes (Backend 5).
+- `BundleRedisStore` (`bundle_store_redis.go`) — Redis-backed shared
+  bundle storage for job + edge consumers; Backend 5+ wires this into
+  the unified evaluator entry-point. Schema documented in
+  [`docs/policy-bundle-store.md`](../../docs/policy-bundle-store.md).
 
 ## Match / Decide contract
 

--- a/core/policy/bundle_store.go
+++ b/core/policy/bundle_store.go
@@ -1,0 +1,122 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// BundleStore is the unified storage interface for Policy Studio bundles
+// (epic-d9a6c0a1). Both job-side (safetykernel) and edge-side consumers
+// read through this interface; the Redis implementation lives in
+// bundle_store_redis.go (Backend 2 step-4).
+//
+// Design intent:
+//   - Bundles are authored once and deployed multiple times. Versions
+//     capture immutable RuleSnapshot at deploy time for tamper-evident
+//     rollback.
+//   - Deployments bind a (bundle, version) pair to a RuleScope. The
+//     active deployment is the one evaluators consult; rollbacks are
+//     append-only and re-bind the active pointer to a prior version.
+//   - All multi-key mutations (DeployVersionToScope, RollbackDeployment)
+//     execute inside one Redis Lua script so concurrent deploys
+//     serialize through Redis itself, not through Go-level WATCH/MULTI
+//     (see memory mem-12f1ceeb — go-redis WATCH+TxPipelined corrupts the
+//     connection pool when miniredis returns errors).
+type BundleStore interface {
+	// Bundle CRUD ----------------------------------------------------------
+
+	// CreateBundle persists a new Bundle. The Bundle's ID must be set; an
+	// existing bundle with the same ID returns ErrBundleExists.
+	CreateBundle(ctx context.Context, b *Bundle) error
+
+	// GetBundle returns the Bundle envelope (without RuleSnapshot — those
+	// live in Versions). Returns ErrBundleNotFound when no such bundle.
+	GetBundle(ctx context.Context, id string) (*Bundle, error)
+
+	// ListBundlesByScope returns every bundle whose ScopeBinding matches
+	// the supplied scope. An empty result is not an error.
+	ListBundlesByScope(ctx context.Context, scope RuleScope) ([]*Bundle, error)
+
+	// Bundle versioning ---------------------------------------------------
+
+	// CreateBundleVersion appends a new version to bundleID. Idempotent on
+	// duplicate version numbers (returns ErrBundleVersionExists). Versions
+	// are immutable once written.
+	CreateBundleVersion(ctx context.Context, bundleID string, v *BundleVersion) error
+
+	// ListBundleVersions returns all versions for the bundle in
+	// chronological deploy order (oldest first).
+	ListBundleVersions(ctx context.Context, bundleID string) ([]*BundleVersion, error)
+
+	// GetBundleVersion returns one specific version. Returns
+	// ErrBundleVersionNotFound when the (bundleID, version) pair is unknown.
+	GetBundleVersion(ctx context.Context, bundleID, version string) (*BundleVersion, error)
+
+	// Deployment ----------------------------------------------------------
+
+	// DeployVersionToScope rebinds the active deployment for scope to the
+	// given (bundleID, version). The previous active deployment (if any)
+	// is preserved in deployment history. Returns the recorded Deployment
+	// on success; ErrBundleVersionNotFound if the version doesn't exist.
+	DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error)
+
+	// RollbackDeployment reverts the active deployment for scope to the
+	// previous entry in history. Returns ErrNoRollbackTarget when history
+	// has fewer than two entries (i.e. no prior deploy to fall back to).
+	// On success the rollback itself is appended to history as a new
+	// Deployment with Action=DeploymentActionRollback.
+	RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error)
+
+	// GetActiveDeployment returns the active deployment for scope.
+	// Returns ErrNoDeploymentForScope when nothing is currently bound.
+	GetActiveDeployment(ctx context.Context, scope RuleScope) (*Deployment, error)
+
+	// ListDeploymentHistory returns up to limit entries from the scope's
+	// deployment history, newest first. The history is bounded to the
+	// last 100 entries by the implementation.
+	ListDeploymentHistory(ctx context.Context, scope RuleScope, limit int) ([]*Deployment, error)
+}
+
+// DeploymentAction discriminates a Deployment record between a fresh
+// deploy and a rollback to a prior version. The two paths share the rest
+// of the envelope; downstream readers branch on Action when they need to
+// surface the distinction (e.g. the dashboard "Deployments" tab).
+type DeploymentAction string
+
+const (
+	// DeploymentActionDeploy records a fresh deploy of a (bundle, version)
+	// pair to a scope. The Version field carries the deployed version.
+	DeploymentActionDeploy DeploymentAction = "deploy"
+
+	// DeploymentActionRollback records a rollback to a prior version. The
+	// Version field carries the version rolled BACK TO (i.e. the new
+	// active version after the rollback completes), not the version
+	// rolled away from.
+	DeploymentActionRollback DeploymentAction = "rollback"
+)
+
+// Deployment is the audit-ready record of one binding event between a
+// (bundle, version) and a scope. Stored in scope deployment history; the
+// most recent entry whose Action == DeploymentActionDeploy or Rollback
+// determines the active deployment.
+type Deployment struct {
+	BundleID      string           `json:"bundle_id"`
+	Version       string           `json:"version"`
+	Scope         RuleScope        `json:"scope"`
+	DeployedAt    time.Time        `json:"deployed_at"`
+	DeployedBy    string           `json:"deployed_by,omitempty"`
+	AuditHash     string           `json:"audit_hash,omitempty"`
+	Action        DeploymentAction `json:"action"`
+}
+
+// Typed errors returned by BundleStore implementations. Consumers should
+// branch on these via errors.Is for stable contract tests.
+var (
+	ErrBundleNotFound        = errors.New("policy: bundle not found")
+	ErrBundleExists          = errors.New("policy: bundle already exists")
+	ErrBundleVersionNotFound = errors.New("policy: bundle version not found")
+	ErrBundleVersionExists   = errors.New("policy: bundle version already exists")
+	ErrNoDeploymentForScope  = errors.New("policy: no active deployment for scope")
+	ErrNoRollbackTarget      = errors.New("policy: no prior deployment to roll back to")
+)

--- a/core/policy/bundle_store.go
+++ b/core/policy/bundle_store.go
@@ -62,10 +62,20 @@ type BundleStore interface {
 	DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error)
 
 	// RollbackDeployment reverts the active deployment for scope to the
-	// previous entry in history. Returns ErrNoRollbackTarget when history
-	// has fewer than two entries (i.e. no prior deploy to fall back to).
+	// (bundle, version) pair that was active immediately before the
+	// current binding was established. Each deploy event records its
+	// PrevBundleID + PrevVersion at write time, so rollback restores the
+	// prior active pair regardless of any rollback markers in between
+	// (e.g. deploy v1, deploy v2, rollback to v1, deploy v3, rollback
+	// returns to v1 — the active state just before v3 — not v2). Chained
+	// rollbacks unwind one step per call.
+	//
+	// Returns ErrNoRollbackTarget when no prior deploy exists (e.g. only
+	// the original deploy is in history, or its PrevBundleID is empty).
 	// On success the rollback itself is appended to history as a new
-	// Deployment with Action=DeploymentActionRollback.
+	// Deployment with Action=DeploymentActionRollback whose PrevBundleID
+	// + PrevVersion fields capture the version we rolled away from
+	// (informational; rollback does not consume its own prev fields).
 	RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error)
 
 	// GetActiveDeployment returns the active deployment for scope.
@@ -100,14 +110,25 @@ const (
 // (bundle, version) and a scope. Stored in scope deployment history; the
 // most recent entry whose Action == DeploymentActionDeploy or Rollback
 // determines the active deployment.
+//
+// Each deploy event records PrevBundleID + PrevVersion at write time —
+// the (bundle, version) pair that was active immediately before this
+// event ran. Rollback uses those fields to restore the prior active
+// pair regardless of any deploy/rollback events that landed in between.
+// On a deploy event, the prev pair is the active state just before this
+// deploy. On a rollback event, the prev pair is the active state just
+// before the rollback (i.e. the version we rolled away from); rollback
+// does not consume its own prev fields.
 type Deployment struct {
-	BundleID      string           `json:"bundle_id"`
-	Version       string           `json:"version"`
-	Scope         RuleScope        `json:"scope"`
-	DeployedAt    time.Time        `json:"deployed_at"`
-	DeployedBy    string           `json:"deployed_by,omitempty"`
-	AuditHash     string           `json:"audit_hash,omitempty"`
-	Action        DeploymentAction `json:"action"`
+	BundleID     string           `json:"bundle_id"`
+	Version      string           `json:"version"`
+	Scope        RuleScope        `json:"scope"`
+	DeployedAt   time.Time        `json:"deployed_at"`
+	DeployedBy   string           `json:"deployed_by,omitempty"`
+	AuditHash    string           `json:"audit_hash,omitempty"`
+	Action       DeploymentAction `json:"action"`
+	PrevBundleID string           `json:"prev_bundle_id,omitempty"`
+	PrevVersion  string           `json:"prev_version,omitempty"`
 }
 
 // Typed errors returned by BundleStore implementations. Consumers should

--- a/core/policy/bundle_store_keys.go
+++ b/core/policy/bundle_store_keys.go
@@ -1,0 +1,61 @@
+package policy
+
+// Redis key constructors for the Policy Studio bundle store
+// (epic-d9a6c0a1 Backend 2). All keys live under two prefixes:
+//
+//	policy:bundle:*  bundle envelopes + per-bundle versions index +
+//	                 per-version blobs
+//	policy:scope:*   per-scope active deployment pointer + history list
+//
+// These prefixes are confirmed clean against existing core/* stores per
+// the step-2 inventory: workflow uses `cordum:wf:*` + `runKey()`, edge
+// uses `edge:session:*` + `edge:rule:*`, and registry uses
+// `sys:workers:*`. None overlap with `policy:*`.
+//
+// Key shapes:
+//
+//	policy:bundle:{id}                          STRING (Bundle envelope JSON)
+//	policy:bundle:{id}:versions                 ZSET   (score = unix nanos of DeployedAt; member = version string)
+//	policy:bundle:{id}:version:{version}        STRING (BundleVersion JSON, includes RuleSnapshot)
+//	policy:scope:{kind}:{value}:active          STRING ("{bundleID}:{version}" pointer; empty when unbound)
+//	policy:scope:{kind}:{value}:history         LIST   (each element is a Deployment JSON; LPUSH on deploy/rollback; LTRIM 0 99 keeps newest 100)
+
+const (
+	bundleKeyPrefix       = "policy:bundle:"
+	bundleVersionInfix    = ":version:"
+	bundleVersionsSuffix  = ":versions"
+	scopeKeyPrefix        = "policy:scope:"
+	scopeActiveSuffix     = ":active"
+	scopeHistorySuffix    = ":history"
+	deploymentHistoryCap  = 100
+)
+
+// bundleKey returns the Redis key for a bundle envelope.
+func bundleKey(id string) string {
+	return bundleKeyPrefix + id
+}
+
+// bundleVersionKey returns the Redis key for one specific BundleVersion.
+func bundleVersionKey(id, version string) string {
+	return bundleKeyPrefix + id + bundleVersionInfix + version
+}
+
+// bundleVersionsIndexKey returns the Redis key for the ZSET that indexes
+// every version belonging to a bundle.
+func bundleVersionsIndexKey(id string) string {
+	return bundleKeyPrefix + id + bundleVersionsSuffix
+}
+
+// scopeActiveKey returns the Redis key for the active-deployment pointer
+// of a scope. The stored value is the literal "{bundleID}:{version}".
+// For RuleScopeGlobal the Value field is empty; the helper still emits a
+// deterministic key.
+func scopeActiveKey(scope RuleScope) string {
+	return scopeKeyPrefix + string(scope.Kind) + ":" + scope.Value + scopeActiveSuffix
+}
+
+// scopeDeploymentHistoryKey returns the Redis key for the LIST that
+// stores a scope's deploy/rollback history.
+func scopeDeploymentHistoryKey(scope RuleScope) string {
+	return scopeKeyPrefix + string(scope.Kind) + ":" + scope.Value + scopeHistorySuffix
+}

--- a/core/policy/bundle_store_keys_test.go
+++ b/core/policy/bundle_store_keys_test.go
@@ -1,0 +1,89 @@
+package policy
+
+import "testing"
+
+func TestBundleKey(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "simple id", id: "b1", want: "policy:bundle:b1"},
+		{name: "uuid id", id: "01H8Z1...EOF", want: "policy:bundle:01H8Z1...EOF"},
+		{name: "empty id is allowed at the helper layer", id: "", want: "policy:bundle:"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bundleKey(tt.id); got != tt.want {
+				t.Errorf("bundleKey(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBundleVersionKey(t *testing.T) {
+	got := bundleVersionKey("b1", "v3")
+	want := "policy:bundle:b1:version:v3"
+	if got != want {
+		t.Errorf("bundleVersionKey(b1, v3) = %q, want %q", got, want)
+	}
+}
+
+func TestBundleVersionsIndexKey(t *testing.T) {
+	got := bundleVersionsIndexKey("b1")
+	want := "policy:bundle:b1:versions"
+	if got != want {
+		t.Errorf("bundleVersionsIndexKey(b1) = %q, want %q", got, want)
+	}
+}
+
+func TestScopeActiveKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope RuleScope
+		want  string
+	}{
+		{
+			name:  "tenant scope",
+			scope: RuleScope{Kind: RuleScopeTenant, Value: "acme"},
+			want:  "policy:scope:tenant:acme:active",
+		},
+		{
+			name:  "global scope (empty value)",
+			scope: RuleScope{Kind: RuleScopeGlobal, Value: ""},
+			want:  "policy:scope:global::active",
+		},
+		{
+			name:  "edge fleet scope",
+			scope: RuleScope{Kind: RuleScopeEdgeFleet, Value: "fleet-1"},
+			want:  "policy:scope:edge_fleet:fleet-1:active",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopeActiveKey(tt.scope); got != tt.want {
+				t.Errorf("scopeActiveKey(%+v) = %q, want %q", tt.scope, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeDeploymentHistoryKey(t *testing.T) {
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	got := scopeDeploymentHistoryKey(scope)
+	want := "policy:scope:tenant:acme:history"
+	if got != want {
+		t.Errorf("scopeDeploymentHistoryKey(%+v) = %q, want %q", scope, got, want)
+	}
+}
+
+func TestKeyPrefixIsolation(t *testing.T) {
+	// Step-2 inventory confirmed no existing core store uses these prefixes.
+	// This test pins the prefix constants so accidental rename is caught.
+	if bundleKeyPrefix != "policy:bundle:" {
+		t.Errorf("bundleKeyPrefix changed: %q (must stay 'policy:bundle:' to avoid collision audit)", bundleKeyPrefix)
+	}
+	if scopeKeyPrefix != "policy:scope:" {
+		t.Errorf("scopeKeyPrefix changed: %q (must stay 'policy:scope:' to avoid collision audit)", scopeKeyPrefix)
+	}
+}

--- a/core/policy/bundle_store_redis.go
+++ b/core/policy/bundle_store_redis.go
@@ -1,0 +1,485 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/infra/redisutil"
+	"github.com/redis/go-redis/v9"
+)
+
+// BundleRedisStore is the Redis-backed BundleStore implementation. All
+// multi-key mutations execute inside Lua scripts so concurrent
+// deploy/rollback operations serialize through Redis itself, not via
+// Go-level WATCH/MULTI/EXEC (per memory mem-12f1ceeb — go-redis
+// WATCH+TxPipelined corrupts the connection pool when miniredis returns
+// errors).
+type BundleRedisStore struct {
+	client redis.UniversalClient
+}
+
+// NewRedisBundleStore constructs a Redis-backed BundleStore.
+func NewRedisBundleStore(url string) (*BundleRedisStore, error) {
+	if url == "" {
+		return nil, fmt.Errorf("redis url required")
+	}
+	client, err := redisutil.NewClient(url)
+	if err != nil {
+		return nil, fmt.Errorf("parse redis url: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("connect redis: %w", err)
+	}
+	return &BundleRedisStore{client: client}, nil
+}
+
+// NewRedisBundleStoreFromClient wraps an existing Redis client. Used by
+// tests to share a miniredis instance with other stores.
+func NewRedisBundleStoreFromClient(client redis.UniversalClient) *BundleRedisStore {
+	return &BundleRedisStore{client: client}
+}
+
+// Close releases the underlying Redis client.
+func (s *BundleRedisStore) Close() error {
+	if s.client == nil {
+		return nil
+	}
+	return s.client.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Bundle CRUD
+// ---------------------------------------------------------------------------
+
+// CreateBundle persists a new Bundle. Returns ErrBundleExists when a
+// bundle with the same ID already exists. Versions are NOT embedded in
+// the envelope payload — they live in their own keys per the schema.
+func (s *BundleRedisStore) CreateBundle(ctx context.Context, b *Bundle) error {
+	if b == nil {
+		return fmt.Errorf("bundle: nil bundle")
+	}
+	if strings.TrimSpace(b.ID) == "" {
+		return fmt.Errorf("bundle: id required")
+	}
+	envelope := *b
+	envelope.Versions = nil
+	payload, err := json.Marshal(&envelope)
+	if err != nil {
+		return fmt.Errorf("marshal bundle: %w", err)
+	}
+	ok, err := s.client.SetNX(ctx, bundleKey(b.ID), payload, 0).Result()
+	if err != nil {
+		return fmt.Errorf("create bundle: %w", err)
+	}
+	if !ok {
+		return ErrBundleExists
+	}
+	return nil
+}
+
+// GetBundle returns a Bundle envelope by ID. Returns ErrBundleNotFound
+// when no such bundle. The Versions field is left empty; callers fetch
+// versions explicitly via ListBundleVersions / GetBundleVersion.
+func (s *BundleRedisStore) GetBundle(ctx context.Context, id string) (*Bundle, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("bundle: id required")
+	}
+	data, err := s.client.Get(ctx, bundleKey(id)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrBundleNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get bundle %s: %w", id, err)
+	}
+	var b Bundle
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("unmarshal bundle %s: %w", id, err)
+	}
+	return &b, nil
+}
+
+// ListBundlesByScope returns every bundle whose ScopeBinding matches the
+// supplied scope. Implementation uses SCAN over the `policy:bundle:*`
+// prefix and filters in-process; this is acceptable for the early
+// adopter cohort but Phase 7 / v3 should add a per-scope index.
+func (s *BundleRedisStore) ListBundlesByScope(ctx context.Context, scope RuleScope) ([]*Bundle, error) {
+	out := make([]*Bundle, 0)
+	var cursor uint64
+	versionInfix := bundleVersionInfix
+	for {
+		keys, next, err := s.client.Scan(ctx, cursor, bundleKeyPrefix+"*", 256).Result()
+		if err != nil {
+			return nil, fmt.Errorf("scan bundles: %w", err)
+		}
+		for _, k := range keys {
+			// Skip per-version + version-index keys; we only want the envelope.
+			if strings.Contains(k, versionInfix) || strings.HasSuffix(k, bundleVersionsSuffix) {
+				continue
+			}
+			data, err := s.client.Get(ctx, k).Bytes()
+			if errors.Is(err, redis.Nil) {
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("read bundle %s: %w", k, err)
+			}
+			var b Bundle
+			if err := json.Unmarshal(data, &b); err != nil {
+				return nil, fmt.Errorf("unmarshal bundle %s: %w", k, err)
+			}
+			if scopeBindingMatches(b.ScopeBinding, scope) {
+				bb := b
+				out = append(out, &bb)
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return out, nil
+}
+
+func scopeBindingMatches(have, want RuleScope) bool {
+	if have.Kind != want.Kind {
+		return false
+	}
+	if want.Kind == RuleScopeGlobal {
+		return true
+	}
+	return have.Value == want.Value
+}
+
+// ---------------------------------------------------------------------------
+// Bundle versioning
+// ---------------------------------------------------------------------------
+
+// CreateBundleVersion appends a new immutable version to bundleID.
+// SETNX on the version blob + ZADD on the index. Idempotent on
+// duplicate version numbers — returns ErrBundleVersionExists.
+func (s *BundleRedisStore) CreateBundleVersion(ctx context.Context, bundleID string, v *BundleVersion) error {
+	if v == nil {
+		return fmt.Errorf("bundle version: nil version")
+	}
+	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(v.Version) == "" {
+		return fmt.Errorf("bundle version: bundle id and version required")
+	}
+	if v.DeployedAt.IsZero() {
+		v.DeployedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal bundle version: %w", err)
+	}
+	ok, err := s.client.SetNX(ctx, bundleVersionKey(bundleID, v.Version), payload, 0).Result()
+	if err != nil {
+		return fmt.Errorf("create bundle version: %w", err)
+	}
+	if !ok {
+		return ErrBundleVersionExists
+	}
+	score := float64(v.DeployedAt.UnixNano())
+	if err := s.client.ZAdd(ctx, bundleVersionsIndexKey(bundleID), redis.Z{Score: score, Member: v.Version}).Err(); err != nil {
+		return fmt.Errorf("index bundle version: %w", err)
+	}
+	return nil
+}
+
+// ListBundleVersions returns all versions for a bundle, oldest first
+// (ascending DeployedAt).
+func (s *BundleRedisStore) ListBundleVersions(ctx context.Context, bundleID string) ([]*BundleVersion, error) {
+	if strings.TrimSpace(bundleID) == "" {
+		return nil, fmt.Errorf("bundle version: bundle id required")
+	}
+	versions, err := s.client.ZRange(ctx, bundleVersionsIndexKey(bundleID), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list versions: %w", err)
+	}
+	if len(versions) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, len(versions))
+	for i, v := range versions {
+		keys[i] = bundleVersionKey(bundleID, v)
+	}
+	raw, err := s.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("mget versions: %w", err)
+	}
+	out := make([]*BundleVersion, 0, len(raw))
+	for i, item := range raw {
+		if item == nil {
+			continue
+		}
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected version payload type for %s", versions[i])
+		}
+		var v BundleVersion
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			return nil, fmt.Errorf("unmarshal version %s: %w", versions[i], err)
+		}
+		vv := v
+		out = append(out, &vv)
+	}
+	return out, nil
+}
+
+// GetBundleVersion returns one version. Returns
+// ErrBundleVersionNotFound for unknown (bundleID, version) pairs.
+func (s *BundleRedisStore) GetBundleVersion(ctx context.Context, bundleID, version string) (*BundleVersion, error) {
+	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(version) == "" {
+		return nil, fmt.Errorf("bundle version: bundle id and version required")
+	}
+	data, err := s.client.Get(ctx, bundleVersionKey(bundleID, version)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrBundleVersionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get bundle version: %w", err)
+	}
+	var v BundleVersion
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, fmt.Errorf("unmarshal bundle version: %w", err)
+	}
+	return &v, nil
+}
+
+// ---------------------------------------------------------------------------
+// Deployment lifecycle (atomic via Lua scripts)
+// ---------------------------------------------------------------------------
+
+// deployScript atomically:
+//  1. Validates the requested (bundle_id, version) version blob exists.
+//  2. SETs `policy:scope:{kind}:{value}:active` to "{bundleID}:{version}".
+//  3. LPUSH a new Deployment{Action:deploy} JSON into the history list.
+//  4. LTRIM the history to the last 100 entries.
+//
+// KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey [3]=bundleVersionKey
+// ARGV: [1]=bundleID [2]=version [3]=deploymentJSON
+//
+// Returns: empty string on success; "ERR_VERSION_NOT_FOUND" if KEYS[3]
+// doesn't exist (caller maps to ErrBundleVersionNotFound).
+var deployScript = redis.NewScript(`
+local exists = redis.call('EXISTS', KEYS[3])
+if exists == 0 then
+  return 'ERR_VERSION_NOT_FOUND'
+end
+redis.call('SET', KEYS[1], ARGV[1] .. ':' .. ARGV[2])
+redis.call('LPUSH', KEYS[2], ARGV[3])
+redis.call('LTRIM', KEYS[2], 0, 99)
+return ''
+`)
+
+// rollbackScript atomically:
+//  1. Reads the current active (bundle_id, version) from KEYS[1].
+//  2. Walks history newest-first to find the most-recent deploy whose
+//     (bundle_id, version) differs from the current active. This skips
+//     any rollback markers AND skips the deploy entry that established
+//     the current active, so chained rollbacks unwind one step per call.
+//  3. SETs active to that prior deploy's (bundle_id, version).
+//  4. LPUSH a Deployment{Action:rollback} entry pointing at that prior pair.
+//  5. LTRIM history to last 100.
+//
+// KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey
+// ARGV: [1]=deployedAtRFC3339Nano [2]=deployedBy [3]=auditHash
+//
+// Returns: a 3-element array [bundleID, version, deploymentJSON] on
+// success, or "ERR_NO_ROLLBACK_TARGET" when no prior deploy with a
+// different (bundle_id, version) exists.
+var rollbackScript = redis.NewScript(`
+local active = redis.call('GET', KEYS[1])
+if not active or active == false or active == '' then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+local sep = string.find(active, ':')
+if not sep then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+local cur_bid = string.sub(active, 1, sep - 1)
+local cur_ver = string.sub(active, sep + 1)
+
+local hist = redis.call('LRANGE', KEYS[2], 0, -1)
+
+-- Locate the most-recent deploy entry matching the current active.
+-- This is the original deploy that introduced the current binding;
+-- we walk backwards from there to find the immediately-prior deploy.
+local cur_deploy_idx = -1
+for i, raw in ipairs(hist) do
+  local ok, dec = pcall(cjson.decode, raw)
+  if ok and type(dec) == 'table' and dec.action == 'deploy' then
+    if dec.bundle_id == cur_bid and dec.version == cur_ver then
+      cur_deploy_idx = i
+      break
+    end
+  end
+end
+if cur_deploy_idx == -1 then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+
+-- Find the next deploy entry strictly older than the current binding.
+local prior_idx = -1
+for i = cur_deploy_idx + 1, #hist do
+  local ok, dec = pcall(cjson.decode, hist[i])
+  if ok and type(dec) == 'table' and dec.action == 'deploy' then
+    prior_idx = i
+    break
+  end
+end
+if prior_idx == -1 then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+local prior = cjson.decode(hist[prior_idx])
+local bundle_id = prior.bundle_id
+local version = prior.version
+redis.call('SET', KEYS[1], bundle_id .. ':' .. version)
+local rollback_json = cjson.encode({
+  bundle_id = bundle_id,
+  version = version,
+  scope = prior.scope,
+  deployed_at = ARGV[1],
+  deployed_by = ARGV[2],
+  audit_hash = ARGV[3],
+  action = 'rollback'
+})
+redis.call('LPUSH', KEYS[2], rollback_json)
+redis.call('LTRIM', KEYS[2], 0, 99)
+return {bundle_id, version, rollback_json}
+`)
+
+// DeployVersionToScope atomically rebinds the active deployment for
+// scope to (bundleID, version) and appends the deploy event to history.
+func (s *BundleRedisStore) DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error) {
+	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(version) == "" {
+		return nil, fmt.Errorf("deploy: bundle id and version required")
+	}
+	dep := Deployment{
+		BundleID:   bundleID,
+		Version:    version,
+		Scope:      scope,
+		DeployedAt: time.Now().UTC(),
+		Action:     DeploymentActionDeploy,
+	}
+	depJSON, err := json.Marshal(&dep)
+	if err != nil {
+		return nil, fmt.Errorf("marshal deployment: %w", err)
+	}
+	keys := []string{
+		scopeActiveKey(scope),
+		scopeDeploymentHistoryKey(scope),
+		bundleVersionKey(bundleID, version),
+	}
+	res, err := deployScript.Run(ctx, s.client, keys, bundleID, version, string(depJSON)).Text()
+	if err != nil {
+		return nil, fmt.Errorf("deploy: %w", err)
+	}
+	if res == "ERR_VERSION_NOT_FOUND" {
+		return nil, ErrBundleVersionNotFound
+	}
+	return &dep, nil
+}
+
+// RollbackDeployment reverts the active deployment for scope to the
+// most-recent prior deploy (skipping rollback entries themselves so
+// chained rollbacks unwind cleanly). Returns ErrNoRollbackTarget when
+// no prior deploy exists.
+func (s *BundleRedisStore) RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error) {
+	keys := []string{
+		scopeActiveKey(scope),
+		scopeDeploymentHistoryKey(scope),
+	}
+	now := time.Now().UTC()
+	res, err := rollbackScript.Run(ctx, s.client, keys, now.Format(time.RFC3339Nano), "", "").Result()
+	if err != nil {
+		return nil, fmt.Errorf("rollback: %w", err)
+	}
+	if errStr, ok := res.(string); ok && errStr == "ERR_NO_ROLLBACK_TARGET" {
+		return nil, ErrNoRollbackTarget
+	}
+	arr, ok := res.([]interface{})
+	if !ok || len(arr) != 3 {
+		return nil, fmt.Errorf("rollback: unexpected script result %T", res)
+	}
+	rollbackJSON, _ := arr[2].(string)
+	var dep Deployment
+	if err := json.Unmarshal([]byte(rollbackJSON), &dep); err != nil {
+		return nil, fmt.Errorf("unmarshal rollback deployment: %w", err)
+	}
+	dep.DeployedAt = now
+	return &dep, nil
+}
+
+// GetActiveDeployment returns the currently-active deployment for
+// scope. The implementation reads the active pointer + the most-recent
+// matching history entry to surface the full Deployment record (incl.
+// timestamp + action). Returns ErrNoDeploymentForScope when nothing is
+// bound.
+func (s *BundleRedisStore) GetActiveDeployment(ctx context.Context, scope RuleScope) (*Deployment, error) {
+	pointer, err := s.client.Get(ctx, scopeActiveKey(scope)).Result()
+	if errors.Is(err, redis.Nil) || pointer == "" {
+		return nil, ErrNoDeploymentForScope
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get active deployment: %w", err)
+	}
+	parts := strings.SplitN(pointer, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("malformed active pointer %q", pointer)
+	}
+	bundleID, version := parts[0], parts[1]
+	// Walk history newest-first to find the deploy/rollback that produced this binding.
+	entries, err := s.client.LRange(ctx, scopeDeploymentHistoryKey(scope), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("get history: %w", err)
+	}
+	for _, raw := range entries {
+		var dep Deployment
+		if err := json.Unmarshal([]byte(raw), &dep); err != nil {
+			continue
+		}
+		if dep.BundleID == bundleID && dep.Version == version {
+			return &dep, nil
+		}
+	}
+	// Pointer set but no matching history — synthesize a minimal record.
+	return &Deployment{
+		BundleID: bundleID,
+		Version:  version,
+		Scope:    scope,
+		Action:   DeploymentActionDeploy,
+	}, nil
+}
+
+// ListDeploymentHistory returns up to limit history entries for scope,
+// newest first. The implementation always reads up to
+// deploymentHistoryCap (100) entries since LTRIM bounds it; the caller's
+// limit is applied client-side.
+func (s *BundleRedisStore) ListDeploymentHistory(ctx context.Context, scope RuleScope, limit int) ([]*Deployment, error) {
+	if limit <= 0 || limit > deploymentHistoryCap {
+		limit = deploymentHistoryCap
+	}
+	entries, err := s.client.LRange(ctx, scopeDeploymentHistoryKey(scope), 0, int64(limit-1)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list deployment history: %w", err)
+	}
+	out := make([]*Deployment, 0, len(entries))
+	for _, raw := range entries {
+		var dep Deployment
+		if err := json.Unmarshal([]byte(raw), &dep); err != nil {
+			return nil, fmt.Errorf("unmarshal deployment: %w", err)
+		}
+		dd := dep
+		out = append(out, &dd)
+	}
+	return out, nil
+}
+
+// Compile-time interface satisfaction check.
+var _ BundleStore = (*BundleRedisStore)(nil)

--- a/core/policy/bundle_store_redis.go
+++ b/core/policy/bundle_store_redis.go
@@ -161,14 +161,24 @@ func scopeBindingMatches(have, want RuleScope) bool {
 // ---------------------------------------------------------------------------
 
 // CreateBundleVersion appends a new immutable version to bundleID.
-// SETNX on the version blob + ZADD on the index. Idempotent on
-// duplicate version numbers — returns ErrBundleVersionExists.
+// Verifies the parent bundle exists (returns ErrBundleNotFound if not)
+// to prevent orphan versions, then SETNX on the version blob + ZADD on
+// the index. Idempotent on duplicate version numbers — returns
+// ErrBundleVersionExists. There is no DeleteBundle on the interface, so
+// the EXISTS-then-SETNX sequence cannot race with a parent removal.
 func (s *BundleRedisStore) CreateBundleVersion(ctx context.Context, bundleID string, v *BundleVersion) error {
 	if v == nil {
 		return fmt.Errorf("bundle version: nil version")
 	}
 	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(v.Version) == "" {
 		return fmt.Errorf("bundle version: bundle id and version required")
+	}
+	exists, err := s.client.Exists(ctx, bundleKey(bundleID)).Result()
+	if err != nil {
+		return fmt.Errorf("check parent bundle: %w", err)
+	}
+	if exists == 0 {
+		return ErrBundleNotFound
 	}
 	if v.DeployedAt.IsZero() {
 		v.DeployedAt = time.Now().UTC()
@@ -257,42 +267,67 @@ func (s *BundleRedisStore) GetBundleVersion(ctx context.Context, bundleID, versi
 
 // deployScript atomically:
 //  1. Validates the requested (bundle_id, version) version blob exists.
-//  2. SETs `policy:scope:{kind}:{value}:active` to "{bundleID}:{version}".
-//  3. LPUSH a new Deployment{Action:deploy} JSON into the history list.
-//  4. LTRIM the history to the last 100 entries.
+//  2. Reads the current active "{bundleID}:{version}" pointer (may be empty).
+//  3. Decodes the incoming deploy JSON, baking the prior active pair
+//     into prev_bundle_id + prev_version so future rollbacks can restore
+//     this exact prior state.
+//  4. SETs `policy:scope:{kind}:{value}:active` to the new "{bundleID}:{version}".
+//  5. LPUSHes the populated deploy JSON into the history list.
+//  6. LTRIMs the history to the last deploymentHistoryCap entries.
 //
 // KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey [3]=bundleVersionKey
-// ARGV: [1]=bundleID [2]=version [3]=deploymentJSON
+// ARGV: [1]=bundleID [2]=version [3]=deploymentJSON [4]=historyCap
 //
-// Returns: empty string on success; "ERR_VERSION_NOT_FOUND" if KEYS[3]
-// doesn't exist (caller maps to ErrBundleVersionNotFound).
+// Returns: the populated deployment JSON (with prev_bundle_id +
+// prev_version filled in) on success, or the literal sentinel string
+// "ERR_VERSION_NOT_FOUND" if KEYS[3] doesn't exist (caller maps to
+// ErrBundleVersionNotFound). The two cases are distinguishable by
+// prefix — JSON starts with '{', the sentinel starts with 'E'.
 var deployScript = redis.NewScript(`
 local exists = redis.call('EXISTS', KEYS[3])
 if exists == 0 then
   return 'ERR_VERSION_NOT_FOUND'
 end
+local prev = redis.call('GET', KEYS[1])
+local prev_bid = ''
+local prev_ver = ''
+if prev and prev ~= false and prev ~= '' then
+  local sep = string.find(prev, ':')
+  if sep then
+    prev_bid = string.sub(prev, 1, sep - 1)
+    prev_ver = string.sub(prev, sep + 1)
+  end
+end
+local dep = cjson.decode(ARGV[3])
+dep.prev_bundle_id = prev_bid
+dep.prev_version = prev_ver
+local dep_json = cjson.encode(dep)
 redis.call('SET', KEYS[1], ARGV[1] .. ':' .. ARGV[2])
-redis.call('LPUSH', KEYS[2], ARGV[3])
-redis.call('LTRIM', KEYS[2], 0, 99)
-return ''
+redis.call('LPUSH', KEYS[2], dep_json)
+redis.call('LTRIM', KEYS[2], 0, tonumber(ARGV[4]) - 1)
+return dep_json
 `)
 
 // rollbackScript atomically:
-//  1. Reads the current active (bundle_id, version) from KEYS[1].
-//  2. Walks history newest-first to find the most-recent deploy whose
-//     (bundle_id, version) differs from the current active. This skips
-//     any rollback markers AND skips the deploy entry that established
-//     the current active, so chained rollbacks unwind one step per call.
-//  3. SETs active to that prior deploy's (bundle_id, version).
-//  4. LPUSH a Deployment{Action:rollback} entry pointing at that prior pair.
-//  5. LTRIM history to last 100.
+//  1. Reads the current active "{bundle_id}:{version}" pointer.
+//  2. Walks history newest-first to find the most-recent deploy event
+//     matching the current active pair (skipping rollback markers).
+//  3. Reads that deploy event's prev_bundle_id + prev_version — the
+//     pair that was active immediately before this deploy ran.
+//  4. SETs active to that prior pair.
+//  5. LPUSHes a Deployment{Action:rollback} entry pointing at the
+//     restored pair, with prev_* fields capturing the pair we rolled
+//     away from (informational; rollback never reads its own prev_*).
+//  6. LTRIMs history to deploymentHistoryCap.
 //
 // KEYS: [1]=scopeActiveKey [2]=scopeHistoryKey
-// ARGV: [1]=deployedAtRFC3339Nano [2]=deployedBy [3]=auditHash
+// ARGV: [1]=deployedAtRFC3339Nano [2]=deployedBy [3]=auditHash [4]=scopeJSON [5]=historyCap
 //
 // Returns: a 3-element array [bundleID, version, deploymentJSON] on
-// success, or "ERR_NO_ROLLBACK_TARGET" when no prior deploy with a
-// different (bundle_id, version) exists.
+// success, or the literal sentinel string "ERR_NO_ROLLBACK_TARGET"
+// when there's no current active OR no matching deploy event OR the
+// matching deploy event has empty prev_* fields (i.e. the original
+// first deploy with no prior state).
 var rollbackScript = redis.NewScript(`
 local active = redis.call('GET', KEYS[1])
 if not active or active == false or active == '' then
@@ -307,55 +342,54 @@ local cur_ver = string.sub(active, sep + 1)
 
 local hist = redis.call('LRANGE', KEYS[2], 0, -1)
 
--- Locate the most-recent deploy entry matching the current active.
--- This is the original deploy that introduced the current binding;
--- we walk backwards from there to find the immediately-prior deploy.
-local cur_deploy_idx = -1
+-- Find the most-recent deploy event matching the current active pair.
+-- That entry's prev_bundle_id + prev_version are the pair to restore.
+local prev_bid = ''
+local prev_ver = ''
+local found = false
 for i, raw in ipairs(hist) do
   local ok, dec = pcall(cjson.decode, raw)
   if ok and type(dec) == 'table' and dec.action == 'deploy' then
     if dec.bundle_id == cur_bid and dec.version == cur_ver then
-      cur_deploy_idx = i
+      prev_bid = dec.prev_bundle_id or ''
+      prev_ver = dec.prev_version or ''
+      found = true
       break
     end
   end
 end
-if cur_deploy_idx == -1 then
+if not found then
+  return 'ERR_NO_ROLLBACK_TARGET'
+end
+if prev_bid == '' or prev_ver == '' then
+  -- Rolling back the original first deploy: no prior state to restore.
   return 'ERR_NO_ROLLBACK_TARGET'
 end
 
--- Find the next deploy entry strictly older than the current binding.
-local prior_idx = -1
-for i = cur_deploy_idx + 1, #hist do
-  local ok, dec = pcall(cjson.decode, hist[i])
-  if ok and type(dec) == 'table' and dec.action == 'deploy' then
-    prior_idx = i
-    break
-  end
-end
-if prior_idx == -1 then
-  return 'ERR_NO_ROLLBACK_TARGET'
-end
-local prior = cjson.decode(hist[prior_idx])
-local bundle_id = prior.bundle_id
-local version = prior.version
-redis.call('SET', KEYS[1], bundle_id .. ':' .. version)
-local rollback_json = cjson.encode({
-  bundle_id = bundle_id,
-  version = version,
-  scope = prior.scope,
+local scope = cjson.decode(ARGV[4])
+redis.call('SET', KEYS[1], prev_bid .. ':' .. prev_ver)
+local marker = {
+  bundle_id = prev_bid,
+  version = prev_ver,
+  scope = scope,
   deployed_at = ARGV[1],
   deployed_by = ARGV[2],
   audit_hash = ARGV[3],
-  action = 'rollback'
-})
-redis.call('LPUSH', KEYS[2], rollback_json)
-redis.call('LTRIM', KEYS[2], 0, 99)
-return {bundle_id, version, rollback_json}
+  action = 'rollback',
+  prev_bundle_id = cur_bid,
+  prev_version = cur_ver,
+}
+local marker_json = cjson.encode(marker)
+redis.call('LPUSH', KEYS[2], marker_json)
+redis.call('LTRIM', KEYS[2], 0, tonumber(ARGV[5]) - 1)
+return {prev_bid, prev_ver, marker_json}
 `)
 
 // DeployVersionToScope atomically rebinds the active deployment for
 // scope to (bundleID, version) and appends the deploy event to history.
+// The returned Deployment carries PrevBundleID + PrevVersion populated
+// from the active state at script-execution time (read inside Lua so
+// concurrent deploys on the same scope serialize correctly).
 func (s *BundleRedisStore) DeployVersionToScope(ctx context.Context, bundleID, version string, scope RuleScope) (*Deployment, error) {
 	if strings.TrimSpace(bundleID) == "" || strings.TrimSpace(version) == "" {
 		return nil, fmt.Errorf("deploy: bundle id and version required")
@@ -376,34 +410,46 @@ func (s *BundleRedisStore) DeployVersionToScope(ctx context.Context, bundleID, v
 		scopeDeploymentHistoryKey(scope),
 		bundleVersionKey(bundleID, version),
 	}
-	res, err := deployScript.Run(ctx, s.client, keys, bundleID, version, string(depJSON)).Text()
+	res, err := deployScript.Run(ctx, s.client, keys, bundleID, version, string(depJSON), deploymentHistoryCap).Text()
 	if err != nil {
 		return nil, fmt.Errorf("deploy: %w", err)
 	}
 	if res == "ERR_VERSION_NOT_FOUND" {
 		return nil, ErrBundleVersionNotFound
 	}
-	return &dep, nil
+	var populated Deployment
+	if err := json.Unmarshal([]byte(res), &populated); err != nil {
+		return nil, fmt.Errorf("unmarshal deploy result: %w", err)
+	}
+	return &populated, nil
 }
 
 // RollbackDeployment reverts the active deployment for scope to the
-// most-recent prior deploy (skipping rollback entries themselves so
-// chained rollbacks unwind cleanly). Returns ErrNoRollbackTarget when
-// no prior deploy exists.
+// (bundle, version) pair that was active immediately before the current
+// binding was established. Per the rollbackScript contract, this reads
+// the matching deploy event's prev_* fields so rollback after a
+// deploy-after-rollback restores the correct prior state. Returns
+// ErrNoRollbackTarget when no current active exists, no matching deploy
+// event is found in bounded history, or the matching deploy has empty
+// prev_* fields (the first-ever deploy).
 func (s *BundleRedisStore) RollbackDeployment(ctx context.Context, scope RuleScope) (*Deployment, error) {
 	keys := []string{
 		scopeActiveKey(scope),
 		scopeDeploymentHistoryKey(scope),
 	}
 	now := time.Now().UTC()
-	res, err := rollbackScript.Run(ctx, s.client, keys, now.Format(time.RFC3339Nano), "", "").Result()
+	scopeJSON, err := json.Marshal(scope)
+	if err != nil {
+		return nil, fmt.Errorf("marshal rollback scope: %w", err)
+	}
+	res, err := rollbackScript.Run(ctx, s.client, keys, now.Format(time.RFC3339Nano), "", "", string(scopeJSON), deploymentHistoryCap).Result()
 	if err != nil {
 		return nil, fmt.Errorf("rollback: %w", err)
 	}
 	if errStr, ok := res.(string); ok && errStr == "ERR_NO_ROLLBACK_TARGET" {
 		return nil, ErrNoRollbackTarget
 	}
-	arr, ok := res.([]interface{})
+	arr, ok := res.([]any)
 	if !ok || len(arr) != 3 {
 		return nil, fmt.Errorf("rollback: unexpected script result %T", res)
 	}

--- a/core/policy/bundle_store_redis_test.go
+++ b/core/policy/bundle_store_redis_test.go
@@ -430,6 +430,152 @@ func TestRollbackChain(t *testing.T) {
 	}
 }
 
+// TestDeployAfterRollback locks in the regression that originally
+// shipped to QA in PR #252 reopen #1 (task-b349524a). Sequence:
+//
+//	deploy v1, deploy v2, rollback (-> v1), deploy v3, rollback
+//
+// The final rollback must restore v1 — the active state immediately
+// before v3 was deployed — NOT v2 (the second-most-recent deploy in
+// raw event order). The original implementation walked history for
+// "next deploy after the matching deploy" and returned v2; the fix
+// stores prev_bundle_id + prev_version on each deploy event inside
+// Lua so rollback restores from the matching deploy's prev fields.
+func TestDeployAfterRollback(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v3", DeployedAt: time.Now().UTC().Add(2 * time.Second)})
+
+	// Step 1+2: deploy v1, deploy v2.
+	d1, err := store.DeployVersionToScope(ctx, "b1", "v1", scope)
+	if err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if d1.PrevBundleID != "" || d1.PrevVersion != "" {
+		t.Errorf("first deploy should record empty prev pair, got %s:%s", d1.PrevBundleID, d1.PrevVersion)
+	}
+	d2, err := store.DeployVersionToScope(ctx, "b1", "v2", scope)
+	if err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+	if d2.PrevBundleID != "b1" || d2.PrevVersion != "v1" {
+		t.Errorf("v2 deploy should record prev=b1:v1, got %s:%s", d2.PrevBundleID, d2.PrevVersion)
+	}
+
+	// Step 3: rollback v2 → v1.
+	rb1, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback after v2: %v", err)
+	}
+	if rb1.Version != "v1" {
+		t.Fatalf("rollback after v2 should restore v1, got %q", rb1.Version)
+	}
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("active after rb1: %v", err)
+	}
+	if active.Version != "v1" {
+		t.Fatalf("active after rb1 = %q, want v1", active.Version)
+	}
+
+	// Step 4: deploy v3 (active state immediately before this deploy is v1).
+	d3, err := store.DeployVersionToScope(ctx, "b1", "v3", scope)
+	if err != nil {
+		t.Fatalf("deploy v3: %v", err)
+	}
+	if d3.PrevBundleID != "b1" || d3.PrevVersion != "v1" {
+		t.Errorf("v3 deploy should record prev=b1:v1 (post-rollback active), got %s:%s", d3.PrevBundleID, d3.PrevVersion)
+	}
+
+	// Step 5: final rollback must restore v1, NOT v2 (the prior deploy
+	// in raw history order).
+	rb2, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback after v3: %v", err)
+	}
+	if rb2.Version != "v1" {
+		t.Fatalf("rollback after deploy-after-rollback should restore v1, got %q (regression: returns the second-most-recent raw deploy v2 instead of the active state before v3)", rb2.Version)
+	}
+	active, err = store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("active after rb2: %v", err)
+	}
+	if active.Version != "v1" {
+		t.Fatalf("active after rb2 = %q, want v1", active.Version)
+	}
+}
+
+// TestCreateBundleVersion_OrphanRejected verifies CreateBundleVersion
+// refuses to write a version for a non-existent parent bundle. Without
+// this check the store could accumulate orphan version blobs +
+// deployment records that point at a bundle envelope nothing owns.
+func TestCreateBundleVersion_OrphanRejected(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	// No CreateBundle call — parent is absent.
+	err := store.CreateBundleVersion(ctx, "ghost", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	if !errors.Is(err, ErrBundleNotFound) {
+		t.Fatalf("orphan version creation should return ErrBundleNotFound, got %v", err)
+	}
+
+	// And the version blob must NOT have been written. Reading it back
+	// is the cleanest proof; ListBundleVersions on the same bundle ID
+	// must return an empty slice (the index ZSET also stays empty).
+	got, err := store.ListBundleVersions(ctx, "ghost")
+	if err != nil {
+		t.Fatalf("list versions for orphan parent: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("orphan parent should have no versions, got %d", len(got))
+	}
+}
+
+// TestDeploymentHistoryCapEnforced verifies the LTRIM-based history
+// cap inside the deploy Lua script. After 105 deploys to the same
+// scope, history must hold exactly 100 entries (the cap from
+// deploymentHistoryCap) and the 5 oldest deploy events must have been
+// dropped.
+func TestDeploymentHistoryCapEnforced(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+
+	const total = 105
+	for i := range total {
+		if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+			t.Fatalf("deploy %d: %v", i, err)
+		}
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, deploymentHistoryCap+50)
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(hist) != deploymentHistoryCap {
+		t.Fatalf("history len = %d, want %d (LTRIM cap)", len(hist), deploymentHistoryCap)
+	}
+	// Newest 100 entries are kept; the 5 oldest dropped. Every entry
+	// is a deploy of v1, so we can't distinguish "oldest" by version,
+	// but len(hist) == cap is the binding assertion that LTRIM ran.
+	for i, dep := range hist {
+		if dep.Action != DeploymentActionDeploy {
+			t.Errorf("history[%d].Action = %s, want deploy", i, dep.Action)
+		}
+		if dep.Version != "v1" {
+			t.Errorf("history[%d].Version = %s, want v1", i, dep.Version)
+		}
+	}
+}
+
 func TestConcurrentDeploy(t *testing.T) {
 	store := newTestBundleStore(t)
 	ctx := context.Background()

--- a/core/policy/bundle_store_redis_test.go
+++ b/core/policy/bundle_store_redis_test.go
@@ -1,0 +1,473 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+)
+
+func newTestBundleStore(t *testing.T) *BundleRedisStore {
+	t.Helper()
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	store, err := NewRedisBundleStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close(); srv.Close() })
+	return store
+}
+
+func mustCreateBundle(t *testing.T, s *BundleRedisStore, b *Bundle) {
+	t.Helper()
+	if err := s.CreateBundle(context.Background(), b); err != nil {
+		t.Fatalf("create bundle: %v", err)
+	}
+}
+
+func mustCreateVersion(t *testing.T, s *BundleRedisStore, bundleID string, v *BundleVersion) {
+	t.Helper()
+	if err := s.CreateBundleVersion(context.Background(), bundleID, v); err != nil {
+		t.Fatalf("create version: %v", err)
+	}
+}
+
+func TestCreateGetBundle(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	b := &Bundle{ID: "b1", Name: "Acme baseline", ScopeBinding: scope}
+	mustCreateBundle(t, store, b)
+
+	got, err := store.GetBundle(ctx, "b1")
+	if err != nil {
+		t.Fatalf("get bundle: %v", err)
+	}
+	if got.ID != "b1" || got.Name != "Acme baseline" {
+		t.Errorf("got bundle = %+v, want id=b1 name='Acme baseline'", got)
+	}
+	if got.ScopeBinding.Kind != RuleScopeTenant || got.ScopeBinding.Value != "acme" {
+		t.Errorf("scope binding mismatch: %+v", got.ScopeBinding)
+	}
+
+	// Duplicate create returns ErrBundleExists.
+	err = store.CreateBundle(ctx, b)
+	if !errors.Is(err, ErrBundleExists) {
+		t.Errorf("duplicate create should return ErrBundleExists, got %v", err)
+	}
+}
+
+func TestGetBundle_NotFound(t *testing.T) {
+	store := newTestBundleStore(t)
+	_, err := store.GetBundle(context.Background(), "missing")
+	if !errors.Is(err, ErrBundleNotFound) {
+		t.Errorf("expected ErrBundleNotFound, got %v", err)
+	}
+}
+
+func TestListBundlesByScope(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	scopeA := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	scopeB := RuleScope{Kind: RuleScopeTenant, Value: "beta"}
+	scopeGlobal := RuleScope{Kind: RuleScopeGlobal}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b-a1", Name: "Acme one", ScopeBinding: scopeA})
+	mustCreateBundle(t, store, &Bundle{ID: "b-a2", Name: "Acme two", ScopeBinding: scopeA})
+	mustCreateBundle(t, store, &Bundle{ID: "b-b1", Name: "Beta one", ScopeBinding: scopeB})
+	mustCreateBundle(t, store, &Bundle{ID: "b-g", Name: "Global", ScopeBinding: scopeGlobal})
+
+	got, err := store.ListBundlesByScope(ctx, scopeA)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 bundles for acme, got %d", len(got))
+	}
+
+	got, err = store.ListBundlesByScope(ctx, scopeGlobal)
+	if err != nil {
+		t.Fatalf("list global: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 global bundle, got %d", len(got))
+	}
+}
+
+func TestCreateBundleVersion_Idempotent(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	v := &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()}
+	mustCreateVersion(t, store, "b1", v)
+
+	err := store.CreateBundleVersion(ctx, "b1", v)
+	if !errors.Is(err, ErrBundleVersionExists) {
+		t.Errorf("duplicate version should return ErrBundleVersionExists, got %v", err)
+	}
+}
+
+func TestListBundleVersions_OrderByDeployedAt(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	t0 := time.Now().UTC()
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v3", DeployedAt: t0.Add(3 * time.Second)})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: t0})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: t0.Add(time.Second)})
+
+	got, err := store.ListBundleVersions(ctx, "b1")
+	if err != nil {
+		t.Fatalf("list versions: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 versions, got %d", len(got))
+	}
+	want := []string{"v1", "v2", "v3"}
+	for i, v := range got {
+		if v.Version != want[i] {
+			t.Errorf("position %d: got %q, want %q", i, v.Version, want[i])
+		}
+	}
+}
+
+func TestGetBundleVersion_NotFound(t *testing.T) {
+	store := newTestBundleStore(t)
+	_, err := store.GetBundleVersion(context.Background(), "b1", "v1")
+	if !errors.Is(err, ErrBundleVersionNotFound) {
+		t.Errorf("expected ErrBundleVersionNotFound, got %v", err)
+	}
+}
+
+func TestDeployVersionToScope_FirstDeploy(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+
+	dep, err := store.DeployVersionToScope(ctx, "b1", "v1", scope)
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	if dep.BundleID != "b1" || dep.Version != "v1" || dep.Action != DeploymentActionDeploy {
+		t.Errorf("got deployment = %+v", dep)
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if active.BundleID != "b1" || active.Version != "v1" {
+		t.Errorf("active = %+v, want b1:v1", active)
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 1 {
+		t.Errorf("expected 1 history entry, got %d", len(hist))
+	}
+}
+
+func TestDeployVersionToScope_OverwritesActive(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scope); err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if active.Version != "v2" {
+		t.Errorf("active version = %q, want v2", active.Version)
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 2 {
+		t.Fatalf("expected 2 history entries, got %d", len(hist))
+	}
+	// Newest first.
+	if hist[0].Version != "v2" || hist[1].Version != "v1" {
+		t.Errorf("history order wrong: %+v", hist)
+	}
+}
+
+func TestDeployVersionToScope_VersionNotFound(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	_, err := store.DeployVersionToScope(ctx, "b1", "ghost", scope)
+	if !errors.Is(err, ErrBundleVersionNotFound) {
+		t.Errorf("expected ErrBundleVersionNotFound, got %v", err)
+	}
+}
+
+func TestRollbackDeployment(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scope); err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+
+	rb, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if rb.Version != "v1" || rb.Action != DeploymentActionRollback {
+		t.Errorf("rollback record = %+v, want v1 action=rollback", rb)
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active after rollback: %v", err)
+	}
+	if active.Version != "v1" {
+		t.Errorf("active after rollback = %q, want v1", active.Version)
+	}
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 3 {
+		t.Errorf("expected 3 history entries (deploy v1, deploy v2, rollback to v1), got %d", len(hist))
+	}
+	if hist[0].Action != DeploymentActionRollback {
+		t.Errorf("newest entry should be rollback, got %s", hist[0].Action)
+	}
+}
+
+func TestRollbackDeployment_NoHistory(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+
+	_, err := store.RollbackDeployment(ctx, scope)
+	if !errors.Is(err, ErrNoRollbackTarget) {
+		t.Errorf("expected ErrNoRollbackTarget, got %v", err)
+	}
+}
+
+func TestGetActiveDeployment_NoDeployment(t *testing.T) {
+	store := newTestBundleStore(t)
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "ghost"}
+	_, err := store.GetActiveDeployment(context.Background(), scope)
+	if !errors.Is(err, ErrNoDeploymentForScope) {
+		t.Errorf("expected ErrNoDeploymentForScope, got %v", err)
+	}
+}
+
+func TestScopeIsolation(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scopeA := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	scopeB := RuleScope{Kind: RuleScopeTenant, Value: "beta"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	// Same bundle deployed to two scopes; rollback on A should not touch B.
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scopeA); err != nil {
+		t.Fatalf("A v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scopeA); err != nil {
+		t.Fatalf("A v2: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scopeB); err != nil {
+		t.Fatalf("B v2: %v", err)
+	}
+
+	if _, err := store.RollbackDeployment(ctx, scopeA); err != nil {
+		t.Fatalf("rollback A: %v", err)
+	}
+
+	activeA, _ := store.GetActiveDeployment(ctx, scopeA)
+	activeB, _ := store.GetActiveDeployment(ctx, scopeB)
+	if activeA.Version != "v1" {
+		t.Errorf("scope A after rollback = %q, want v1", activeA.Version)
+	}
+	if activeB.Version != "v2" {
+		t.Errorf("scope B should be untouched at v2, got %q", activeB.Version)
+	}
+}
+
+func TestEmptyIDInputs(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+
+	if err := store.CreateBundle(ctx, nil); err == nil {
+		t.Errorf("CreateBundle(nil) should error")
+	}
+	if err := store.CreateBundle(ctx, &Bundle{ID: ""}); err == nil {
+		t.Errorf("CreateBundle empty id should error")
+	}
+	if _, err := store.GetBundle(ctx, ""); err == nil {
+		t.Errorf("GetBundle empty id should error")
+	}
+	if err := store.CreateBundleVersion(ctx, "", &BundleVersion{Version: "v1"}); err == nil {
+		t.Errorf("CreateBundleVersion empty bundle id should error")
+	}
+	if err := store.CreateBundleVersion(ctx, "b1", nil); err == nil {
+		t.Errorf("CreateBundleVersion nil should error")
+	}
+	if _, err := store.GetBundleVersion(ctx, "", "v1"); err == nil {
+		t.Errorf("GetBundleVersion empty bundle id should error")
+	}
+	if _, err := store.ListBundleVersions(ctx, ""); err == nil {
+		t.Errorf("ListBundleVersions empty id should error")
+	}
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+	if _, err := store.DeployVersionToScope(ctx, "", "v1", scope); err == nil {
+		t.Errorf("DeployVersionToScope empty bundle id should error")
+	}
+}
+
+func TestListBundleVersions_EmptyBundle(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	got, err := store.ListBundleVersions(ctx, "b1")
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected zero versions, got %d", len(got))
+	}
+}
+
+func TestListBundlesByScope_NoMatches(t *testing.T) {
+	store := newTestBundleStore(t)
+	got, err := store.ListBundlesByScope(context.Background(), RuleScope{Kind: RuleScopeTenant, Value: "ghost"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected zero bundles for ghost tenant, got %d", len(got))
+	}
+}
+
+func TestRollbackChain(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v3", DeployedAt: time.Now().UTC().Add(2 * time.Second)})
+
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v1", scope); err != nil {
+		t.Fatalf("deploy v1: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v2", scope); err != nil {
+		t.Fatalf("deploy v2: %v", err)
+	}
+	if _, err := store.DeployVersionToScope(ctx, "b1", "v3", scope); err != nil {
+		t.Fatalf("deploy v3: %v", err)
+	}
+
+	// Rollback: v3 → v2.
+	rb1, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback 1: %v", err)
+	}
+	if rb1.Version != "v2" {
+		t.Errorf("rollback 1 → %q, want v2", rb1.Version)
+	}
+
+	// Rollback again: should walk past the rollback marker to find v1.
+	rb2, err := store.RollbackDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("rollback 2: %v", err)
+	}
+	if rb2.Version != "v1" {
+		t.Errorf("rollback 2 → %q, want v1 (skipping the rollback marker)", rb2.Version)
+	}
+}
+
+func TestConcurrentDeploy(t *testing.T) {
+	store := newTestBundleStore(t)
+	ctx := context.Background()
+	scope := RuleScope{Kind: RuleScopeTenant, Value: "acme"}
+
+	mustCreateBundle(t, store, &Bundle{ID: "b1", Name: "B", ScopeBinding: RuleScope{Kind: RuleScopeGlobal}})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v1", DeployedAt: time.Now().UTC()})
+	mustCreateVersion(t, store, "b1", &BundleVersion{Version: "v2", DeployedAt: time.Now().UTC().Add(time.Second)})
+
+	// Two goroutines deploy v1 + v2 to the same scope concurrently. Lua
+	// EVAL serializes Redis-side, so one fully completes before the other.
+	// Both deploys must land in history; the active pointer is whichever
+	// goroutine's SET ran last.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = store.DeployVersionToScope(ctx, "b1", "v1", scope)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = store.DeployVersionToScope(ctx, "b1", "v2", scope)
+	}()
+	wg.Wait()
+
+	hist, err := store.ListDeploymentHistory(ctx, scope, 100)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 2 {
+		t.Errorf("expected both deploys in history, got %d", len(hist))
+	}
+
+	active, err := store.GetActiveDeployment(ctx, scope)
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if active.Version != "v1" && active.Version != "v2" {
+		t.Errorf("active version should be v1 or v2, got %q", active.Version)
+	}
+}

--- a/core/protocol/pb/v1/pb.go
+++ b/core/protocol/pb/v1/pb.go
@@ -43,6 +43,29 @@ type (
 	SafetyKernelClient              = agentv1.SafetyKernelClient
 	SafetyKernelServer              = agentv1.SafetyKernelServer
 	UnimplementedSafetyKernelServer = agentv1.UnimplementedSafetyKernelServer
+
+	// Unified Policy Studio types.
+	Rule                               = agentv1.Rule
+	RuleScope                          = agentv1.RuleScope
+	AuditMetadata                      = agentv1.AuditMetadata
+	TraceStep                          = agentv1.TraceStep
+	Decision                           = agentv1.Decision
+	BundleMetadata                     = agentv1.BundleMetadata
+	BundleVersion                      = agentv1.BundleVersion
+	Bundle                             = agentv1.Bundle
+	JobEvaluationContext               = agentv1.JobEvaluationContext
+	EdgeEvaluationContext              = agentv1.EdgeEvaluationContext
+	PolicyEvaluateRequest              = agentv1.PolicyEvaluateRequest
+	PolicyEvaluateResponse             = agentv1.PolicyEvaluateResponse
+	PolicyEvaluatorClient              = agentv1.PolicyEvaluatorClient
+	PolicyEvaluatorServer              = agentv1.PolicyEvaluatorServer
+	UnimplementedPolicyEvaluatorServer = agentv1.UnimplementedPolicyEvaluatorServer
+
+	RuleType       = agentv1.RuleType
+	RuleStatus     = agentv1.RuleStatus
+	DecisionSource = agentv1.DecisionSource
+	RuleScopeKind  = agentv1.RuleScopeKind
+	EdgeMode       = agentv1.EdgeMode
 )
 
 const (
@@ -72,16 +95,45 @@ const (
 	DecisionType_DECISION_TYPE_REQUIRE_HUMAN          = agentv1.DecisionType_DECISION_TYPE_REQUIRE_HUMAN
 	DecisionType_DECISION_TYPE_THROTTLE               = agentv1.DecisionType_DECISION_TYPE_THROTTLE
 	DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS = agentv1.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS
+	DecisionType_DECISION_TYPE_QUARANTINE             = agentv1.DecisionType_DECISION_TYPE_QUARANTINE
+	DecisionType_DECISION_TYPE_REDACT                 = agentv1.DecisionType_DECISION_TYPE_REDACT
+
+	RuleType_RULE_TYPE_UNSPECIFIED = agentv1.RuleType_RULE_TYPE_UNSPECIFIED
+	RuleType_RULE_TYPE_INPUT       = agentv1.RuleType_RULE_TYPE_INPUT
+	RuleType_RULE_TYPE_OUTPUT      = agentv1.RuleType_RULE_TYPE_OUTPUT
+	RuleType_RULE_TYPE_VELOCITY    = agentv1.RuleType_RULE_TYPE_VELOCITY
+	RuleType_RULE_TYPE_EDGE        = agentv1.RuleType_RULE_TYPE_EDGE
+
+	RuleStatus_RULE_STATUS_UNSPECIFIED = agentv1.RuleStatus_RULE_STATUS_UNSPECIFIED
+	RuleStatus_RULE_STATUS_DRAFT       = agentv1.RuleStatus_RULE_STATUS_DRAFT
+	RuleStatus_RULE_STATUS_PUBLISHED   = agentv1.RuleStatus_RULE_STATUS_PUBLISHED
+	RuleStatus_RULE_STATUS_DEPRECATED  = agentv1.RuleStatus_RULE_STATUS_DEPRECATED
+
+	DecisionSource_DECISION_SOURCE_UNSPECIFIED = agentv1.DecisionSource_DECISION_SOURCE_UNSPECIFIED
+	DecisionSource_DECISION_SOURCE_JOB         = agentv1.DecisionSource_DECISION_SOURCE_JOB
+	DecisionSource_DECISION_SOURCE_EDGE        = agentv1.DecisionSource_DECISION_SOURCE_EDGE
+
+	RuleScopeKind_RULE_SCOPE_KIND_UNSPECIFIED = agentv1.RuleScopeKind_RULE_SCOPE_KIND_UNSPECIFIED
+	RuleScopeKind_RULE_SCOPE_KIND_GLOBAL      = agentv1.RuleScopeKind_RULE_SCOPE_KIND_GLOBAL
+	RuleScopeKind_RULE_SCOPE_KIND_TENANT      = agentv1.RuleScopeKind_RULE_SCOPE_KIND_TENANT
+	RuleScopeKind_RULE_SCOPE_KIND_WORKFLOW    = agentv1.RuleScopeKind_RULE_SCOPE_KIND_WORKFLOW
+	RuleScopeKind_RULE_SCOPE_KIND_EDGE_FLEET  = agentv1.RuleScopeKind_RULE_SCOPE_KIND_EDGE_FLEET
+	RuleScopeKind_RULE_SCOPE_KIND_EDGE_USER   = agentv1.RuleScopeKind_RULE_SCOPE_KIND_EDGE_USER
+
+	EdgeMode_EDGE_MODE_UNSPECIFIED       = agentv1.EdgeMode_EDGE_MODE_UNSPECIFIED
+	EdgeMode_EDGE_MODE_OBSERVE           = agentv1.EdgeMode_EDGE_MODE_OBSERVE
+	EdgeMode_EDGE_MODE_ENFORCE           = agentv1.EdgeMode_EDGE_MODE_ENFORCE
+	EdgeMode_EDGE_MODE_ENTERPRISE_STRICT = agentv1.EdgeMode_EDGE_MODE_ENTERPRISE_STRICT
 
 	ActorType_ACTOR_TYPE_UNSPECIFIED = agentv1.ActorType_ACTOR_TYPE_UNSPECIFIED
 	ActorType_ACTOR_TYPE_HUMAN       = agentv1.ActorType_ACTOR_TYPE_HUMAN
 	ActorType_ACTOR_TYPE_SERVICE     = agentv1.ActorType_ACTOR_TYPE_SERVICE
 
 	// ErrorCode enum values — protocol errors (100-199)
-	ErrorCode_ERROR_CODE_UNSPECIFIED              = agentv1.ErrorCode_ERROR_CODE_UNSPECIFIED
-	ErrorCode_ERROR_CODE_PROTOCOL_VERSION_MISMATCH = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_VERSION_MISMATCH
-	ErrorCode_ERROR_CODE_PROTOCOL_MALFORMED_PACKET = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_MALFORMED_PACKET
-	ErrorCode_ERROR_CODE_PROTOCOL_UNKNOWN_PAYLOAD  = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_UNKNOWN_PAYLOAD
+	ErrorCode_ERROR_CODE_UNSPECIFIED                = agentv1.ErrorCode_ERROR_CODE_UNSPECIFIED
+	ErrorCode_ERROR_CODE_PROTOCOL_VERSION_MISMATCH  = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_VERSION_MISMATCH
+	ErrorCode_ERROR_CODE_PROTOCOL_MALFORMED_PACKET  = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_MALFORMED_PACKET
+	ErrorCode_ERROR_CODE_PROTOCOL_UNKNOWN_PAYLOAD   = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_UNKNOWN_PAYLOAD
 	ErrorCode_ERROR_CODE_PROTOCOL_SIGNATURE_INVALID = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_SIGNATURE_INVALID
 	ErrorCode_ERROR_CODE_PROTOCOL_SIGNATURE_MISSING = agentv1.ErrorCode_ERROR_CODE_PROTOCOL_SIGNATURE_MISSING
 	// ErrorCode — job errors (200-299)
@@ -118,6 +170,8 @@ const (
 )
 
 var (
-	RegisterSafetyKernelServer = agentv1.RegisterSafetyKernelServer
-	NewSafetyKernelClient      = agentv1.NewSafetyKernelClient
+	RegisterSafetyKernelServer    = agentv1.RegisterSafetyKernelServer
+	NewSafetyKernelClient         = agentv1.NewSafetyKernelClient
+	RegisterPolicyEvaluatorServer = agentv1.RegisterPolicyEvaluatorServer
+	NewPolicyEvaluatorClient      = agentv1.NewPolicyEvaluatorClient
 )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,6 +8,7 @@ Source of truth: `core/controlplane/gateway/gateway_core.go` route registration 
 - Interactive Swagger UI wrapper: `docs/api/openapi/index.html`
 - REST + gRPC overview: `docs/api.md`
 - gRPC service definition (`CordumApi`): `core/protocol/proto/v1/api.proto`
+- gRPC service definition (`PolicyEvaluator`): `cap/proto/cordum/agent/v1/policy.proto`
 
 This file is the comprehensive REST route reference; the canonical OpenAPI spec lives alongside it at `docs/api/openapi/cordum-api.yaml`.
 
@@ -1452,52 +1453,59 @@ Notes:
 
 ## 8. Policy Evaluation and Bundles
 
-### Policy evaluation endpoints
+### Unified policy evaluator
 
 ### POST `/api/v1/policy/evaluate`
-### POST `/api/v1/policy/simulate`
-### POST `/api/v1/policy/explain`
 
-- Auth: required
-- Request schema (`policyCheckRequest`):
+- Canonical Policy Studio evaluator for job and Edge contexts.
+- Auth: required + tenant access; requires `policy.write` or `admin`.
+- Request: unified `PolicyEvaluateRequest` with exactly one rule source
+  (`rule`, or `bundle_id` + `scope`) and exactly one context
+  (`job_context` or `edge_context`).
+- Response: `{ "decision": Decision }`, where `Decision.source` is `job` for
+  `input`/`output`/`velocity` rules and `edge` for `edge` rules.
+- gRPC parity: `PolicyEvaluator.EvaluateUnified`.
+- Full contract: [`docs/policy-evaluate-api.md`](policy-evaluate-api.md).
 
 ```json
 {
-  "job_id": "job-id",
-  "topic": "job.default",
-  "tenant": "default",
-  "org_id": "default",
-  "team_id": "team-a",
-  "workflow_id": "wf-id",
-  "step_id": "step-id",
-  "principal_id": "user-1",
-  "priority": "interactive",
-  "estimated_cost": 0.1,
-  "budget": {
-    "max_input_tokens": 8000,
-    "max_output_tokens": 1024,
-    "max_total_tokens": 4096,
-    "deadline_ms": 30000
-  },
-  "labels": {"k":"v"},
-  "memory_id": "run:abc",
-  "effective_config": {},
-  "meta": {
-    "tenant_id": "default",
-    "actor_id": "user-1",
-    "actor_type": "human",
-    "idempotency_key": "abc",
+  "bundle_id": "secops/default",
+  "scope": { "kind": "tenant", "value": "tenant-acme" },
+  "job_context": {
+    "tenant_id": "tenant-acme",
+    "job_id": "job-id",
+    "topic": "job.default",
+    "principal_id": "user-1",
     "capability": "summarize",
     "risk_tags": ["pii"],
-    "requires": ["approval"],
-    "pack_id": "pack.example",
-    "labels": {}
+    "input": {
+      "content": "summarize this document",
+      "content_type": "text/plain",
+      "size_bytes": 23
+    }
   }
 }
 ```
 
-- Response: protobuf-JSON `PolicyCheckResponse` from safety kernel
-- Errors: `400`, `403`, `502`, `503`
+Errors: `400` invalid request/type confusion, `401`/`403` auth or tenant
+denial, `404` no active bundle/rule, `502`/`503` downstream/store unavailable,
+`500` unexpected server error.
+
+### Deprecated legacy evaluator endpoints
+
+### POST `/api/v1/policy/simulate`
+### POST `/api/v1/policy/explain`
+
+- Status: deprecated but live during the Policy Studio migration window.
+- Auth: required + `policy.write` or `admin`.
+- Request/response: unchanged legacy protobuf-JSON
+  `PolicyCheckRequest`/`PolicyCheckResponse`.
+- Response metadata: `Deprecation: true` and
+  `Link: </api/v1/policy/evaluate>; rel="successor-version"`.
+
+Legacy `PolicyCheckRequest` bodies posted to `POST /api/v1/policy/evaluate`
+are also accepted during the migration window and return the unchanged legacy
+response with the same deprecation headers.
 
 ### GET `/api/v1/policy/snapshots`
 
@@ -1750,6 +1758,25 @@ Notes:
 - Deletes a policy bundle by ID.
 - Response: `204 No Content`
 - Errors: `400` (invalid id), `404` (not found)
+
+### BundleStore lifecycle routes
+
+These routes operate on the unified Policy Studio `BundleStore` used by the
+evaluator's `bundle_id` + `scope` path. They coexist with the legacy config
+bundle CRUD/snapshot endpoints above.
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/api/v1/policy/bundles/{id}/versions` | `policy.read` or admin | List immutable versions. |
+| `POST` | `/api/v1/policy/bundles/{id}/versions` | `policy.write` or admin | Create a version with `rule_snapshot`. |
+| `GET` | `/api/v1/policy/bundles/{id}/versions/{version}` | `policy.read` or admin | Fetch one version. |
+| `POST` | `/api/v1/policy/bundles/{id}/deploy` | `policy.write` or admin | Bind a version to a `RuleScope`. |
+| `GET` | `/api/v1/policy/bundles/deployments` | `policy.read` or admin | List deployment history by `scope_kind`/`scope_value`. |
+| `POST` | `/api/v1/policy/bundles/deployments/rollback` | `policy.write` or admin | Restore the previous active deployment for a scope. |
+
+Tenant-scoped deploy/history/rollback requests require the authenticated
+tenant to match `scope.value`. BundleStore conflicts return `409`; missing
+bundles, versions, active deployments, or rollback targets return `404`.
 
 ### GET `/api/v1/policy/output/rules`
 
@@ -3122,11 +3149,13 @@ legacy `OutputRule`, `VelocityRule`, and `PolicyBundleSummary` schemas
 during the migration window — DoD #3 of task-3bf37e32 verifies the legacy
 schemas are byte-identical to pre-edit.
 
-Path operations that consume the new schemas (`/policies`,
-`/policies/bundles`, `/policies/decisions`, etc.) land in Backend 5 (the
-unified evaluator entry-point task). The Backend 1 PR ships the type
-definitions only; orval-generated dashboard hooks therefore have no new
-operations to wire until Backend 5 merges.
+Backend 5 adds the first canonical operations that consume the unified shapes:
+HTTP `POST /api/v1/policy/evaluate`, gRPC
+`PolicyEvaluator.EvaluateUnified`, and BundleStore-backed lifecycle routes
+for bundle versions/deployments/rollback. Dashboard-only `/policies`,
+`/policies/bundles`, and `/policies/decisions` navigation remains a separate
+dashboard surface; backend clients should use the `/api/v1/policy/*` routes
+documented above and in [`docs/policy-evaluate-api.md`](policy-evaluate-api.md).
 
 The full design is documented in
 [docs/specs/policy-studio-rewrite.md](specs/policy-studio-rewrite.md).

--- a/docs/api/openapi/cordum-api.yaml
+++ b/docs/api/openapi/cordum-api.yaml
@@ -1106,7 +1106,9 @@ paths:
     post:
       operationId: evaluateEdgeAction
       summary: Evaluate an Edge action with Safety Kernel policy
-      description: Classifies a bounded, redacted agent action for an existing Edge session/execution, calls the Safety Kernel using the Edge policy topic, persists a redacted policy decision or degraded event, and returns hook-friendly allow/deny fields. Raw `tool_input`, raw transcripts, and unredacted payloads are rejected; large evidence must use artifact pointers.
+      deprecated: true
+      x-live-route: true
+      description: Deprecated during the Policy Studio migration window. Use `POST /api/v1/policy/evaluate` with an edge `PolicyEvaluateRequest` for new integrations. This legacy endpoint still classifies a bounded, redacted agent action for an existing Edge session/execution, calls the Safety Kernel using the Edge policy topic, persists a redacted policy decision or degraded event, and returns hook-friendly allow/deny fields. Raw `tool_input`, raw transcripts, and unredacted payloads are rejected; large evidence must use artifact pointers.
       tags:
       - Edge
       parameters:
@@ -1120,6 +1122,17 @@ paths:
       responses:
         '200':
           description: Hook-friendly Edge policy decision. Safety outages may still return 200 with `degraded=true` when policy mode permits and degraded evidence was persisted.
+          headers:
+            Deprecation:
+              description: Set to `true` during the migration window.
+              schema:
+                type: string
+                example: 'true'
+            Link:
+              description: Successor relation pointing to `/api/v1/policy/evaluate`.
+              schema:
+                type: string
+                example: '</api/v1/policy/evaluate>; rel="successor-version"'
           content:
             application/json:
               schema:
@@ -2439,7 +2452,15 @@ paths:
   /api/v1/policy/evaluate:
     post:
       operationId: evaluatePolicy
-      summary: Evaluate safety policy against a request
+      summary: Evaluate unified policy against a job or edge context
+      description: |
+        Unified Policy Studio evaluator. New callers send
+        `PolicyEvaluateRequest` with either an inline `rule` or
+        `bundle_id` + `scope`, plus exactly one of `job_context` or
+        `edge_context`. During the migration window this endpoint also accepts
+        the legacy `PolicyCheckRequest` shape and returns the legacy
+        `PolicyCheckResponse` so existing clients keep working. Legacy-shape
+        responses include `Deprecation` and successor `Link` headers.
       tags:
       - Policy
       parameters:
@@ -2449,24 +2470,46 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PolicyCheckRequest'
+              oneOf:
+              - $ref: '#/components/schemas/PolicyEvaluateRequest'
+              - $ref: '#/components/schemas/PolicyCheckRequest'
       responses:
         '200':
           description: Policy evaluation result
+          headers:
+            Deprecation:
+              description: Present and set to `true` only when a legacy `PolicyCheckRequest` shape is evaluated.
+              schema:
+                type: string
+                example: 'true'
+            Link:
+              description: Successor relation pointing to `/api/v1/policy/evaluate` for legacy-shape callers.
+              schema:
+                type: string
+                example: '</api/v1/policy/evaluate>; rel="successor-version"'
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PolicyCheckResponse'
+                oneOf:
+                - $ref: '#/components/schemas/PolicyEvaluateResponse'
+                - $ref: '#/components/schemas/PolicyCheckResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /api/v1/policy/simulate:
     post:
       operationId: simulatePolicy
       summary: Simulate policy evaluation (no side effects)
+      deprecated: true
+      x-live-route: true
+      description: Deprecated during the Policy Studio migration window. Use `POST /api/v1/policy/evaluate` with `PolicyEvaluateRequest`; this endpoint keeps the legacy `PolicyCheckRequest`/`PolicyCheckResponse` schema until the cut-over.
       tags:
       - Policy
       parameters:
@@ -2480,6 +2523,17 @@ paths:
       responses:
         '200':
           description: Simulation result
+          headers:
+            Deprecation:
+              description: Set to `true` during the migration window.
+              schema:
+                type: string
+                example: 'true'
+            Link:
+              description: Successor relation pointing to `/api/v1/policy/evaluate`.
+              schema:
+                type: string
+                example: '</api/v1/policy/evaluate>; rel="successor-version"'
           content:
             application/json:
               schema:
@@ -2494,6 +2548,9 @@ paths:
     post:
       operationId: explainPolicy
       summary: Explain policy evaluation reasoning
+      deprecated: true
+      x-live-route: true
+      description: Deprecated during the Policy Studio migration window. Use `POST /api/v1/policy/evaluate` with `PolicyEvaluateRequest`; this endpoint keeps the legacy `PolicyCheckRequest`/`PolicyCheckResponse` schema until the cut-over.
       tags:
       - Policy
       parameters:
@@ -2507,6 +2564,17 @@ paths:
       responses:
         '200':
           description: Explanation result
+          headers:
+            Deprecation:
+              description: Set to `true` during the migration window.
+              schema:
+                type: string
+                example: 'true'
+            Link:
+              description: Successor relation pointing to `/api/v1/policy/evaluate`.
+              schema:
+                type: string
+                example: '</api/v1/policy/evaluate>; rel="successor-version"'
           content:
             application/json:
               schema:
@@ -2685,6 +2753,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
   /api/v1/policy/bundles:
+    x-subroute-dispatch: true
     get:
       operationId: listPolicyBundles
       summary: List policy bundles
@@ -2713,6 +2782,80 @@ paths:
                     format: date-time
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/policy/bundles/deployments:
+    get:
+      operationId: listPolicyBundleDeployments
+      summary: List policy bundle deployment history for a scope
+      description: Returns the BundleStore deployment history for one rule scope, newest first.
+      tags:
+      - Policy
+      parameters:
+      - $ref: '#/components/parameters/TenantID'
+      - name: scope_kind
+        in: query
+        required: true
+        schema:
+          $ref: '#/components/schemas/RuleScopeKind'
+      - name: scope_value
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 100
+      responses:
+        '200':
+          description: Deployment history
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyBundleDeploymentHistoryResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/policy/bundles/deployments/rollback:
+    post:
+      operationId: rollbackPolicyBundleDeployment
+      summary: Roll back the active policy bundle deployment for a scope
+      description: Restores the previous active (bundle, version) pair for the supplied scope and appends a rollback deployment marker.
+      tags:
+      - Policy
+      parameters:
+      - $ref: '#/components/parameters/TenantID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyBundleRollbackRequest'
+      responses:
+        '200':
+          description: Rollback deployment record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyBundleDeploymentResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /api/v1/policy/bundles/{id}:
@@ -2775,6 +2918,136 @@ paths:
       responses:
         '204':
           description: Policy bundle deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/policy/bundles/{id}/versions:
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    - $ref: '#/components/parameters/TenantID'
+    get:
+      operationId: listPolicyBundleVersions
+      summary: List immutable versions for a policy bundle
+      description: Returns the BundleStore versions for the bundle in chronological order.
+      tags:
+      - Policy
+      responses:
+        '200':
+          description: Bundle versions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyBundleVersionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      operationId: createPolicyBundleVersion
+      summary: Create an immutable policy bundle version
+      description: Persists a versioned rule snapshot in the BundleStore; versions are immutable and duplicate version ids return 409.
+      tags:
+      - Policy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyBundleVersionCreateRequest'
+      responses:
+        '201':
+          description: Bundle version created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyBundleVersionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/policy/bundles/{id}/versions/{version}:
+    get:
+      operationId: getPolicyBundleVersion
+      summary: Get one immutable policy bundle version
+      tags:
+      - Policy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: version
+        in: path
+        required: true
+        schema:
+          type: string
+      - $ref: '#/components/parameters/TenantID'
+      responses:
+        '200':
+          description: Bundle version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyBundleVersionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/v1/policy/bundles/{id}/deploy:
+    post:
+      operationId: deployPolicyBundleVersion
+      summary: Deploy a policy bundle version to a rule scope
+      description: Rebinds the active BundleStore deployment for the supplied scope and preserves the previous binding in deployment history.
+      tags:
+      - Policy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - $ref: '#/components/parameters/TenantID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyBundleDeployRequest'
+      responses:
+        '200':
+          description: Deployment record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyBundleDeploymentResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -11193,6 +11466,125 @@ components:
       - rule_id
       - type
       - timestamp
+    JobEvaluationInput:
+      type: object
+      description: |
+        Job-side content snapshot evaluated by a unified job Rule. `content`
+        may be truncated by callers; `size_bytes` records the original size.
+      properties:
+        content:
+          type: string
+        content_type:
+          type: string
+        size_bytes:
+          type: integer
+          format: int64
+    JobEvaluationContext:
+      type: object
+      description: |
+        Job-side context for the unified evaluator. Used with input, output,
+        and velocity rules and dispatched to the safetykernel path.
+      properties:
+        tenant_id:
+          type: string
+        job_id:
+          type: string
+        workflow_id:
+          type: string
+        topic:
+          type: string
+        principal_id:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        memory_id:
+          type: string
+        capability:
+          type: string
+        risk_tags:
+          type: array
+          items:
+            type: string
+        input:
+          $ref: '#/components/schemas/JobEvaluationInput'
+      required:
+      - tenant_id
+      - topic
+    EdgeEvaluationContext:
+      type: object
+      description: |
+        Edge-side action snapshot for the unified evaluator. Raw tool input is
+        intentionally absent; callers provide only redacted input and labels.
+      properties:
+        tenant_id:
+          type: string
+        principal_id:
+          type: string
+        session_id:
+          type: string
+        execution_id:
+          type: string
+        agent_product:
+          type: string
+        tool_name:
+          type: string
+        tool_input_redacted:
+          type: object
+          additionalProperties: true
+        input_hash:
+          type: string
+        tool_input_hash:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        risk_tags:
+          type: array
+          items:
+            type: string
+      required:
+      - tenant_id
+      - principal_id
+    PolicyEvaluateRequest:
+      type: object
+      description: |
+        Unified Policy Studio evaluator request. Provide either `rule` or
+        `bundle_id` + `scope`, and exactly one of `job_context` or
+        `edge_context`. Job contexts are valid for input/output/velocity
+        rules; edge contexts are valid only for edge rules.
+      properties:
+        rule:
+          $ref: '#/components/schemas/Rule'
+        bundle_id:
+          type: string
+        scope:
+          $ref: '#/components/schemas/RuleScope'
+        job_context:
+          $ref: '#/components/schemas/JobEvaluationContext'
+        edge_context:
+          $ref: '#/components/schemas/EdgeEvaluationContext'
+      anyOf:
+      - required:
+        - rule
+      - required:
+        - bundle_id
+        - scope
+      oneOf:
+      - required:
+        - job_context
+      - required:
+        - edge_context
+    PolicyEvaluateResponse:
+      type: object
+      description: Unified evaluator response containing the shared Decision.
+      properties:
+        decision:
+          $ref: '#/components/schemas/Decision'
+      required:
+      - decision
     BundleMetadata:
       type: object
       description: |
@@ -11225,6 +11617,116 @@ components:
       required:
       - version
       - deployed_at
+    PolicyBundleVersionCreateRequest:
+      type: object
+      description: Request to append an immutable BundleStore version.
+      properties:
+        version:
+          type: string
+        rule_snapshot:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rule'
+        deployed_at:
+          type: string
+          format: date-time
+        audit_hash:
+          type: string
+      required:
+      - version
+      - rule_snapshot
+    PolicyBundleVersionResponse:
+      type: object
+      properties:
+        bundle_id:
+          type: string
+        version:
+          $ref: '#/components/schemas/BundleVersion'
+      required:
+      - bundle_id
+      - version
+    PolicyBundleVersionsResponse:
+      type: object
+      properties:
+        bundle_id:
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BundleVersion'
+      required:
+      - bundle_id
+      - items
+    PolicyBundleDeployRequest:
+      type: object
+      properties:
+        version:
+          type: string
+        scope:
+          $ref: '#/components/schemas/RuleScope'
+      required:
+      - version
+      - scope
+    PolicyBundleRollbackRequest:
+      type: object
+      properties:
+        scope:
+          $ref: '#/components/schemas/RuleScope'
+      required:
+      - scope
+    BundleDeploymentAction:
+      type: string
+      enum:
+      - deploy
+      - rollback
+    BundleDeployment:
+      type: object
+      description: Audit-ready BundleStore binding event for one rule scope.
+      properties:
+        bundle_id:
+          type: string
+        version:
+          type: string
+        scope:
+          $ref: '#/components/schemas/RuleScope'
+        deployed_at:
+          type: string
+          format: date-time
+        deployed_by:
+          type: string
+        audit_hash:
+          type: string
+        action:
+          $ref: '#/components/schemas/BundleDeploymentAction'
+        prev_bundle_id:
+          type: string
+        prev_version:
+          type: string
+      required:
+      - bundle_id
+      - version
+      - scope
+      - deployed_at
+      - action
+    PolicyBundleDeploymentResponse:
+      type: object
+      properties:
+        deployment:
+          $ref: '#/components/schemas/BundleDeployment'
+      required:
+      - deployment
+    PolicyBundleDeploymentHistoryResponse:
+      type: object
+      properties:
+        scope:
+          $ref: '#/components/schemas/RuleScope'
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BundleDeployment'
+      required:
+      - scope
+      - items
     Bundle:
       type: object
       description: |

--- a/docs/policy-bundle-store.md
+++ b/docs/policy-bundle-store.md
@@ -63,11 +63,26 @@ All multi-key mutations execute inside a single Redis Lua script:
   scripts in-process to completion).
 
 - `rollbackScript` — reads the current active pointer, locates the
-  deploy entry that established it (skipping rollback markers), walks
-  backward to the immediately-prior deploy entry, SETs active to that
-  pair, and LPUSHes a rollback marker. Chained rollbacks unwind one
-  step per call (`v3 → v2 → v1`); this is the test
-  `TestRollbackChain` invariant.
+  deploy entry that established it (skipping rollback markers), reads
+  the `prev_bundle_id` + `prev_version` fields recorded ON that deploy
+  event at deploy-time, SETs active to that prior pair, and LPUSHes a
+  rollback marker. Chained rollbacks unwind one step per call
+  (`v3 → v2 → v1`); the test `TestRollbackChain` pins this. After a
+  deploy-after-rollback (`v1 → v2 → rollback → v3 → rollback`) the
+  final rollback restores v1 — the active state immediately before
+  v3 was deployed — because that pair was captured on the v3 deploy
+  event. The test `TestDeployAfterRollback` pins this regression
+  closed (was QA reopen #1 on 2026-05-09).
+
+### Why prev-active is recorded on each deploy event
+
+Without per-event prev-active fields, rollback can only inspect raw
+history order, which loses information after a deploy-after-rollback:
+the second-most-recent deploy event (v2) is no longer the active
+state immediately before the current deploy (v1, post-rollback). The
+script reads the current active pointer and writes the deploy event
+inside the same Lua execution, so concurrent deploys to the same scope
+produce a totally-ordered prev-active chain.
 
 The Lua-EVAL choice is load-bearing: per memory `mem-12f1ceeb`,
 go-redis's WATCH+TxPipelined sequence corrupts the connection pool when

--- a/docs/policy-bundle-store.md
+++ b/docs/policy-bundle-store.md
@@ -1,0 +1,110 @@
+# Policy Bundle Store
+
+Redis-backed storage for the unified Policy Studio bundles introduced in
+epic-d9a6c0a1. The store sits in `core/policy/` and is consumed by both
+job-side (safetykernel) and edge-side evaluators via the
+[`BundleStore`](../core/policy/bundle_store.go) interface; the unified
+view replaces the per-track bundle tables that lived in v2.
+
+## Purpose
+
+Policy Studio's three-surface IA (`/policies`, `/policies/bundles`,
+`/policies/decisions`) needs a single canonical store for:
+
+- Bundle envelopes (id, name, scope binding, metadata).
+- Per-bundle version history (immutable BundleVersion records with
+  full RuleSnapshot for tamper-evident rollback).
+- Per-scope active deployment + ordered deploy/rollback history.
+
+`BundleStore` is the contract; `BundleRedisStore` is the canonical
+implementation.
+
+## Redis schema
+
+| Key | Type | Purpose | Cardinality | TTL |
+|---|---|---|---|---|
+| `policy:bundle:{id}` | STRING (JSON Bundle envelope, no Versions) | Bundle metadata | 1 per bundle | none (immutable + long-lived) |
+| `policy:bundle:{id}:versions` | ZSET (member=version, score=DeployedAt unix nanos) | Per-bundle version index | 1 per bundle | none |
+| `policy:bundle:{id}:version:{version}` | STRING (JSON BundleVersion incl. RuleSnapshot + AuditHash) | Immutable version blob | 1 per (bundle, version) | none |
+| `policy:scope:{kind}:{value}:active` | STRING (`"{bundleID}:{version}"` pointer) | Active deployment for scope | 1 per scope | none |
+| `policy:scope:{kind}:{value}:history` | LIST (each element a Deployment JSON; LPUSH on deploy/rollback) | Ordered history (newest first) | bounded to 100 entries via LTRIM in Lua | none |
+
+### Why the prefix split
+
+`policy:bundle:*` covers everything keyed by bundle id; `policy:scope:*`
+covers everything keyed by scope. Step-2 inventory confirmed neither
+prefix collides with existing core/* stores (workflow uses `cordum:wf:*`
++ `runKey()`, edge uses `edge:session:*`, registry uses
+`sys:workers:*`).
+
+## CRUD operations
+
+| Operation | Atomic? | Idempotent? | Typed errors |
+|---|---|---|---|
+| `CreateBundle` | SETNX (single key) | yes (duplicate returns ErrBundleExists) | ErrBundleExists |
+| `GetBundle` | GET (single key) | yes | ErrBundleNotFound |
+| `ListBundlesByScope` | SCAN over `policy:bundle:*` + in-process filter | yes | — |
+| `CreateBundleVersion` | SETNX + ZADD pipeline | yes (duplicate version-number returns ErrBundleVersionExists) | ErrBundleVersionExists |
+| `ListBundleVersions` | ZRANGE + MGET pipeline | yes | — |
+| `GetBundleVersion` | GET (single key) | yes | ErrBundleVersionNotFound |
+| `DeployVersionToScope` | **single Lua EVAL** (`deployScript`) | yes | ErrBundleVersionNotFound |
+| `RollbackDeployment` | **single Lua EVAL** (`rollbackScript`) | yes | ErrNoRollbackTarget |
+| `GetActiveDeployment` | GET pointer + LRANGE history (read-only) | yes | ErrNoDeploymentForScope |
+| `ListDeploymentHistory` | LRANGE | yes | — |
+
+## Concurrency model
+
+All multi-key mutations execute inside a single Redis Lua script:
+
+- `deployScript` — validates the requested `policy:bundle:{id}:version:{n}`
+  exists, then SETs the active pointer, LPUSHes the deploy event into
+  history, and LTRIMs to the last 100 entries. Atomic; concurrent
+  deploys to the same scope serialize Redis-side (Redis runs Lua
+  scripts in-process to completion).
+
+- `rollbackScript` — reads the current active pointer, locates the
+  deploy entry that established it (skipping rollback markers), walks
+  backward to the immediately-prior deploy entry, SETs active to that
+  pair, and LPUSHes a rollback marker. Chained rollbacks unwind one
+  step per call (`v3 → v2 → v1`); this is the test
+  `TestRollbackChain` invariant.
+
+The Lua-EVAL choice is load-bearing: per memory `mem-12f1ceeb`,
+go-redis's WATCH+TxPipelined sequence corrupts the connection pool when
+miniredis returns errors, which broke the workflow store's
+`TestHandleJobResult_UpdateRunRetry_Succeeds` during task-a45b8eb1.
+Lua scripts have no equivalent failure mode under miniredis.
+
+## Bounded sizes
+
+History lists are LTRIMmed to the most recent 100 entries (constant
+`deploymentHistoryCap` in `bundle_store_keys.go`). The cap fires inside
+each Lua mutation, so no separate sweeper is needed. 100 is the
+DoD-defined upper bound; tune if dashboard's "Deployments" tab needs
+deeper history.
+
+## Open questions for v3
+
+1. **`ListBundlesByScope` SCAN cost** — current impl scans every
+   `policy:bundle:*` key and filters in-process. At ~1k bundles per
+   tenant this is fine; at 100k+ a per-scope ZSET index would amortize
+   the cost. Defer until a real performance signal appears.
+
+2. **Cluster-mode key colocation** — the deploy/rollback Lua scripts
+   touch two keys (active + history) for a single scope. Both keys
+   share the `policy:scope:{kind}:{value}:` prefix; with Redis
+   Cluster's hash-tag rule, wrap the scope segment in `{...}` when the
+   cluster topology requires colocation. Not needed for single-node
+   deployments.
+
+3. **Audit-chain integration** — `Deployment.AuditHash` is currently
+   plumbed but unused; Backend 5 will populate it via the existing
+   `core/audit` chain.
+
+## Cross-references
+
+- Task: `task-b349524a` (Backend 2 of epic-d9a6c0a1).
+- Predecessor: `task-3bf37e32` (Backend 1 — types).
+- Consumers: Backend 3 (job evaluator), Backend 4 (edge evaluator),
+  Backend 5 (unified evaluator entry-point).
+- Spec: `docs/specs/policy-studio-rewrite.md`.

--- a/docs/policy-evaluate-api.md
+++ b/docs/policy-evaluate-api.md
@@ -1,0 +1,178 @@
+# Unified Policy Evaluator API
+
+Backend 5 of the Policy Studio rewrite adds one evaluator entry-point for job
+and Edge policy decisions while preserving the old split endpoints during the
+migration window.
+
+## Entry points
+
+| Surface | Endpoint | Status | Auth |
+| --- | --- | --- | --- |
+| HTTP | `POST /api/v1/policy/evaluate` | canonical | API key or bearer token + `X-Tenant-ID`; requires `policy.write` or `admin` |
+| gRPC | `PolicyEvaluator.EvaluateUnified` | canonical | gateway gRPC auth; requires `admin` or `operator` role |
+| HTTP | `POST /api/v1/policy/simulate` | deprecated/live | same legacy policy auth; returns `Deprecation` + successor `Link` headers |
+| HTTP | `POST /api/v1/policy/explain` | deprecated/live | same legacy policy auth; returns `Deprecation` + successor `Link` headers |
+| HTTP | `POST /api/v1/edge/evaluate` | deprecated/live for new clients | same legacy Edge auth; returns `Deprecation` + successor `Link` headers |
+
+`/api/v1/policy/evaluate` also accepts the old `PolicyCheckRequest` body while
+clients migrate. Legacy-shape calls return the unchanged protobuf-JSON
+`PolicyCheckResponse` plus the deprecation headers. Unified-shape calls return
+`{ "decision": Decision }`.
+
+## Unified HTTP request
+
+A unified request must provide exactly one rule source and exactly one context:
+
+- Rule source: either inline `rule`, or `bundle_id` + `scope`.
+- Context: either `job_context`, or `edge_context`.
+
+### Job inline rule example
+
+```json
+{
+  "rule": {
+    "id": "rule-input-allow",
+    "name": "allow job input",
+    "type": "input",
+    "scope": { "kind": "tenant", "value": "tenant-acme" },
+    "status": "published",
+    "version": "v1",
+    "match": { "topic": "job.deploy" },
+    "decide": { "decision": "allow" }
+  },
+  "job_context": {
+    "tenant_id": "tenant-acme",
+    "job_id": "job-123",
+    "topic": "job.deploy",
+    "principal_id": "alice",
+    "capability": "deploy",
+    "risk_tags": ["release"],
+    "input": {
+      "content": "deploy service api",
+      "content_type": "text/plain",
+      "size_bytes": 18
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "decision": {
+    "type": "allow",
+    "source": "job",
+    "rule_id": "rule-input-allow",
+    "timestamp": "2026-05-09T18:00:00Z",
+    "trace": [
+      {
+        "rule_id": "rule-input-allow",
+        "decision_type": "allow",
+        "reason": "matched job-side safety policy"
+      }
+    ]
+  }
+}
+```
+
+### Edge inline rule example
+
+```json
+{
+  "rule": {
+    "id": "edge-shell-deny",
+    "name": "deny shell writes",
+    "type": "edge",
+    "scope": { "kind": "tenant", "value": "tenant-acme" },
+    "status": "published",
+    "version": "v1",
+    "match": { "tool_name": "Bash", "capability": "exec.shell" },
+    "decide": { "decision": "deny", "reason": "shell writes require review" }
+  },
+  "edge_context": {
+    "tenant_id": "tenant-acme",
+    "principal_id": "alice",
+    "session_id": "edge-session-1",
+    "execution_id": "exec-1",
+    "agent_product": "claude-code",
+    "tool_name": "Bash",
+    "tool_input_redacted": { "command": "rm -rf build" },
+    "input_hash": "sha256:...",
+    "risk_tags": ["shell"]
+  }
+}
+```
+
+## Dispatch matrix
+
+| `Rule.type` | Required context | Dispatcher | Decision source |
+| --- | --- | --- | --- |
+| `input` | `job_context` | Safety Kernel input adapter/evaluator | `job` |
+| `output` | `job_context` | Safety Kernel output adapter/evaluator | `job` |
+| `velocity` | `job_context` | Safety Kernel velocity adapter/evaluator | `job` |
+| `edge` | `edge_context` | Edge classifier adapter/evaluator | `edge` |
+
+Type-confusion requests fail before dispatch. For example, `Rule.type=edge`
+with `job_context` returns `400` over HTTP or `InvalidArgument` over gRPC; no
+Safety Kernel or Edge classifier call is made.
+
+## Bundle resolution
+
+When a request uses `bundle_id` + `scope`, the evaluator:
+
+1. Reads the active deployment for `scope` from `BundleStore`.
+2. Requires the active deployment's `bundle_id` to equal the requested
+   `bundle_id`.
+3. Loads the active `BundleVersion` and scans its immutable `rule_snapshot`.
+4. Selects the first `published` rule whose `Rule.type` is compatible with the
+   supplied context.
+5. Evaluates that rule and stamps the returned `Decision` with
+   `bundle_id`/`bundle_version`.
+
+No active deployment, a bundle mismatch, a missing version, or a snapshot with
+no compatible published rule returns `404`/`NotFound`.
+
+## Bundle lifecycle HTTP access
+
+Backend 5 exposes real BundleStore-backed lifecycle routes; these are not
+YAML-only OpenAPI placeholders.
+
+| Method | Path | Auth | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/api/v1/policy/bundles/{id}/versions` | `policy.read` or `admin` | List immutable versions. |
+| `POST` | `/api/v1/policy/bundles/{id}/versions` | `policy.write` or `admin` | Create a version with `version`, `rule_snapshot`, optional `deployed_at`, and `audit_hash`. |
+| `GET` | `/api/v1/policy/bundles/{id}/versions/{version}` | `policy.read` or `admin` | Fetch one version. |
+| `POST` | `/api/v1/policy/bundles/{id}/deploy` | `policy.write` or `admin` | Deploy version to a `RuleScope`; tenant scopes require matching tenant access. |
+| `GET` | `/api/v1/policy/bundles/deployments` | `policy.read` or `admin` | Query history by `scope_kind`, optional `scope_value`, and `limit` (max 100). |
+| `POST` | `/api/v1/policy/bundles/deployments/rollback` | `policy.write` or `admin` | Roll back the active deployment for a scope by one deploy step. |
+
+## Error table
+
+| Failure | HTTP | gRPC |
+| --- | --- | --- |
+| Invalid JSON, missing rule source/context, unsupported rule type, type confusion | `400` | `InvalidArgument` |
+| Auth missing or tenant/RBAC denied | `401`/`403` | `Unauthenticated`/`PermissionDenied` |
+| No active deployment, bundle/version missing, no compatible published rule | `404` | `NotFound` |
+| Bundle store unavailable | `503` | `Unavailable` |
+| Downstream evaluator failure | `502` or `503` | `Unavailable` |
+| Unexpected server error | `500` | `Internal` |
+
+## Audit-chain behavior
+
+Unified evaluations emit the shared `policy.decision.v2` audit record. During
+the migration window, job and Edge evaluators can run in dual-emission mode:
+legacy audit records (`safety.decision` or legacy Edge decision events) are
+written first, then the unified `policy.decision.v2` record. This preserves
+existing consumers while the Decisions surface reads the unified stream.
+
+## Migration guide
+
+- New job and Edge clients should move to `POST /api/v1/policy/evaluate` (or
+  `PolicyEvaluator.EvaluateUnified`) with `PolicyEvaluateRequest`.
+- Existing `/api/v1/policy/simulate`, `/api/v1/policy/explain`, legacy-shape
+  `/api/v1/policy/evaluate`, and `/api/v1/edge/evaluate` callers can continue
+  during the Policy Studio transition window. They receive `Deprecation: true`
+  and `Link: </api/v1/policy/evaluate>; rel="successor-version"`.
+- Removal of deprecated evaluator surfaces is deferred until the later Policy
+  Studio cut-over after backend and dashboard clients have migrated.

--- a/go.mod
+++ b/go.mod
@@ -78,3 +78,5 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
 )
+
+replace github.com/cordum-io/cap/v2 => ../cap

--- a/sdk/typescript/src/_generated/schema.d.ts
+++ b/sdk/typescript/src/_generated/schema.d.ts
@@ -453,9 +453,9 @@ export interface paths {
         /**
          * Verify audit chain integrity
          * @description Walks the tenant's audit stream and attests integrity of the hash chain. Reports
-         *     `status=ok` on a contiguous chain, `status=gap` with classification when seq numbers are
-         *     missing (retention-trimmed vs suspected tampering), and `status=tamper` on a broken hash
-         *     link. Admin-only and entitlement-gated; NEVER returns raw event bodies — this is an
+         *     `status=ok` on a contiguous chain, `status=partial` when gaps are below the
+         *     retention boundary, and `status=compromised` for missing sequence numbers or a
+         *     broken hash link. Admin-only and entitlement-gated; NEVER returns raw event bodies — this is an
          *     integrity report surface, not event retrieval.
          */
         get: operations["verifyAuditChain"];
@@ -554,6 +554,26 @@ export interface paths {
         put?: never;
         /** Logout and invalidate session */
         post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/oidc/group-role-mapping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update OIDC groups-to-roles mapping
+         * @description Admin-only endpoint for updating the active Okta/OIDC groups claim and Cordum role mapping. Values are validated, applied to the live provider, and persisted into system/default config.
+         */
+        put: operations["updateOIDCGroupRoleMapping"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -678,6 +698,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/copilot/sessions/{sessionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Copilot session detail
+         * @description Returns a Copilot chat transcript plus linked jobs and governance decisions.
+         */
+        get: operations["getCopilotSession"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/delegations": {
         parameters: {
             query?: never;
@@ -757,6 +797,381 @@ export interface paths {
         get: operations["listDLQPaginated"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/approvals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Edge action approvals
+         * @description Lists tenant-scoped Edge approval records for action-level governance. Non-admin/non-operator callers receive only approvals whose `principal_id` matches the authenticated `auth.PrincipalID`; admin and operator callers may list all approvals in the tenant for operations and forensics. Status, tuple, cursor, and limit filters are applied within that visibility scope so list pagination remains principal-stable. Raw action payloads are never returned; actions are represented by `event_id`, `action_hash`, `input_hash`, and `policy_snapshot`.
+         */
+        get: operations["listEdgeApprovals"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/approvals/{approval_ref}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get an Edge action approval
+         * @description Returns one tenant-scoped Edge approval record. Detail reads are principal-bound: the caller must be the original requester principal (`auth.PrincipalID` matches the approval `principal_id`) or hold an admin/operator role. Cross-tenant requests and same-tenant callers that fail this binding are reported as not found and no raw tool/action payload is exposed.
+         */
+        get: operations["getEdgeApproval"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/approvals/{approval_ref}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve an Edge action approval
+         * @description Resolves a pending Edge approval as approved for one retry/consume. Requires approval/admin permission, enforces tenant scope and self-approval protection, and fails with 409 if the session/execution/event/action hash or policy snapshot is stale.
+         *
+         *     EDGE-060 — supports `Idempotency-Key` for safe retry against
+         *     the resolution state transition. Same key + same body returns
+         *     the SAME cached 200 response (replay), NOT 409 "already
+         *     approved" — this is the EDGE-060 DoD #7 invariant. A different
+         *     key against an already-terminal approval still surfaces the
+         *     existing 409 path.
+         */
+        post: operations["approveEdgeApproval"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/approvals/{approval_ref}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reject an Edge action approval
+         * @description Resolves a pending Edge approval as rejected. Requires approval/admin permission, enforces tenant scope and self-approval protection, and fails with 409 if the referenced Edge session/execution/event is stale.
+         *
+         *     EDGE-060 — supports `Idempotency-Key` for safe retry against
+         *     the resolution state transition. Same key + same body returns
+         *     the SAME cached 200 response (replay), NOT 409 "already
+         *     rejected".
+         */
+        post: operations["rejectEdgeApproval"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/approvals/{approval_ref}/wait": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bounded blocking wait for an Edge approval to leave Pending
+         * @description Agentd/local-dev affordance that polls the Edge approval store until the approval is non-pending or the bounded timeout elapses, then returns the current EdgeApproval. The wait is principal-bound: the caller must be the original requester principal (`auth.PrincipalID` matches the approval `principal_id`) or hold an admin/operator role. The server clamps `timeout_ms` to a 5 minute maximum and uses a 30 second default when omitted or non-positive. Tenant isolation is enforced; cross-tenant references and same-tenant callers that fail the principal binding return 404 with no metadata leakage. This endpoint is not required by the dashboard approve/reject UX — callers there should use the standard list/detail/approve/reject flow.
+         */
+        post: operations["waitEdgeApproval"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/evaluate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Evaluate an Edge action with Safety Kernel policy
+         * @deprecated
+         * @description Deprecated during the Policy Studio migration window. Use `POST /api/v1/policy/evaluate` with an edge `PolicyEvaluateRequest` for new integrations. This legacy endpoint still classifies a bounded, redacted agent action for an existing Edge session/execution, calls the Safety Kernel using the Edge policy topic, persists a redacted policy decision or degraded event, and returns hook-friendly allow/deny fields. Raw `tool_input`, raw transcripts, and unredacted payloads are rejected; large evidence must use artifact pointers.
+         */
+        post: operations["evaluateEdgeAction"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Append a single Edge agent action event
+         * @description Writes a redacted AgentActionEvent for an existing Edge session/execution. Raw tool inputs, raw tool results, and transcripts must not be sent inline; send bounded `input_redacted` details and reference large evidence with `artifact_ptrs`. Optional `Idempotency-Key` retries are scoped by tenant and endpoint: the same normalized request replays the first 201 response without appending a duplicate event, while the same key with a different normalized request returns 409 `idempotency_conflict`. The append and replay record commit in one Redis transaction. If the replay record has expired and the same logical `event_id` is already present, the API returns 409 `idempotency_window_expired` and does not append a duplicate event.
+         */
+        post: operations["createEdgeEvent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/events/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Append a batch of Edge agent action events
+         * @description Appends a fully prevalidated, ordered batch for existing Edge session/execution parents. Mixed-tenant or invalid items are rejected before append where possible. Large raw payloads must be stored separately and referenced by `artifact_ptrs`. Optional `Idempotency-Key` retries are scoped by tenant and endpoint: the same normalized batch replays the first 201 response without partial append or duplicate events, while the same key with a different normalized batch returns 409 `idempotency_conflict`. The append and replay record commit in one Redis transaction. If the replay record has expired and any same logical `event_id` is already present, the API returns 409 `idempotency_window_expired` and does not append duplicate events.
+         */
+        post: operations["createEdgeEventsBatch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/executions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Edge agent executions for a tenant */
+        get: operations["listEdgeExecutions"];
+        put?: never;
+        /**
+         * Create an Edge agent execution
+         * @description EDGE-060 — supports `Idempotency-Key`. A retry with the same
+         *     key and identical body returns the SAME `execution_id` (cached
+         *     replay, 201) without burning against the per-session execution
+         *     cap. A retry with the same key but different body returns 409
+         *     `idempotency_conflict`. Missing key falls back to non-idempotent
+         *     behavior (every call generates a fresh `execution_id`).
+         */
+        post: operations["createEdgeExecution"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/executions/{execution_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an Edge agent execution */
+        get: operations["getEdgeExecution"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/executions/{execution_id}/end": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** End an Edge agent execution */
+        post: operations["endEdgeExecution"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/executions/{execution_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Edge events for an execution
+         * @description Returns tenant-scoped events for one execution in ascending sequence order with cursor pagination and optional kind, decision, and RFC3339 time-window filters.
+         */
+        get: operations["listEdgeExecutionEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Edge sessions for a tenant */
+        get: operations["listEdgeSessions"];
+        put?: never;
+        /**
+         * Create an Edge session and initial execution
+         * @description EDGE-060 — supports `Idempotency-Key`. A retry with the same key
+         *     and identical body returns the SAME `session_id` /
+         *     `execution_id` / `trace_id` (cached replay, 201). A retry with
+         *     the same key but different body returns 409
+         *     `idempotency_conflict`. Missing key falls back to non-idempotent
+         *     behavior (every call generates fresh UUIDs).
+         */
+        post: operations["createEdgeSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/sessions/{session_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an Edge session */
+        get: operations["getEdgeSession"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/sessions/{session_id}/end": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** End an Edge session */
+        post: operations["endEdgeSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/sessions/{session_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Edge events for a session
+         * @description Returns tenant-scoped events across executions in the session with cursor pagination and optional kind, decision, and RFC3339 time-window filters.
+         */
+        get: operations["listEdgeSessionEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/sessions/{session_id}/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assemble an Edge session evidence bundle
+         * @description Returns a `SessionExportBundle` for the named session — session record,
+         *     executions, ordered AgentActionEvents, approvals, and a metadata-only
+         *     manifest of every artifact pointer attached to those events. Bundles
+         *     contain artifact metadata (URI, sha256, size, content_type, retention,
+         *     redaction level) but never raw artifact bodies. Cross-tenant probes
+         *     receive 404 indistinguishable from missing-session.
+         */
+        post: operations["exportEdgeSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/edge/sessions/{session_id}/heartbeat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh an Edge session heartbeat */
+        post: operations["heartbeatEdgeSession"];
         delete?: never;
         options?: never;
         head?: never;
@@ -955,6 +1370,33 @@ export interface paths {
         };
         /** Query the governance decision log */
         get: operations["listGovernanceDecisions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/governance/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Composite governance health score per tenant
+         * @description Returns the Command Center governance-health aggregate for the tenant:
+         *     denial-rate, approval-latency p95, policy coverage, and audit-chain integrity
+         *     rolled up into a 0-100 score plus A-F grade.
+         *
+         *     Admin-only. When governance-health caching is enabled, results are cached
+         *     per tenant for 60 seconds so dashboards can poll without forcing a full
+         *     recompute on every refresh. If caching is disabled, the handler falls
+         *     back to a fresh per-request cache and the endpoint behaves as uncached.
+         */
+        get: operations["getGovernanceHealth"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1568,6 +2010,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/policy/bundles/{id}/deploy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Deploy a policy bundle version to a rule scope
+         * @description Rebinds the active BundleStore deployment for the supplied scope and preserves the previous binding in deployment history.
+         */
+        post: operations["deployPolicyBundleVersion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/policy/bundles/{id}/simulate": {
         parameters: {
             query?: never;
@@ -1579,6 +2041,92 @@ export interface paths {
         put?: never;
         /** Simulate a policy bundle against a request */
         post: operations["simulatePolicyBundle"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/bundles/{id}/versions": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * List immutable versions for a policy bundle
+         * @description Returns the BundleStore versions for the bundle in chronological order.
+         */
+        get: operations["listPolicyBundleVersions"];
+        put?: never;
+        /**
+         * Create an immutable policy bundle version
+         * @description Persists a versioned rule snapshot in the BundleStore; versions are immutable and duplicate version ids return 409.
+         */
+        post: operations["createPolicyBundleVersion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/bundles/{id}/versions/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one immutable policy bundle version */
+        get: operations["getPolicyBundleVersion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/bundles/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List policy bundle deployment history for a scope
+         * @description Returns the BundleStore deployment history for one rule scope, newest first.
+         */
+        get: operations["listPolicyBundleDeployments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/bundles/deployments/rollback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Roll back the active policy bundle deployment for a scope
+         * @description Restores the previous active (bundle, version) pair for the supplied scope and appends a rollback deployment marker.
+         */
+        post: operations["rollbackPolicyBundleDeployment"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1629,7 +2177,16 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Evaluate safety policy against a request */
+        /**
+         * Evaluate unified policy against a job or edge context
+         * @description Unified Policy Studio evaluator. New callers send
+         *     `PolicyEvaluateRequest` with either an inline `rule` or
+         *     `bundle_id` + `scope`, plus exactly one of `job_context` or
+         *     `edge_context`. During the migration window this endpoint also accepts
+         *     the legacy `PolicyCheckRequest` shape and returns the legacy
+         *     `PolicyCheckResponse` so existing clients keep working. Legacy-shape
+         *     responses include `Deprecation` and successor `Link` headers.
+         */
         post: operations["evaluatePolicy"];
         delete?: never;
         options?: never;
@@ -1646,8 +2203,43 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Explain policy evaluation reasoning */
+        /**
+         * Explain policy evaluation reasoning
+         * @deprecated
+         * @description Deprecated during the Policy Studio migration window. Use `POST /api/v1/policy/evaluate` with `PolicyEvaluateRequest`; this endpoint keeps the legacy `PolicyCheckRequest`/`PolicyCheckResponse` schema until the cut-over.
+         */
         post: operations["explainPolicy"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/global": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read the unified Global policy authority
+         * @description EDGE-052 — returns the five-section view of the Global policy
+         *     authority that all four evaluators (Cordum job, Edge action, MCP
+         *     tool, output scan) consult. Each section is a YAML SafetyPolicy
+         *     fragment persisted under a dedicated `secops/`-prefixed bundle key.
+         */
+        get: operations["getPolicyGlobal"];
+        /**
+         * Atomically update the unified Global policy authority
+         * @description EDGE-052 — atomically writes one or more sections of the Global
+         *     policy. Sections not present in the request body are left
+         *     unchanged. A `snapshot_version` field on the request acts as
+         *     optimistic concurrency: when non-empty and != the current
+         *     snapshot the request is rejected with 409 Conflict.
+         */
+        put: operations["updatePolicyGlobal"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1773,6 +2365,127 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/policy/shadows/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description Tilde-encoded bundle id; `/` in logical IDs (e.g. `secops/safety`)
+                 *     becomes `~` on the wire (`secops~safety`). The server decodes the
+                 *     tilde back to `/` before looking up the shadow.
+                 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Get the shadow policy for a bundle
+         * @description Returns the active shadow policy for `{id}` or 404 if none is set.
+         *     Requires `policy.read` (admin role bypasses). Dashboards translate
+         *     the 404 into an empty-state render rather than an error.
+         */
+        get: operations["getPolicyShadow"];
+        /**
+         * Activate or replace the shadow policy for a bundle
+         * @description PUT upserts the shadow policy for the given bundle. A bundle has at
+         *     most one shadow at a time; re-activating replaces the current one
+         *     in place. Validation matches `handlePutPolicyBundle` — malformed
+         *     YAML returns 400 before any Redis write.
+         */
+        put: operations["activatePolicyShadow"];
+        post?: never;
+        /**
+         * Remove the shadow policy for a bundle
+         * @description Deactivates the shadow. Emits a `safety.policy_change` audit event
+         *     with `action=shadow_deactivate` and the outgoing shadow's
+         *     `shadow_bundle_id` so the activate/deactivate pair correlates.
+         */
+        delete: operations["deletePolicyShadow"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/shadows/{id}/results/comparisons": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tilde-encoded bundle id (see `/api/v1/policy/shadows/{id}`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Paginated shadow-vs-active decision comparisons
+         * @description Returns individual shadow-eval entries with both the active verdict
+         *     and the shadow's would-be verdict. Paginates via Redis-stream
+         *     cursors; clients pass `next_cursor` back as `?cursor=` to resume.
+         *     `truncated_at_max=true` means the page ended because the scan hit
+         *     its budget before reaching `to`.
+         */
+        get: operations["getPolicyShadowResultsComparisons"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/shadows/{id}/results/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tilde-encoded bundle id (see `/api/v1/policy/shadows/{id}`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Aggregate shadow-evaluation counts over a time window
+         * @description Counts shadow-eval outcomes (escalated / relaxed / approval_differ /
+         *     unchanged) across the audit stream between `from` and `to`.
+         *     Memoised for 60 s per (tenant, bundle, window) so dashboard polling
+         *     doesn't thrash Redis XRANGE. Requires `policy.read`.
+         */
+        get: operations["getPolicyShadowResultsSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/policy/shadows/{id}/results/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tilde-encoded bundle id (see `/api/v1/policy/shadows/{id}`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Zero-filled bucketed timeseries of shadow outcomes
+         * @description Returns one row per bucket (including empty buckets) so the
+         *     dashboard chart shows gaps rather than stretching the last
+         *     observation. Bucket widths are a closed whitelist to prevent
+         *     fine-grained requests blowing out the 2000-bucket ceiling.
+         */
+        get: operations["getPolicyShadowResultsTimeseries"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/policy/simulate": {
         parameters: {
             query?: never;
@@ -1782,7 +2495,11 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Simulate policy evaluation (no side effects) */
+        /**
+         * Simulate policy evaluation (no side effects)
+         * @deprecated
+         * @description Deprecated during the Policy Studio migration window. Use `POST /api/v1/policy/evaluate` with `PolicyEvaluateRequest`; this endpoint keeps the legacy `PolicyCheckRequest`/`PolicyCheckResponse` schema until the cut-over.
+         */
         post: operations["simulatePolicy"];
         delete?: never;
         options?: never;
@@ -2711,11 +3428,68 @@ export interface components {
                 size_bytes?: number;
             };
         };
+        /**
+         * @description Records who created or last updated a Rule or Bundle. The `updated_*`
+         *     fields are zero-valued on first creation and populated by the first
+         *     subsequent edit.
+         */
+        AuditMetadata: {
+            /** Format: date-time */
+            created_at: string;
+            created_by: string;
+            /** Format: date-time */
+            updated_at?: string;
+            updated_by?: string;
+        };
+        AuditVerifyGap: {
+            /**
+             * Format: int64
+             * @description Sequence number where the gap or mismatch was observed.
+             */
+            at_seq: number;
+            /** @enum {string} */
+            type: "missing" | "out_of_order" | "hash_mismatch" | "retention_trimmed";
+        };
+        AuditVerifyResult: {
+            /**
+             * Format: int64
+             * @description First sequence number observed in the verified range.
+             */
+            first_seq?: number;
+            gaps: components["schemas"]["AuditVerifyGap"][];
+            /**
+             * Format: int64
+             * @description Last sequence number observed in the verified range.
+             */
+            last_seq?: number;
+            /**
+             * Format: int64
+             * @description Lowest sequence number still present in the retained stream.
+             */
+            retention_boundary_seq: number;
+            /**
+             * Format: double
+             * @description Configured audit retention window in hours.
+             */
+            retention_window_hours?: number;
+            /** @enum {string} */
+            status: "ok" | "compromised" | "partial";
+            /** @description Number of events walked in the requested range. */
+            total_events: number;
+            /** @description Number of events whose hash and linkage verified. */
+            verified_events: number;
+        };
         AuthConfig: {
             default_tenant?: string;
             oidc_client_id?: string;
             oidc_client_secret_masked?: string;
             oidc_enabled?: boolean;
+            /** @description Case-insensitive group name to Cordum role mapping. */
+            oidc_group_role_mapping?: {
+                [key: string]: "admin" | "operator" | "viewer";
+            };
+            /** @description OIDC claim containing IdP group names, defaulting to groups. */
+            oidc_groups_claim?: string;
             oidc_issuer?: string;
             oidc_login_url?: string;
             oidc_redirect_uri?: string;
@@ -2747,6 +3521,58 @@ export interface components {
             updated_at?: string;
             username?: string;
         };
+        /**
+         * @description Deployable set of rules with a deployment scope. Rules are referenced
+         *     by id rather than embedded so a bundle can rotate its members without
+         *     forcing rule duplication; the snapshot at deploy time lives in
+         *     `versions[].rule_snapshot` for tamper-evident rollback. Coexists
+         *     alongside the legacy PolicyBundleSummary schema.
+         */
+        Bundle: {
+            id: string;
+            metadata?: components["schemas"]["BundleMetadata"];
+            name: string;
+            rule_ids?: string[];
+            scope_binding: components["schemas"]["RuleScope"];
+            versions?: components["schemas"]["BundleVersion"][];
+        };
+        /** @description Audit-ready BundleStore binding event for one rule scope. */
+        BundleDeployment: {
+            action: components["schemas"]["BundleDeploymentAction"];
+            audit_hash?: string;
+            bundle_id: string;
+            /** Format: date-time */
+            deployed_at: string;
+            deployed_by?: string;
+            prev_bundle_id?: string;
+            prev_version?: string;
+            scope: components["schemas"]["RuleScope"];
+            version: string;
+        };
+        /** @enum {string} */
+        BundleDeploymentAction: "deploy" | "rollback";
+        /**
+         * @description Per-bundle authoring metadata that does not affect match/decide
+         *     payloads. `edge_mode` is the per-bundle enforcement posture for
+         *     edge-scoped bundles, replacing the legacy global EdgePolicyMode
+         *     switch.
+         */
+        BundleMetadata: {
+            edge_mode?: components["schemas"]["EdgeMode"];
+        };
+        /**
+         * @description Immutable record of a Bundle deploy. `rule_snapshot` captures the
+         *     full Rule contents at deploy time so rollback and audit do not depend
+         *     on the live rule store; `audit_hash` chains the version into the
+         *     audit chain.
+         */
+        BundleVersion: {
+            audit_hash?: string;
+            /** Format: date-time */
+            deployed_at: string;
+            rule_snapshot?: components["schemas"]["Rule"][];
+            version: string;
+        };
         ChangePasswordRequest: {
             /** Format: password */
             current_password: string;
@@ -2772,6 +3598,68 @@ export interface components {
             /** @enum {string} */
             scope?: "system" | "org" | "team" | "workflow" | "step";
             scope_id?: string;
+        };
+        CopilotMessage: {
+            content: string;
+            id: string;
+            jobIds?: string[];
+            /** @enum {string} */
+            role: "user" | "assistant" | "tool" | "system";
+            /** Format: date-time */
+            timestamp: string;
+        };
+        CopilotSession: {
+            /** Format: date-time */
+            createdAt: string;
+            id: string;
+            messages: components["schemas"]["CopilotMessage"][];
+            metadata?: {
+                [key: string]: string;
+            };
+            title?: string;
+            /** Format: date-time */
+            updatedAt: string;
+            userId: string;
+        };
+        CopilotSessionDecision: {
+            agentId?: string;
+            approvalDecision?: string;
+            approvalStatus?: string;
+            constraints?: {
+                [key: string]: unknown;
+            } | null;
+            jobId: string;
+            matchedRule?: string;
+            policyVersion?: string;
+            reason?: string;
+            ruleName?: string;
+            /** Format: date-time */
+            timestamp: string;
+            topic?: string;
+            verdict: string;
+        };
+        CopilotSessionDetailResponse: {
+            decisions: components["schemas"]["CopilotSessionDecision"][];
+            jobs: components["schemas"]["CopilotSessionJob"][];
+            session: components["schemas"]["CopilotSession"];
+            /** @description True when the backend capped jobs or decisions at 500 entries. */
+            truncated: boolean;
+        };
+        CopilotSessionJob: {
+            capabilities: string[];
+            /** Format: date-time */
+            createdAt?: string;
+            id: string;
+            metadata: {
+                [key: string]: string;
+            };
+            pool?: string;
+            riskTags: string[];
+            status: string;
+            topic?: string;
+            type?: string;
+            /** Format: date-time */
+            updatedAt?: string;
         };
         CreateAPIKeyRequest: {
             /** Format: date-time */
@@ -2807,6 +3695,40 @@ export interface components {
             tenant?: string;
             username: string;
         };
+        /**
+         * @description Unified evaluator output. A single Decision may aggregate multiple
+         *     rule evaluations via `trace`; `type` holds the final outcome the
+         *     evaluator derived from the trace. `source` distinguishes the
+         *     producing evaluator. `input_ref`/`output_ref` are pointers into the
+         *     blob store rather than embedded payloads.
+         */
+        Decision: {
+            audit_hash?: string;
+            bundle_id?: string;
+            bundle_version?: string;
+            input_ref?: string;
+            output_ref?: string;
+            rule_id: string;
+            source: components["schemas"]["DecisionSource"];
+            /** Format: date-time */
+            timestamp: string;
+            trace?: components["schemas"]["TraceStep"][];
+            type: components["schemas"]["DecisionType"];
+        };
+        /**
+         * @description Identifies which evaluator produced a Decision: the safetykernel job
+         *     pipeline (`job`) or the edge classifier path (`edge`).
+         * @enum {string}
+         */
+        DecisionSource: "job" | "edge";
+        /**
+         * @description Unified decision outcome emitted by either evaluator. The seven values
+         *     mirror the wire-format DecisionType enum in
+         *     cap/proto/cordum/agent/v1/safety.proto (epic-d9a6c0a1 appended
+         *     QUARANTINE and REDACT to the existing five values).
+         * @enum {string}
+         */
+        DecisionType: "allow" | "deny" | "require_human" | "throttle" | "allow_with_constraints" | "quarantine" | "redact";
         DelegationChainLink: {
             agent_id: string;
             /** Format: date-time */
@@ -2879,6 +3801,478 @@ export interface components {
             estimated_duration_sec?: number;
             steps?: components["schemas"]["RunStepStatus"][];
             warnings?: string[];
+        };
+        EdgeAgentActionEvent: {
+            action_name?: string;
+            agent_product?: string;
+            approval_ref?: string;
+            /** @description References to redacted external evidence artifacts. Large tool payloads/transcripts are represented here instead of inline raw event fields. */
+            artifact_ptrs?: components["schemas"]["EdgeArtifactPointer"][];
+            capability?: string;
+            /** @enum {string} */
+            decision: "ALLOW" | "DENY" | "REQUIRE_APPROVAL" | "THROTTLE" | "CONSTRAIN" | "RECORDED";
+            decision_reason?: string;
+            duration_ms?: number;
+            error_code?: string;
+            error_message?: string;
+            event_id: string;
+            execution_id: string;
+            /** @description Stable `sha256:` hash for the original input when available. */
+            input_hash?: string;
+            /** @description Bounded redacted input summary safe to persist and return. */
+            input_redacted?: {
+                [key: string]: unknown;
+            } | null;
+            /** @description Open-ended non-empty event kind such as `hook.pre_tool_use` or `mcp.tool.pre`. */
+            kind: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            /** @enum {string} */
+            layer: "hook" | "mcp" | "llm" | "runtime" | "workflow" | "system";
+            policy_snapshot?: string;
+            principal_id?: string;
+            risk_tags?: string[];
+            rule_id?: string;
+            seq: number;
+            session_id: string;
+            /** @enum {string} */
+            status: "ok" | "blocked" | "failed" | "degraded";
+            tenant_id: string;
+            tool_name?: string;
+            tool_use_id?: string;
+            /** Format: date-time */
+            ts: string;
+        };
+        EdgeAgentActionEventBatchRequest: {
+            events: components["schemas"]["EdgeAgentActionEventWriteRequest"][];
+        };
+        EdgeAgentActionEventBatchResponse: {
+            items?: components["schemas"]["EdgeAgentActionEvent"][];
+        };
+        EdgeAgentActionEventPageResponse: {
+            items?: components["schemas"]["EdgeAgentActionEvent"][];
+            next_cursor?: string | null;
+        };
+        /** @description Redacted event write payload. Do not send raw `tool_input`, `tool_result`, `raw_input`, `raw_transcript`, or `transcript` fields; large evidence belongs in `artifact_ptrs`. */
+        EdgeAgentActionEventWriteRequest: {
+            action_name?: string;
+            agent_product?: string;
+            approval_ref?: string;
+            /** @description References to redacted external artifacts for transcripts, tool inputs/results, diffs, or evidence bundles that are too large or sensitive for inline event storage. */
+            artifact_ptrs?: components["schemas"]["EdgeArtifactPointer"][];
+            capability?: string;
+            /** @enum {string} */
+            decision: "ALLOW" | "DENY" | "REQUIRE_APPROVAL" | "THROTTLE" | "CONSTRAIN" | "RECORDED";
+            decision_reason?: string;
+            duration_ms?: number;
+            error_code?: string;
+            error_message?: string;
+            event_id: string;
+            execution_id: string;
+            /** @description Optional stable hash. When `input_redacted` is present, the server derives a stable `sha256:` hash before persistence. */
+            input_hash?: string;
+            /** @description Bounded, redacted, client-safe input summary. Secrets and large raw payloads are rejected; store large evidence using `artifact_ptrs`. */
+            input_redacted?: {
+                [key: string]: unknown;
+            } | null;
+            /** @description Open-ended non-empty event kind such as `hook.pre_tool_use` or `mcp.tool.pre`. */
+            kind: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            /** @enum {string} */
+            layer: "hook" | "mcp" | "llm" | "runtime" | "workflow" | "system";
+            policy_snapshot?: string;
+            principal_id?: string;
+            risk_tags?: string[];
+            rule_id?: string;
+            /** @description Optional sequence number. Omit or set 0 for server assignment; explicit values must be the next sequence for the execution. */
+            seq?: number;
+            session_id: string;
+            /** @enum {string} */
+            status: "ok" | "blocked" | "failed" | "degraded";
+            /** @description Optional body tenant; when present it must match X-Tenant-ID. */
+            tenant_id?: string;
+            tool_name?: string;
+            tool_use_id?: string;
+            /** Format: date-time */
+            ts: string;
+        };
+        EdgeAgentExecution: {
+            /** @enum {string} */
+            adapter: "claude-code-hook" | "mcp-gateway" | "llm-proxy" | "runtime-sidecar" | "sdk-runner";
+            attempt?: number;
+            /** Format: date-time */
+            ended_at?: string | null;
+            execution_id: string;
+            job_id?: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            metrics?: components["schemas"]["EdgeExecutionMetrics"];
+            /** @enum {string} */
+            mode: "local-dev" | "enterprise-managed" | "workflow" | "ci" | "prod-runner";
+            policy_snapshot?: string;
+            session_id: string;
+            /** Format: date-time */
+            started_at: string;
+            /** @enum {string} */
+            status: "running" | "waiting_for_approval" | "succeeded" | "failed" | "cancelled" | "timeout" | "degraded";
+            step_id?: string;
+            tenant_id: string;
+            trace_id?: string;
+            worker_id?: string;
+            workflow_run_id?: string;
+        };
+        /** @description Tenant-scoped action approval bound to an Edge session/execution/event, action hash, and policy snapshot. Raw action/tool payloads are not stored here; use hashes and artifact pointers for evidence. */
+        EdgeApproval: {
+            /** @description Stable action hash. The raw action payload is not stored. */
+            action_hash: string;
+            approval_ref: string;
+            /**
+             * Format: date-time
+             * @description Set once an approved approval is atomically claimed by the agent retry path.
+             */
+            consumed_at?: string | null;
+            /** Format: date-time */
+            created_at: string;
+            /**
+             * @description Empty while pending; terminal decisions match status.
+             * @enum {string}
+             */
+            decision?: "" | "approve" | "reject" | "expire" | "invalidate";
+            event_id: string;
+            execution_id: string;
+            /** Format: date-time */
+            expires_at: string | null;
+            /** @description Stable hash of the redacted/bounded action input used for evidence correlation. */
+            input_hash: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            metadata?: {
+                [key: string]: string;
+            };
+            /** @description Redacted policy snapshot identifier; used to reject stale approvals. */
+            policy_snapshot: string;
+            /** @description Principal that requested the governed action. */
+            principal_id: string;
+            /** @description Trigger reason explaining why approval was required. */
+            reason: string;
+            /** @description Authenticated requester identity used for self-approval protection. */
+            requester: string;
+            /** @description Resolver-provided reason or system expiry reason for terminal records. */
+            resolution_reason?: string;
+            /** Format: date-time */
+            resolved_at?: string | null;
+            /** @description Display/audit identity for the resolver. */
+            resolved_by?: string;
+            /** @description Principal that approved/rejected/expired the approval. */
+            resolver_id?: string;
+            rule_id: string;
+            session_id: string;
+            /** @enum {string} */
+            status: "pending" | "approved" | "rejected" | "expired" | "invalidated";
+            tenant_id: string;
+        };
+        /** @description Human resolver note for approving or rejecting an Edge action approval. */
+        EdgeApprovalDecisionRequest: {
+            reason?: string;
+        };
+        EdgeApprovalPageResponse: {
+            items?: components["schemas"]["EdgeApproval"][];
+            next_cursor?: string | null;
+        };
+        /** @description Pointer to redacted evidence stored outside the event row. Its tenant/session/execution/event IDs must match the enclosing event, and the URI must be an internal artifact reference rather than a signed URL or token-bearing external URI. */
+        EdgeArtifactPointer: {
+            /** @enum {string} */
+            artifact_type: "edge.transcript" | "edge.diff" | "edge.tool_input" | "edge.tool_result" | "edge.evidence_bundle";
+            /** Format: date-time */
+            created_at: string;
+            event_id: string;
+            execution_id: string;
+            /** @enum {string} */
+            redaction_level: "standard" | "strict";
+            /** @enum {string} */
+            retention_class: "short" | "standard" | "audit";
+            session_id: string;
+            sha256: string;
+            tenant_id: string;
+            /** @description Internal artifact URI such as `artifact://...` or `edge-artifact://...`; signed URLs, query-string tokens, userinfo, fragments, and external HTTP(S) storage URLs are rejected before persistence. */
+            uri: string;
+        };
+        EdgeEndExecutionRequest: {
+            /** Format: date-time */
+            ended_at?: string;
+            /**
+             * @default succeeded
+             * @enum {string}
+             */
+            status: "succeeded" | "failed" | "cancelled" | "timeout";
+        };
+        EdgeEndSessionRequest: {
+            /** Format: date-time */
+            ended_at?: string;
+            /**
+             * @default ended
+             * @enum {string}
+             */
+            status: "ended" | "failed";
+        };
+        EdgeEnforcementLayers: {
+            [key: string]: boolean;
+        };
+        /** @description Standard error envelope for all `/api/v1/edge/*` routes. Messages and details are sanitized and must not echo raw tool payloads, API keys, signed URLs, or secrets. */
+        EdgeError: {
+            /**
+             * @description Stable machine-readable Edge error code.
+             * @example idempotency_conflict
+             * @enum {string}
+             */
+            code: "unauthorized" | "access_denied" | "tenant_required" | "tenant_mismatch" | "tenant_access_denied" | "missing_path_param" | "invalid_request" | "invalid_json" | "missing_required_field" | "not_found" | "request_too_large" | "service_unavailable" | "store_unavailable" | "internal_error" | "upstream_error" | "conflict" | "session_terminal" | "execution_terminal" | "execution_session_mismatch" | "raw_payload_rejected" | "artifact_pointer_invalid" | "approval_conflict" | "approval_not_actionable" | "self_approval_denied" | "idempotency_conflict" | "idempotency_key_invalid" | "idempotency_window_expired" | "max_executions_exceeded" | "event_cap_exceeded";
+            /** @description Optional sanitized structured details. */
+            details?: {
+                [key: string]: unknown;
+            };
+            /**
+             * @description Sanitized human-readable message.
+             * @example idempotency key already used with a different request
+             */
+            message: string;
+            /** @description Request correlation id from `X-Request-Id`/middleware. */
+            request_id: string;
+        };
+        /** @description Redacted Edge action evaluation request for an existing session/execution. Do not send raw `tool_input`, `tool_result`, `raw_input`, `raw_transcript`, or `transcript`; send bounded `input_redacted`/`tool_input_redacted` plus `artifact_ptrs`. */
+        EdgeEvaluateRequest: {
+            /** @description Optional client hint; ignored/overridden by the server-side classifier when derivable. */
+            action_name?: string;
+            agent_product?: string;
+            /**
+             * @description Optional override of the default 5-minute approval TTL when policy
+             *     returns REQUIRE_APPROVAL (EDGE-059). Bound to [1, 300] seconds
+             *     server-side; values outside this range or omitted use the 5-minute
+             *     default. Callers can ONLY shorten the TTL — values >300 are
+             *     silently capped at the default. Used by e2e tests that need to
+             *     exercise approval expiration inside a bounded sleep window.
+             * @example 2
+             */
+            approval_ttl_seconds?: number;
+            /** @description References to redacted external artifacts for large or sensitive evidence. */
+            artifact_ptrs?: components["schemas"]["EdgeArtifactPointer"][];
+            /** @description Optional client hint; ignored/overridden by the server-side classifier when derivable. */
+            capability?: string;
+            cwd?: string;
+            /** @description Optional caller-supplied event ID; omitted values are generated by the server. */
+            event_id?: string;
+            execution_id: string;
+            git_branch?: string;
+            git_remote?: string;
+            git_sha?: string;
+            /** @description Optional client hash. When redacted input is supplied, the server computes/overwrites the persisted `sha256:` hash from accepted redacted input. */
+            input_hash?: string;
+            /** @description Bounded, redacted action input. The server re-redacts and computes the persisted `input_hash`. */
+            input_redacted?: {
+                [key: string]: unknown;
+            } | null;
+            /** @description Non-empty Edge event kind such as `hook.pre_tool_use`. */
+            kind: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            /** @enum {string} */
+            layer: "hook" | "mcp" | "llm" | "runtime" | "workflow" | "system";
+            principal_id: string;
+            repo?: string;
+            /** @description Optional client hints. Server-side classifier output is authoritative. */
+            risk_tags?: string[];
+            session_id: string;
+            /** @description Optional body tenant; when present it must match X-Tenant-ID. */
+            tenant_id?: string;
+            /** @description Claude-hook-friendly alias for `input_hash`. */
+            tool_input_hash?: string;
+            /** @description Claude-hook-friendly alias for `input_redacted`. */
+            tool_input_redacted?: {
+                [key: string]: unknown;
+            } | null;
+            /** @description Hook tool name such as `Bash`; required for hook-layer tool evaluations. */
+            tool_name?: string;
+            tool_use_id?: string;
+        };
+        EdgeEvaluateResponse: {
+            /** @description Opaque approval reference from the Safety Kernel/approval integration. This endpoint does not create approval records. */
+            approval_ref?: string;
+            constraints?: {
+                [key: string]: unknown;
+            } | null;
+            /** @enum {string} */
+            decision: "ALLOW" | "DENY" | "REQUIRE_APPROVAL" | "THROTTLE" | "CONSTRAIN";
+            /** @description True when Safety was unavailable and the response follows policy-mode degraded behavior. */
+            degraded?: boolean;
+            /** @enum {string} */
+            error_code?: "safety_unavailable";
+            /** @description Sanitized bounded error guidance; upstream secret-bearing error strings are not returned. */
+            error_message?: string;
+            /** @description Persisted Edge decision/degraded event ID. */
+            event_id?: string;
+            /** @description Hook/terminal-friendly exit code; zero for allow-like responses and non-zero for deny/block guidance. */
+            exit_code: number;
+            /**
+             * @description Hook-friendly permission decision.
+             * @enum {string}
+             */
+            permission_decision: "allow" | "deny";
+            permission_decision_reason?: string;
+            policy_snapshot?: string;
+            reason?: string;
+            rule_id?: string;
+            terminal_message?: string;
+            terminal_title?: string;
+            timeout_ms?: number;
+            updated_input?: {
+                [key: string]: unknown;
+            } | null;
+            /** @enum {string} */
+            wait_strategy?: "manual_approval" | "backoff" | "retry";
+        };
+        /**
+         * @description Edge-side action snapshot for the unified evaluator. Raw tool input is
+         *     intentionally absent; callers provide only redacted input and labels.
+         */
+        EdgeEvaluationContext: {
+            agent_product?: string;
+            execution_id?: string;
+            input_hash?: string;
+            labels?: {
+                [key: string]: string;
+            };
+            principal_id: string;
+            risk_tags?: string[];
+            session_id?: string;
+            tenant_id: string;
+            tool_input_hash?: string;
+            tool_input_redacted?: {
+                [key: string]: unknown;
+            };
+            tool_name?: string;
+        };
+        EdgeExecutionCreateRequest: {
+            /** @enum {string} */
+            adapter?: "claude-code-hook" | "mcp-gateway" | "llm-proxy" | "runtime-sidecar" | "sdk-runner";
+            attempt?: number;
+            job_id?: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            /** @enum {string} */
+            mode?: "local-dev" | "enterprise-managed" | "workflow" | "ci" | "prod-runner";
+            /** @description Redacted policy snapshot identifier or summary; raw secrets are redacted before persistence/response. */
+            policy_snapshot?: string;
+            session_id: string;
+            step_id?: string;
+            /** @description Optional body tenant; when present it must match X-Tenant-ID. */
+            tenant_id?: string;
+            trace_id?: string;
+            worker_id?: string;
+            workflow_run_id?: string;
+        };
+        EdgeExecutionMetrics: {
+            allow?: number;
+            artifacts?: number;
+            deny?: number;
+            events?: number;
+            llm_cost_usd?: number;
+            require_approval?: number;
+        };
+        EdgeExecutionPageResponse: {
+            items?: components["schemas"]["EdgeAgentExecution"][];
+            next_cursor?: string | null;
+        };
+        EdgeHeartbeatResponse: {
+            heartbeat_alive: boolean;
+            session_id: string;
+        };
+        EdgeLabels: {
+            [key: string]: string;
+        };
+        /**
+         * @description Per-bundle enforcement posture for the edge evaluator. Migrates the
+         *     legacy global EdgePolicyMode switch onto bundle metadata so different
+         *     fleets and users can run at different modes simultaneously. See spec
+         *     cordum/docs/specs/policy-studio-rewrite.md "Edge bundle metadata".
+         * @enum {string}
+         */
+        EdgeMode: "observe" | "enforce" | "enterprise-strict";
+        EdgeRiskSummary: {
+            approval_count?: number;
+            artifact_count?: number;
+            denied_count?: number;
+            /** @enum {string} */
+            max_risk?: "low" | "medium" | "high" | "critical";
+        };
+        EdgeSession: {
+            agent_product?: string;
+            agent_version?: string;
+            cwd?: string;
+            device_id?: string;
+            /** Format: date-time */
+            ended_at?: string | null;
+            enforcement_layers?: components["schemas"]["EdgeEnforcementLayers"];
+            git_branch?: string;
+            git_remote?: string;
+            git_sha?: string;
+            host_id?: string;
+            job_id?: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            /** @enum {string} */
+            mode: "local-dev" | "enterprise-managed" | "workflow" | "ci" | "prod-runner";
+            /** @enum {string} */
+            policy_mode: "observe" | "enforce" | "enterprise-strict";
+            /** @description Redacted policy snapshot identifier or summary; raw secrets are redacted before persistence/response. */
+            policy_snapshot?: string;
+            principal_id?: string;
+            /** @enum {string} */
+            principal_type: "human" | "service" | "unknown";
+            repo?: string;
+            risk_summary: components["schemas"]["EdgeRiskSummary"];
+            session_id: string;
+            /** Format: date-time */
+            started_at: string;
+            /** @enum {string} */
+            status: "starting" | "running" | "waiting_for_approval" | "degraded" | "ended" | "failed";
+            tenant_id: string;
+            trace_id: string;
+            workflow_run_id?: string;
+        };
+        EdgeSessionCreateRequest: {
+            agent_product?: string;
+            agent_version?: string;
+            cwd?: string;
+            device_id?: string;
+            enforcement_layers?: components["schemas"]["EdgeEnforcementLayers"];
+            git_branch?: string;
+            git_remote?: string;
+            git_sha?: string;
+            host_id?: string;
+            job_id?: string;
+            labels?: components["schemas"]["EdgeLabels"];
+            /** @enum {string} */
+            mode?: "local-dev" | "enterprise-managed" | "workflow" | "ci" | "prod-runner";
+            /** @enum {string} */
+            policy_mode?: "observe" | "enforce" | "enterprise-strict";
+            /** @description Redacted policy snapshot identifier or summary; raw secrets are redacted before persistence/response. */
+            policy_snapshot?: string;
+            principal_id?: string;
+            /** @enum {string} */
+            principal_type?: "human" | "service" | "unknown";
+            repo?: string;
+            /** @description Optional body tenant; when present it must match X-Tenant-ID. */
+            tenant_id?: string;
+            trace_id?: string;
+            workflow_run_id?: string;
+        };
+        EdgeSessionCreateResponse: {
+            /** @description Relative dashboard URL for the Edge session. */
+            dashboard_url: string;
+            execution: components["schemas"]["EdgeAgentExecution"];
+            execution_id: string;
+            /** @description Redacted policy snapshot identifier or summary; raw secrets are redacted before persistence/response. */
+            policy_snapshot: string;
+            session: components["schemas"]["EdgeSession"];
+            session_id: string;
+            trace_id: string;
+        };
+        EdgeSessionPageResponse: {
+            items?: components["schemas"]["EdgeSession"][];
+            next_cursor?: string | null;
         };
         Error: {
             /** @description Human-readable error message */
@@ -2958,6 +4352,24 @@ export interface components {
         GenericObject: {
             [key: string]: unknown;
         };
+        GovernanceHealth: {
+            factors: {
+                [key: string]: components["schemas"]["GovernanceHealthFactor"];
+            };
+            /** Format: date-time */
+            generated_at: string;
+            /** @enum {string} */
+            grade: "A" | "B" | "C" | "D" | "F";
+            score: number;
+            truncated_at_max?: boolean;
+        };
+        GovernanceHealthFactor: {
+            notes?: string;
+            /** @description Factor-specific raw measurement payload. */
+            raw?: unknown;
+            score: number;
+            weight: number;
+        };
         /**
          * @description Pack-signature verification outcome computed by the gateway at
          *     install time. Never client-supplied — the gateway discards any
@@ -3025,6 +4437,34 @@ export interface components {
             /** Format: date-time */
             started_at?: string | null;
             trace_id?: string;
+        };
+        /**
+         * @description Job-side context for the unified evaluator. Used with input, output,
+         *     and velocity rules and dispatched to the safetykernel path.
+         */
+        JobEvaluationContext: {
+            capability?: string;
+            input?: components["schemas"]["JobEvaluationInput"];
+            job_id?: string;
+            labels?: {
+                [key: string]: string;
+            };
+            memory_id?: string;
+            principal_id?: string;
+            risk_tags?: string[];
+            tenant_id: string;
+            topic: string;
+            workflow_id?: string;
+        };
+        /**
+         * @description Job-side content snapshot evaluated by a unified job Rule. `content`
+         *     may be truncated by callers; `size_bytes` records the original size.
+         */
+        JobEvaluationInput: {
+            content?: string;
+            content_type?: string;
+            /** Format: int64 */
+            size_bytes?: number;
         };
         JobRecord: {
             actor_id?: string;
@@ -3171,6 +4611,17 @@ export interface components {
             transport?: "sse" | "stdio";
             uptime_seconds?: number;
         };
+        OIDCGroupRoleMappingUpdateRequest: {
+            /** @description JSON object mapping Okta/OIDC group names to Cordum roles. */
+            oidc_group_role_mapping: {
+                [key: string]: "admin" | "operator" | "viewer";
+            };
+            /**
+             * @description OIDC claim containing IdP group names.
+             * @default groups
+             */
+            oidc_groups_claim: string;
+        };
         OutputRule: {
             /** @enum {string} */
             action?: "BLOCK" | "REDACT" | "WARN" | "LOG";
@@ -3226,10 +4677,24 @@ export interface components {
             /** Format: date-time */
             timestamp?: string;
         };
+        PolicyBundleDeploymentHistoryResponse: {
+            items: components["schemas"]["BundleDeployment"][];
+            scope: components["schemas"]["RuleScope"];
+        };
+        PolicyBundleDeploymentResponse: {
+            deployment: components["schemas"]["BundleDeployment"];
+        };
+        PolicyBundleDeployRequest: {
+            scope: components["schemas"]["RuleScope"];
+            version: string;
+        };
         PolicyBundleDetail: components["schemas"]["PolicyBundleSummary"] & {
             /** @description Raw YAML content of the bundle */
             content?: string;
             rules?: components["schemas"]["PolicyRule"][];
+        };
+        PolicyBundleRollbackRequest: {
+            scope: components["schemas"]["RuleScope"];
         };
         PolicyBundleSummary: {
             author?: string;
@@ -3240,6 +4705,22 @@ export interface components {
             source?: string;
             /** Format: date-time */
             updated_at?: string;
+        };
+        /** @description Request to append an immutable BundleStore version. */
+        PolicyBundleVersionCreateRequest: {
+            audit_hash?: string;
+            /** Format: date-time */
+            deployed_at?: string;
+            rule_snapshot: components["schemas"]["Rule"][];
+            version: string;
+        };
+        PolicyBundleVersionResponse: {
+            bundle_id: string;
+            version: components["schemas"]["BundleVersion"];
+        };
+        PolicyBundleVersionsResponse: {
+            bundle_id: string;
+            items: components["schemas"]["BundleVersion"][];
         };
         PolicyCheckRequest: {
             capability?: string;
@@ -3265,6 +4746,52 @@ export interface components {
             evaluations?: components["schemas"]["SafetyDecision"][] | null;
             reason?: string;
             rule_id?: string | null;
+        };
+        /**
+         * @description Unified Policy Studio evaluator request. Provide either `rule` or
+         *     `bundle_id` + `scope`, and exactly one of `job_context` or
+         *     `edge_context`. Job contexts are valid for input/output/velocity
+         *     rules; edge contexts are valid only for edge rules.
+         */
+        PolicyEvaluateRequest: ({
+            bundle_id?: string;
+            edge_context?: components["schemas"]["EdgeEvaluationContext"];
+            job_context?: components["schemas"]["JobEvaluationContext"];
+            rule?: components["schemas"]["Rule"];
+            scope?: components["schemas"]["RuleScope"];
+        } | unknown | unknown) & (unknown | unknown);
+        /** @description Unified evaluator response containing the shared Decision. */
+        PolicyEvaluateResponse: {
+            decision: components["schemas"]["Decision"];
+        };
+        /**
+         * @description EDGE-052 — five-section view of the Global policy authority. The
+         *     snapshot_hash matches the cfg:&lt;sha&gt; identifier the kernel
+         *     propagates on policy decisions; clients pass it back on PUT for
+         *     optimistic concurrency.
+         */
+        PolicyGlobalDocument: {
+            /** @description Keyed by section name — input_rules, output_rules, edge_action_rules, mcp_tool_rules, invariants. */
+            sections?: {
+                [key: string]: components["schemas"]["PolicyGlobalSection"];
+            };
+            snapshot_hash?: string;
+            snapshot_version?: string;
+            /** Format: date-time */
+            updated_at?: string;
+        };
+        /**
+         * @description One section of the unified Global policy. The bundle_id is the
+         *     underlying configsvc key (e.g. `secops/global-input`,
+         *     `secops/invariants`). Empty content means no studio overrides
+         *     are authored for this section.
+         */
+        PolicyGlobalSection: {
+            bundle_id?: string;
+            /** @description YAML SafetyPolicy fragment for this section. */
+            content?: string;
+            enabled?: boolean;
+            sha256?: string;
         };
         PolicyReplayRequest: {
             candidate_bundle_id?: string;
@@ -3330,6 +4857,43 @@ export interface components {
             priority?: number;
             /** @description Bundle or file that defines this rule */
             source?: string;
+        };
+        /**
+         * @description Full stored representation of a shadow candidate policy. `content`
+         *     is the raw YAML source — consumers that only need to list shadows
+         *     may prefer the server-side summary projection (not exposed as a
+         *     separate endpoint today).
+         */
+        PolicyShadow: {
+            /**
+             * Format: date-time
+             * @description Bumped on each re-activation; equals `created_at` on the first.
+             */
+            activated_at: string;
+            /** @description Active bundle this shadow is tied to (one shadow per bundle). */
+            bundle_id: string;
+            /** @description Raw YAML source of the candidate policy. */
+            content: string;
+            /** Format: date-time */
+            created_at: string;
+            /** @description Principal ID that activated the shadow. */
+            created_by: string;
+            /** @description Arbitrary operator-supplied key/value pairs (e.g. ticket refs). */
+            metadata?: {
+                [key: string]: string;
+            };
+            /** @description Stable `shadow-<12 hex>` handle that persists across reactivation. */
+            shadow_bundle_id: string;
+            tenant_id: string;
+        };
+        /** @description PUT body for activating or replacing a shadow policy. */
+        PolicyShadowUpsertRequest: {
+            /** @description Raw YAML source of the candidate policy. Required. */
+            content: string;
+            /** @description Arbitrary operator-supplied key/value pairs; optional. */
+            metadata?: {
+                [key: string]: string;
+            };
         };
         PolicySnapshot: {
             author?: string;
@@ -3406,6 +4970,60 @@ export interface components {
             note?: string;
             snapshot_id: string;
         };
+        /**
+         * @description Unified authoring surface for both job-side and edge-side policy. The
+         *     envelope (id, name, type, scope, status, version, audit) is shared
+         *     across all rule types; type-specific match/decide payloads carry the
+         *     per-RuleType schema as free-form objects to preserve lossless
+         *     roundtrip with the Go json.RawMessage and protobuf
+         *     google.protobuf.Struct transport. Coexists alongside the legacy
+         *     OutputRule/VelocityRule schemas during the migration window.
+         */
+        Rule: {
+            audit: components["schemas"]["AuditMetadata"];
+            decide: {
+                [key: string]: unknown;
+            };
+            description?: string;
+            id: string;
+            match: {
+                [key: string]: unknown;
+            };
+            name: string;
+            scope: components["schemas"]["RuleScope"];
+            status: components["schemas"]["RuleStatus"];
+            type: components["schemas"]["RuleType"];
+            version: string;
+        };
+        /**
+         * @description Narrows where a rule (or bundle) applies. When `kind` is `global`,
+         *     `value` is unused and may be empty; for the other kinds, `value`
+         *     carries the corresponding identifier (tenant id, workflow id, edge
+         *     fleet name, edge user id).
+         */
+        RuleScope: {
+            kind: components["schemas"]["RuleScopeKind"];
+            value?: string;
+        };
+        /**
+         * @description Narrows where a rule (or bundle) applies. `global` covers an entire
+         *     deployment; `tenant`/`workflow` scope to job-side bindings;
+         *     `edge_fleet`/`edge_user` scope to edge-side bindings.
+         * @enum {string}
+         */
+        RuleScopeKind: "global" | "tenant" | "workflow" | "edge_fleet" | "edge_user";
+        /**
+         * @description Lifecycle state of a Rule. `draft` rules are author-only; `published`
+         *     rules participate in evaluation; `deprecated` rules remain queryable
+         *     for audit and rollback but are skipped by evaluators.
+         * @enum {string}
+         */
+        RuleStatus: "draft" | "published" | "deprecated";
+        /**
+         * @description Discriminator for a Rule's match/decide payload schema.
+         * @enum {string}
+         */
+        RuleType: "input" | "output" | "velocity" | "edge";
         RunDetail: components["schemas"]["RunSummary"] & {
             created_by?: string;
             dry_run?: boolean;
@@ -3477,6 +5095,88 @@ export interface components {
             schema: {
                 [key: string]: unknown;
             };
+        };
+        ShadowComparisonEntry: {
+            active_rule_id?: string;
+            active_verdict?: string;
+            agent_id?: string;
+            /** @enum {string} */
+            diff?: "escalated" | "relaxed" | "approval_differ" | "unchanged";
+            job_id?: string;
+            /** @description Shadow-evaluation latency in ms, stored as a string in the audit event Extra map. */
+            latency_ms?: string;
+            /** Format: int64 */
+            seq?: number;
+            shadow_bundle_id?: string;
+            shadow_rule_id?: string;
+            shadow_verdict?: string;
+            /** Format: int64 */
+            ts_ms?: number;
+        };
+        ShadowComparisonsResponse: {
+            entries: components["schemas"]["ShadowComparisonEntry"][];
+            /** @description Redis stream ID (`<ms>-<seq>`) to pass back as `?cursor=` for the next page. Empty when no more rows. */
+            next_cursor?: string;
+            truncated_at_max: boolean;
+        };
+        ShadowResultsSummary: {
+            /**
+             * Format: int64
+             * @description Both reached a terminal decision but differed on REQUIRE_APPROVAL.
+             */
+            approval_differ_count: number;
+            bundle_id: string;
+            /**
+             * Format: int64
+             * @description Shadow would have been stricter than active (e.g. DENY vs ALLOW).
+             */
+            escalated_count: number;
+            /** Format: int64 */
+            from_ms: number;
+            /**
+             * Format: int64
+             * @description Shadow would have been more permissive than active.
+             */
+            relaxed_count: number;
+            shadow_bundle_id?: string;
+            /** Format: int64 */
+            to_ms: number;
+            /** Format: int64 */
+            total_evaluated: number;
+            /** @description True when the scan hit its event budget before reaching `to_ms`. */
+            truncated_at_max: boolean;
+            /** Format: int64 */
+            unchanged_count: number;
+        };
+        ShadowTimeseriesBucket: {
+            /** Format: int64 */
+            approval_differ: number;
+            /** Format: int64 */
+            escalated: number;
+            /** Format: int64 */
+            relaxed: number;
+            /** Format: int64 */
+            total: number;
+            /**
+             * Format: int64
+             * @description Bucket start time (aligned down to the bucket boundary).
+             */
+            ts_ms: number;
+            /** Format: int64 */
+            unchanged: number;
+        };
+        ShadowTimeseriesResponse: {
+            /**
+             * @description Bucket width as the caller requested (e.g. `1m`, `5m`).
+             * @enum {string}
+             */
+            bucket: "1m" | "5m" | "15m" | "1h" | "1d";
+            buckets: components["schemas"]["ShadowTimeseriesBucket"][];
+            /** Format: int64 */
+            from_ms: number;
+            /** Format: int64 */
+            to_ms: number;
+            truncated_at_max: boolean;
         };
         StatusResponse: {
             build?: {
@@ -3606,11 +5306,45 @@ export interface components {
             risk_tags?: string[];
             status: string;
         };
+        /**
+         * @description Records one rule evaluation contributing to a Decision. Multiple
+         *     TraceSteps are emitted when a rule chain or bundle composition
+         *     produces a final decision through ordered evaluation. `constraints`
+         *     carries the raw constraints payload (e.g. the existing safetykernel
+         *     BudgetConstraints/SandboxProfile JSON) when the evaluator applied an
+         *     allow_with_constraints path; downstream consumers parse it per
+         *     RuleType.
+         */
+        TraceStep: {
+            bundle_id?: string;
+            constraints?: {
+                [key: string]: unknown;
+            };
+            decision_type: components["schemas"]["DecisionType"];
+            reason?: string;
+            rule_id: string;
+            /** Format: date-time */
+            timestamp: string;
+        };
         UpdatePolicyBundleRequest: {
             author?: string;
             content?: string;
             enabled?: boolean;
             message?: string;
+        };
+        UpdatePolicyGlobalRequest: {
+            author?: string;
+            message?: string;
+            /** @description Keyed by section name. Only listed sections are written; absent sections remain unchanged. */
+            sections: {
+                [key: string]: {
+                    /** @description YAML SafetyPolicy fragment. Empty content deletes the section's bundle. */
+                    content?: string;
+                    enabled?: boolean;
+                };
+            };
+            /** @description Optimistic concurrency token. When non-empty and != current snapshot, request is rejected with 409. */
+            snapshot_version?: string;
         };
         UpdateUserRequest: {
             display_name?: string;
@@ -3743,6 +5477,117 @@ export interface components {
                 "application/json": components["schemas"]["Error"];
             };
         };
+        /** @description Edge bad gateway — upstream service error */
+        EdgeBadGateway: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge bad request — invalid or missing parameters */
+        EdgeBadRequest: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge conflict — resource state or idempotency conflict */
+        EdgeConflict: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /**
+         * @description The target Edge execution already holds the maximum number of
+         *     AgentActionEvent rows allowed by the store (default 5000). End the
+         *     execution or start a new session to continue recording evidence. Error
+         *     envelope `code` is `event_cap_exceeded`.
+         */
+        EdgeEventCapExceeded: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge forbidden — insufficient permissions or tenant access denied */
+        EdgeForbidden: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge internal server error */
+        EdgeInternalServerError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /**
+         * @description The target Edge session already holds the maximum number of
+         *     AgentExecution rows allowed by the gateway. Configure the cap via
+         *     CORDUM_EDGE_MAX_EXECUTIONS_PER_SESSION; default 100. End the session
+         *     and start a new one to continue recording executions. Error envelope
+         *     `code` is `max_executions_exceeded`; `details` carries
+         *     `{limit, current}`.
+         */
+        EdgeMaxExecutionsExceeded: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge resource not found */
+        EdgeNotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge payload too large */
+        EdgePayloadTooLarge: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge service unavailable */
+        EdgeServiceUnavailable: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
+        /** @description Edge unauthorized — missing or invalid credentials */
+        EdgeUnauthorized: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["EdgeError"];
+            };
+        };
         /** @description Forbidden — insufficient permissions */
         Forbidden: {
             headers: {
@@ -3750,6 +5595,15 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Composite governance health score */
+        GovernanceHealthResponse: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["GovernanceHealth"];
             };
         };
         /** @description Internal server error */
@@ -3821,7 +5675,7 @@ export interface components {
     parameters: {
         ForceQ: boolean;
         HoldID: string;
-        /** @description Optional idempotency key for safe retries. */
+        /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
         IdempotencyKey: string;
         /** @description Job ID */
         JobID: string;
@@ -4837,7 +6691,7 @@ export interface operations {
                 limit?: number;
                 /** @description Inclusive lower bound on event time (unix ms) */
                 since?: number;
-                /** @description Tenant id (must match caller scope) */
+                /** @description Tenant id to verify; must match caller scope and defaults to the authenticated/request tenant. */
                 tenant?: string;
                 /** @description Inclusive upper bound on event time (unix ms) */
                 until?: number;
@@ -4857,22 +6711,14 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GenericObject"];
+                    "application/json": components["schemas"]["AuditVerifyResult"];
                 };
             };
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             500: components["responses"]["InternalServerError"];
-            /** @description Audit chainer not installed; integrity cannot be attested */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     getAuthConfig: {
@@ -5030,6 +6876,38 @@ export interface operations {
                 content?: never;
             };
             401: components["responses"]["Unauthorized"];
+        };
+    };
+    updateOIDCGroupRoleMapping: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OIDCGroupRoleMappingUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Sanitized authentication configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthConfig"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            500: components["responses"]["InternalServerError"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
     changeOwnPassword: {
@@ -5327,6 +7205,45 @@ export interface operations {
             500: components["responses"]["InternalServerError"];
         };
     };
+    getCopilotSession: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Copilot session detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CopilotSessionDetailResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+            /** @description Copilot session store is not wired yet */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     listDelegations: {
         parameters: {
             query?: {
@@ -5477,6 +7394,787 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             500: components["responses"]["InternalServerError"];
+        };
+    };
+    listEdgeApprovals: {
+        parameters: {
+            query?: {
+                /** @description Optional tuple filter; must be supplied with `session_id` and `execution_id`. */
+                action_hash?: string;
+                cursor?: string;
+                /** @description Optional tuple filter; must be supplied with `session_id` and `action_hash`. */
+                execution_id?: string;
+                limit?: number;
+                /** @description Optional tuple filter; must be supplied with `execution_id` and `action_hash`. */
+                session_id?: string;
+                status?: "pending" | "approved" | "rejected" | "expired" | "invalidated";
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge approval page scoped to the caller's principal unless the caller has admin/operator visibility. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeApprovalPageResponse"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    getEdgeApproval: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                approval_ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge approval */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeApproval"];
+                };
+            };
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            /** @description Edge approval not found, cross-tenant, or caller is not the original requester principal and lacks admin/operator role. The same not_found envelope is used to prevent tenant-insider enumeration of approval timing or decisions. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeError"];
+                };
+            };
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    approveEdgeApproval: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                approval_ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["EdgeApprovalDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description Approved Edge approval */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeApproval"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            /** @description Approval permission denied or self-approval rejected (`code=self_approval_denied`). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeError"];
+                };
+            };
+            404: components["responses"]["EdgeNotFound"];
+            409: components["responses"]["EdgeConflict"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            429: components["responses"]["EdgeEventCapExceeded"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    rejectEdgeApproval: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                approval_ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["EdgeApprovalDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description Rejected Edge approval */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeApproval"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            /** @description Approval permission denied or self-approval rejected (`code=self_approval_denied`). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeError"];
+                };
+            };
+            404: components["responses"]["EdgeNotFound"];
+            409: components["responses"]["EdgeConflict"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    waitEdgeApproval: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                approval_ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Caller-requested wait budget. Server clamps to a 5-minute max and uses a 30s default when omitted or non-positive. */
+                    timeout_ms?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Current Edge approval after the wait (resolved if approved/rejected/expired/invalidated; otherwise still pending). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeApproval"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            /** @description Edge approval not found, cross-tenant, or caller is not the original requester principal and lacks admin/operator role. The same not_found envelope is used to prevent tenant-insider enumeration of approval timing or decisions. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeError"];
+                };
+            };
+            409: components["responses"]["EdgeConflict"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    evaluateEdgeAction: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EdgeEvaluateRequest"];
+            };
+        };
+        responses: {
+            /** @description Hook-friendly Edge policy decision. Safety outages may still return 200 with `degraded=true` when policy mode permits and degraded evidence was persisted. */
+            200: {
+                headers: {
+                    /** @description Set to `true` during the migration window. */
+                    Deprecation?: string;
+                    /** @description Successor relation pointing to `/api/v1/policy/evaluate`. */
+                    Link?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeEvaluateResponse"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            409: components["responses"]["EdgeConflict"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            500: components["responses"]["EdgeInternalServerError"];
+            502: components["responses"]["EdgeBadGateway"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    createEdgeEvent: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EdgeAgentActionEventWriteRequest"];
+            };
+        };
+        responses: {
+            /** @description Edge event appended */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeAgentActionEvent"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            409: components["responses"]["EdgeConflict"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    createEdgeEventsBatch: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EdgeAgentActionEventBatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Edge events appended in input order */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeAgentActionEventBatchResponse"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            409: components["responses"]["EdgeConflict"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    listEdgeExecutions: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                job_id?: string;
+                limit?: number;
+                session_id?: string;
+                trace_id?: string;
+                workflow_run_id?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge execution page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeExecutionPageResponse"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    createEdgeExecution: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EdgeExecutionCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Edge execution created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeAgentExecution"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            429: components["responses"]["EdgeMaxExecutionsExceeded"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    getEdgeExecution: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge execution */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeAgentExecution"];
+                };
+            };
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    endEdgeExecution: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["EdgeEndExecutionRequest"];
+            };
+        };
+        responses: {
+            /** @description Ended Edge execution */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeAgentExecution"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    listEdgeExecutionEvents: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                decision?: "ALLOW" | "DENY" | "REQUIRE_APPROVAL" | "THROTTLE" | "CONSTRAIN" | "RECORDED";
+                /** @description Optional event kind filter; event kinds are open-ended non-empty strings such as `hook.pre_tool_use`. */
+                kind?: string;
+                limit?: number;
+                /** @description Inclusive lower timestamp bound. */
+                since?: string;
+                /** @description Inclusive upper timestamp bound. */
+                until?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                execution_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge event page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeAgentActionEventPageResponse"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    listEdgeSessions: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                limit?: number;
+                principal_id?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge session page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeSessionPageResponse"];
+                };
+            };
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    createEdgeSession: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EdgeSessionCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Edge session created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeSessionCreateResponse"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            409: components["responses"]["EdgeConflict"];
+            413: components["responses"]["EdgePayloadTooLarge"];
+            429: components["responses"]["EdgeEventCapExceeded"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    getEdgeSession: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge session */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeSession"];
+                };
+            };
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    endEdgeSession: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["EdgeEndSessionRequest"];
+            };
+        };
+        responses: {
+            /** @description Ended Edge session */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeSession"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    listEdgeSessionEvents: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                decision?: "ALLOW" | "DENY" | "REQUIRE_APPROVAL" | "THROTTLE" | "CONSTRAIN" | "RECORDED";
+                /** @description Optional event kind filter; event kinds are open-ended non-empty strings such as `hook.pre_tool_use`. */
+                kind?: string;
+                limit?: number;
+                /** @description Inclusive lower timestamp bound. */
+                since?: string;
+                /** @description Inclusive upper timestamp bound. */
+                until?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge event page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeAgentActionEventPageResponse"];
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    exportEdgeSession: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description Caps the number of events the bundle carries. When the
+                     *     session has more, `truncation.events_truncated = true`
+                     *     and `truncation.event_count` records the actual total.
+                     *     Values above 10000 are rejected with HTTP 400 +
+                     *     `code=max_events_too_large` (EDGE-065 request-validation
+                     *     bound). Values <= 0 fall back to the assembler default
+                     *     (5000).
+                     * @default 5000
+                     */
+                    max_events?: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Edge session export bundle */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** Format: date-time */
+                        generated_at: string;
+                        /** @example edge.export.v1 */
+                        manifest_version: string;
+                        /** @enum {string} */
+                        redaction_level?: "standard" | "strict";
+                        tenant_id: string;
+                    } & {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            400: components["responses"]["EdgeBadRequest"];
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            /** @description Bundle exceeds `CORDUM_EDGE_EXPORT_MAX_BYTES`; reduce `max_events` and retry. */
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeError"];
+                };
+            };
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
+        };
+    };
+    heartbeatEdgeSession: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Heartbeat refreshed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeHeartbeatResponse"];
+                };
+            };
+            401: components["responses"]["EdgeUnauthorized"];
+            403: components["responses"]["EdgeForbidden"];
+            404: components["responses"]["EdgeNotFound"];
+            500: components["responses"]["EdgeInternalServerError"];
+            503: components["responses"]["EdgeServiceUnavailable"];
         };
     };
     listEvalDatasets: {
@@ -6051,6 +8749,27 @@ export interface operations {
             503: components["responses"]["ServiceUnavailable"];
         };
     };
+    getGovernanceHealth: {
+        parameters: {
+            query?: {
+                /** @description Tenant id (must match caller scope) */
+                tenant?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["GovernanceHealthResponse"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
     healthCheckV1: {
         parameters: {
             query?: never;
@@ -6113,7 +8832,7 @@ export interface operations {
         parameters: {
             query?: never;
             header: {
-                /** @description Optional idempotency key for safe retries. */
+                /** @description Optional idempotency key for safe retries. Edge event create/batch scopes keys by tenant and endpoint, replays the first response for the same normalized request, and returns 409 `idempotency_conflict` if the same key is reused with a different normalized request. Callers SHOULD send a UUID (per the original Job submit contract); the Edge runtime additionally accepts any non-empty string up to 512 bytes for backward-compatible local-dev keys. */
                 "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
                 /** @description Tenant isolation header (required on all protected routes). */
                 "X-Tenant-ID": components["parameters"]["TenantID"];
@@ -7234,6 +9953,40 @@ export interface operations {
             500: components["responses"]["InternalServerError"];
         };
     };
+    deployPolicyBundleVersion: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyBundleDeployRequest"];
+            };
+        };
+        responses: {
+            /** @description Deployment record */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyBundleDeploymentResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
     simulatePolicyBundle: {
         parameters: {
             query?: never;
@@ -7267,6 +10020,163 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listPolicyBundleVersions: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Bundle versions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyBundleVersionsResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    createPolicyBundleVersion: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyBundleVersionCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Bundle version created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyBundleVersionResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getPolicyBundleVersion: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                id: string;
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Bundle version */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyBundleVersionResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    listPolicyBundleDeployments: {
+        parameters: {
+            query: {
+                limit?: number;
+                scope_kind: components["schemas"]["RuleScopeKind"];
+                scope_value?: string;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment history */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyBundleDeploymentHistoryResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    rollbackPolicyBundleDeployment: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyBundleRollbackRequest"];
+            };
+        };
+        responses: {
+            /** @description Rollback deployment record */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyBundleDeploymentResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             500: components["responses"]["InternalServerError"];
         };
@@ -7369,21 +10279,27 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["PolicyCheckRequest"];
+                "application/json": components["schemas"]["PolicyEvaluateRequest"] | components["schemas"]["PolicyCheckRequest"];
             };
         };
         responses: {
             /** @description Policy evaluation result */
             200: {
                 headers: {
+                    /** @description Present and set to `true` only when a legacy `PolicyCheckRequest` shape is evaluated. */
+                    Deprecation?: string;
+                    /** @description Successor relation pointing to `/api/v1/policy/evaluate` for legacy-shape callers. */
+                    Link?: string;
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PolicyCheckResponse"];
+                    "application/json": components["schemas"]["PolicyEvaluateResponse"] | components["schemas"]["PolicyCheckResponse"];
                 };
             };
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
             500: components["responses"]["InternalServerError"];
         };
     };
@@ -7406,6 +10322,10 @@ export interface operations {
             /** @description Explanation result */
             200: {
                 headers: {
+                    /** @description Set to `true` during the migration window. */
+                    Deprecation?: string;
+                    /** @description Successor relation pointing to `/api/v1/policy/evaluate`. */
+                    Link?: string;
                     [name: string]: unknown;
                 };
                 content: {
@@ -7414,6 +10334,69 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getPolicyGlobal: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unified Global policy snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyGlobalDocument"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    updatePolicyGlobal: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePolicyGlobalRequest"];
+            };
+        };
+        responses: {
+            /** @description Unified Global policy updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyGlobalDocument"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description snapshot_version mismatch (optimistic concurrency) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             500: components["responses"]["InternalServerError"];
         };
     };
@@ -7634,6 +10617,230 @@ export interface operations {
             500: components["responses"]["InternalServerError"];
         };
     };
+    getPolicyShadow: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                /**
+                 * @description Tilde-encoded bundle id; `/` in logical IDs (e.g. `secops/safety`)
+                 *     becomes `~` on the wire (`secops~safety`). The server decodes the
+                 *     tilde back to `/` before looking up the shadow.
+                 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shadow policy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyShadow"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    activatePolicyShadow: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                /**
+                 * @description Tilde-encoded bundle id; `/` in logical IDs (e.g. `secops/safety`)
+                 *     becomes `~` on the wire (`secops~safety`). The server decodes the
+                 *     tilde back to `/` before looking up the shadow.
+                 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyShadowUpsertRequest"];
+            };
+        };
+        responses: {
+            /** @description Shadow policy activated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyShadow"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            409: components["responses"]["Conflict"];
+            500: components["responses"]["InternalServerError"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    deletePolicyShadow: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                /**
+                 * @description Tilde-encoded bundle id; `/` in logical IDs (e.g. `secops/safety`)
+                 *     becomes `~` on the wire (`secops~safety`). The server decodes the
+                 *     tilde back to `/` before looking up the shadow.
+                 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shadow policy removed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            500: components["responses"]["InternalServerError"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getPolicyShadowResultsComparisons: {
+        parameters: {
+            query: {
+                /** @description Redis stream ID (`<ms>-<seq>`) returned as `next_cursor` from the previous page. */
+                cursor?: string;
+                /** @description Filter to one diff class (omit for all classes). */
+                diff?: "escalated" | "relaxed" | "approval_differ" | "unchanged" | "all";
+                /** @description Inclusive lower bound, unix milliseconds. */
+                from: number;
+                /** @description Page size. Default 50, maximum 500. */
+                limit?: number;
+                /** @description Exclusive upper bound, unix milliseconds (≤ 30 days after `from`). */
+                to: number;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                /** @description Tilde-encoded bundle id (see `/api/v1/policy/shadows/{id}`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated comparisons */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShadowComparisonsResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getPolicyShadowResultsSummary: {
+        parameters: {
+            query: {
+                /** @description Inclusive lower bound, unix milliseconds. */
+                from: number;
+                /** @description Exclusive upper bound, unix milliseconds. Must be strictly greater than `from`; the range cannot exceed 30 days. */
+                to: number;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                /** @description Tilde-encoded bundle id (see `/api/v1/policy/shadows/{id}`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShadowResultsSummary"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getPolicyShadowResultsTimeseries: {
+        parameters: {
+            query: {
+                /** @description Bucket width (closed whitelist). */
+                bucket: "1m" | "5m" | "15m" | "1h" | "1d";
+                /** @description Inclusive lower bound, unix milliseconds. */
+                from: number;
+                /** @description Exclusive upper bound, unix milliseconds (≤ 30 days after `from`). */
+                to: number;
+            };
+            header: {
+                /** @description Tenant isolation header (required on all protected routes). */
+                "X-Tenant-ID": components["parameters"]["TenantID"];
+            };
+            path: {
+                /** @description Tilde-encoded bundle id (see `/api/v1/policy/shadows/{id}`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Timeseries */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShadowTimeseriesResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
     simulatePolicy: {
         parameters: {
             query?: never;
@@ -7653,6 +10860,10 @@ export interface operations {
             /** @description Simulation result */
             200: {
                 headers: {
+                    /** @description Set to `true` during the migration window. */
+                    Deprecation?: string;
+                    /** @description Successor relation pointing to `/api/v1/policy/evaluate`. */
+                    Link?: string;
                     [name: string]: unknown;
                 };
                 content: {
@@ -9471,6 +12682,7 @@ export interface operations {
 }
 export enum ApiPaths {
     getAuthConfig = "/api/v1/auth/config",
+    updateOIDCGroupRoleMapping = "/api/v1/auth/oidc/group-role-mapping",
     login = "/api/v1/auth/login",
     getSession = "/api/v1/auth/session",
     logout = "/api/v1/auth/logout",
@@ -9483,6 +12695,27 @@ export enum ApiPaths {
     listAPIKeys = "/api/v1/auth/keys",
     createAPIKey = "/api/v1/auth/keys",
     deleteAPIKey = "/api/v1/auth/keys/{id}",
+    getCopilotSession = "/api/v1/copilot/sessions/{sessionId}",
+    createEdgeSession = "/api/v1/edge/sessions",
+    listEdgeSessions = "/api/v1/edge/sessions",
+    getEdgeSession = "/api/v1/edge/sessions/{session_id}",
+    heartbeatEdgeSession = "/api/v1/edge/sessions/{session_id}/heartbeat",
+    endEdgeSession = "/api/v1/edge/sessions/{session_id}/end",
+    listEdgeExecutions = "/api/v1/edge/executions",
+    createEdgeExecution = "/api/v1/edge/executions",
+    getEdgeExecution = "/api/v1/edge/executions/{execution_id}",
+    endEdgeExecution = "/api/v1/edge/executions/{execution_id}/end",
+    listEdgeApprovals = "/api/v1/edge/approvals",
+    getEdgeApproval = "/api/v1/edge/approvals/{approval_ref}",
+    approveEdgeApproval = "/api/v1/edge/approvals/{approval_ref}/approve",
+    waitEdgeApproval = "/api/v1/edge/approvals/{approval_ref}/wait",
+    rejectEdgeApproval = "/api/v1/edge/approvals/{approval_ref}/reject",
+    evaluateEdgeAction = "/api/v1/edge/evaluate",
+    createEdgeEvent = "/api/v1/edge/events",
+    createEdgeEventsBatch = "/api/v1/edge/events/batch",
+    listEdgeSessionEvents = "/api/v1/edge/sessions/{session_id}/events",
+    exportEdgeSession = "/api/v1/edge/sessions/{session_id}/export",
+    listEdgeExecutionEvents = "/api/v1/edge/executions/{execution_id}/events",
     submitJob = "/api/v1/jobs",
     listJobs = "/api/v1/jobs",
     getJob = "/api/v1/jobs/{id}",
@@ -9521,14 +12754,28 @@ export enum ApiPaths {
     listPolicyRules = "/api/v1/policy/rules",
     listOutputRules = "/api/v1/policy/output/rules",
     upsertOutputRule = "/api/v1/policy/output/rules/{id}",
+    getPolicyGlobal = "/api/v1/policy/global",
+    updatePolicyGlobal = "/api/v1/policy/global",
     listPolicyBundles = "/api/v1/policy/bundles",
+    listPolicyBundleDeployments = "/api/v1/policy/bundles/deployments",
+    rollbackPolicyBundleDeployment = "/api/v1/policy/bundles/deployments/rollback",
     getPolicyBundle = "/api/v1/policy/bundles/{id}",
     updatePolicyBundle = "/api/v1/policy/bundles/{id}",
     deletePolicyBundle = "/api/v1/policy/bundles/{id}",
+    listPolicyBundleVersions = "/api/v1/policy/bundles/{id}/versions",
+    createPolicyBundleVersion = "/api/v1/policy/bundles/{id}/versions",
+    getPolicyBundleVersion = "/api/v1/policy/bundles/{id}/versions/{version}",
+    deployPolicyBundleVersion = "/api/v1/policy/bundles/{id}/deploy",
     simulatePolicyBundle = "/api/v1/policy/bundles/{id}/simulate",
     listBundleSnapshots = "/api/v1/policy/bundles/snapshots",
     createBundleSnapshot = "/api/v1/policy/bundles/snapshots",
     getBundleSnapshot = "/api/v1/policy/bundles/snapshots/{id}",
+    activatePolicyShadow = "/api/v1/policy/shadows/{id}",
+    getPolicyShadow = "/api/v1/policy/shadows/{id}",
+    deletePolicyShadow = "/api/v1/policy/shadows/{id}",
+    getPolicyShadowResultsSummary = "/api/v1/policy/shadows/{id}/results/summary",
+    getPolicyShadowResultsComparisons = "/api/v1/policy/shadows/{id}/results/comparisons",
+    getPolicyShadowResultsTimeseries = "/api/v1/policy/shadows/{id}/results/timeseries",
     publishPolicy = "/api/v1/policy/publish",
     rollbackPolicy = "/api/v1/policy/rollback",
     getPolicyAudit = "/api/v1/policy/audit",
@@ -9620,6 +12867,7 @@ export enum ApiPaths {
     listDelegationsForAgent = "/api/v1/agents/{id}/delegations",
     listDelegations = "/api/v1/delegations",
     listGovernanceDecisions = "/api/v1/governance/decisions",
+    getGovernanceHealth = "/api/v1/governance/health",
     listMcpApprovals = "/api/v1/mcp/approvals",
     getMcpApproval = "/api/v1/mcp/approvals/{id}",
     approveMcpApproval = "/api/v1/mcp/approvals/{id}/approve",

--- a/tools/openapi-audit/main.go
+++ b/tools/openapi-audit/main.go
@@ -165,12 +165,16 @@ func collectRoutes(dir string) ([]Route, error) {
 // isDeprecatedOp returns true when an operation node declares
 // `deprecated: true`. The node is the mapping value under e.g. `get:`.
 func isDeprecatedOp(n *yaml.Node) bool {
+	return hasBoolField(n, "deprecated") && !hasBoolField(n, "x-live-route")
+}
+
+func hasBoolField(n *yaml.Node, key string) bool {
 	if n == nil || n.Kind != yaml.MappingNode {
 		return false
 	}
 	for i := 0; i+1 < len(n.Content); i += 2 {
-		if strings.ToLower(n.Content[i].Value) == "deprecated" &&
-			strings.ToLower(n.Content[i+1].Value) == "true" {
+		if strings.EqualFold(n.Content[i].Value, key) &&
+			strings.EqualFold(n.Content[i+1].Value, "true") {
 			return true
 		}
 	}

--- a/tools/openapi-audit/main_test.go
+++ b/tools/openapi-audit/main_test.go
@@ -291,7 +291,7 @@ paths:
 	}
 }
 
-func TestLoadSpecOps_DeprecatedOpsSkipped(t *testing.T) {
+func TestLoadSpecOps_DeprecatedOpsSkippedUnlessLiveRoute(t *testing.T) {
 	dir := t.TempDir()
 	specPath := filepath.Join(dir, "spec.yaml")
 	mustWrite(t, specPath, `
@@ -300,6 +300,11 @@ info: {title: t, version: "1"}
 paths:
   /live:
     get: {summary: live}
+  /live-deprecated:
+    get:
+      deprecated: true
+      x-live-route: true
+      summary: migration window
   /gone:
     get:
       deprecated: true
@@ -309,8 +314,8 @@ paths:
 	if err != nil {
 		t.Fatalf("loadSpecOps: %v", err)
 	}
-	if len(ops) != 1 || ops[0].Path != "/live" {
-		t.Fatalf("expected only /live to survive deprecated filter, got %+v", ops)
+	if len(ops) != 2 || ops[0].Path != "/live" || ops[1].Path != "/live-deprecated" {
+		t.Fatalf("expected /live and /live-deprecated to survive deprecated filter, got %+v", ops)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds unified `/api/v1/policy/evaluate` HTTP entrypoint and CAP gRPC `PolicyEvaluator.EvaluateUnified` for Policy Studio job/edge evaluations.
- Dispatches by `Rule.type`: job rules to safetykernel, edge rules to edge classifier, returning unified `policy.Decision` and emitting `policy.decision.v2` audit events.
- Keeps old endpoints live with deprecation metadata, adds real BundleStore lifecycle gateway handlers/OpenAPI, and documents the migration path.

## Stack / dependencies
- Base: `policy-studio-edge`.
- Includes merge of `origin/policy-studio-bundle-store` because Backend 2 BundleStore artifacts were not present on `policy-studio-edge`.
- Depends on CAP PR #47 (`feat/policy-studio-cross-sdk`) with commit `9d9d924` adding the `PolicyEvaluator` proto/service; this Cordum branch uses `replace github.com/cordum-io/cap/v2 => ../cap` for the stacked local build.

## Verification
- `make proto` EXIT=0.
- `make openapi` attempted via WSL and hit known WSL1/Windows Node issue; canonical fallback `./tools/scripts/gen_openapi.sh` EXIT=0, Redocly valid with 11 known warnings.
- `go build ./...` EXIT=0.
- `make test` EXIT=0.
- `go test -count=3 -timeout 240s ./core/controlplane/gateway/... ./core/policy/... ./core/audit/...` EXIT=0.
- `go test -count=3 -timeout 240s ./core/controlplane/safetykernel/... ./core/edge/...` EXIT=0.
- CAP `go test ./sdk/go/... -count=3` EXIT=0.
- `npm run generate` + `npm run check:generated` in `sdk/typescript` EXIT=0.
- `git diff --check` / staged diff check EXIT=0 (only autocrlf warnings).

## DoD evidence
- DoD #1: `/api/v1/policy/evaluate` dispatch + gRPC `PolicyEvaluator.EvaluateUnified` implemented and documented.
- DoD #2: job dispatch to safetykernel and edge dispatch to classifier covered by HTTP/gRPC tests.
- DoD #3: unified Decision responses + `policy.decision.v2` audit chain covered by tests.
- DoD #4: legacy policy/edge endpoints kept live with deprecation headers/OpenAPI/CHANGELOG.
- DoD #5: integration tests cover both job and edge paths plus validation/auth/bundle resolution.