### PR TITLE
feat(pack,safetykernel): metadata.aliases + constraints additive-extension (Backend 6, task-e4e9489c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+#### Backend 6 — pack `metadata.aliases` + safety-policy `constraints` extensions (2026-05-10, task-e4e9489c)
+
+- **Pack manifest**: `metadata.aliases: []string` is now optional and additive. When set, topic / pools-patch / timeouts-patch namespace checks accept `job.<id>.*` AND `job.<alias>.*` for each declared alias. Regex `^[a-z][a-z0-9_-]{1,30}$`, max 8 entries, duplicates rejected. Unblocks the CordClaw pack owning `job.openclaw.*` topics under `metadata.id: cordclaw` (task-1e446868). Existing packs without aliases keep validating under the strict prefix rule. See `docs/operations/pack-aliases.md`.
+- **Safety-policy `constraints`** schema (`core/infra/config/schema/safety_policy.schema.json`) now permits three additional fields under `rule.constraints`:
+  - `max_output_bytes` (integer, 0–16 777 216 / 16 MiB upper bound enforced to prevent OOM via misconfigured large outputs).
+  - `allowed_destinations` ([]string — write-target allowlist).
+  - `redact_patterns` ([]string — regex patterns redacted before downstream emission).
+  Schema retains `additionalProperties: false`; typos still fail. Existing policy fragments without these fields validate unchanged. See `docs/operations/safetykernel-constraints.md`.
+- Both changes are additive only — no schema-version bump on either surface. CLI + gateway validators (`cmd/cordumctl/pack.go`, `core/controlplane/gateway/packs/validate.go`) are mirror-updated; pools-patch and timeouts-patch validators thread aliases through. Sibling invariants (pack-id regex, schema-id prefix, workflow-id prefix, pool-name prefix) are unchanged — only the topic namespace check honors aliases. Tests cover alias regex, count cap, duplicates, back-compat, and the new constraint bounds.
+
 #### Cordum Edge P0 (2026-04-30)
 
 EDGE epic shipped 32 P0 tasks for the Compliance Firewall surface — local

--- a/cmd/cordumctl/pack.go
+++ b/cmd/cordumctl/pack.go
@@ -52,10 +52,10 @@ type packManifest struct {
 }
 
 type packMetadata struct {
-	ID          string   `yaml:"id"`
-	Version     string   `yaml:"version"`
-	Title       string   `yaml:"title"`
-	Description string   `yaml:"description"`
+	ID          string `yaml:"id"`
+	Version     string `yaml:"version"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
 	// Aliases declares additional namespace identifiers this pack owns,
 	// in addition to ID. When set, topic/pools-patch namespace checks
 	// accept `job.<id>.*` AND `job.<alias>.*` for each alias. Each alias
@@ -143,16 +143,16 @@ type packPolicySimulationRequest struct {
 }
 
 type packRecord struct {
-	ID           string                   `json:"id"`
-	Version      string                   `json:"version"`
-	Status       string                   `json:"status"`
-	InstalledAt  string                   `json:"installed_at,omitempty"`
-	InstalledBy  string                   `json:"installed_by,omitempty"`
-	Manifest     packRecordManifest       `json:"manifest,omitempty"`
-	Resources    packRecordResources      `json:"resources,omitempty"`
-	Overlays     packRecordOverlays       `json:"overlays,omitempty"`
-	Tests        packTests                `json:"tests,omitempty"`
-	Verification *packRecordVerification  `json:"verification,omitempty"`
+	ID           string                  `json:"id"`
+	Version      string                  `json:"version"`
+	Status       string                  `json:"status"`
+	InstalledAt  string                  `json:"installed_at,omitempty"`
+	InstalledBy  string                  `json:"installed_by,omitempty"`
+	Manifest     packRecordManifest      `json:"manifest,omitempty"`
+	Resources    packRecordResources     `json:"resources,omitempty"`
+	Overlays     packRecordOverlays      `json:"overlays,omitempty"`
+	Tests        packTests               `json:"tests,omitempty"`
+	Verification *packRecordVerification `json:"verification,omitempty"`
 }
 
 // packRecordVerification is the on-the-wire shape the gateway persists
@@ -345,6 +345,14 @@ func runPackInstall(args []string) error {
 	if *dryRun {
 		fmt.Printf("pack %s %s: dry-run\n", manifest.Metadata.ID, manifest.Metadata.Version)
 		return nil
+	}
+
+	installed, _, err := loadPackRegistry(ctx, client)
+	if err != nil {
+		return fmt.Errorf("load pack registry: %w", err)
+	}
+	if err := validatePackAliasOwnership(manifest.Metadata.ID, manifest.Metadata.Aliases, manifest.Topics, installed); err != nil {
+		return err
 	}
 
 	rollback := func(installErr error) error {
@@ -862,6 +870,95 @@ func validatePackAliases(aliases []string) error {
 		seen[alias] = struct{}{}
 	}
 	return nil
+}
+
+// validatePackAliasOwnership rejects namespace hijacks before install. Alias
+// syntax alone is insufficient because an alias grants authority over
+// job.<alias>.* topics; it must not collide with another installed pack id,
+// another installed alias, or topics that another pack already registered.
+func validatePackAliasOwnership(packID string, aliases []string, topics []packTopic, installed map[string]packRecord) error {
+	packID = strings.TrimSpace(packID)
+	if packID == "" {
+		return errors.New("metadata.id required")
+	}
+	candidateNamespaces := map[string]struct{}{packID: {}}
+	for _, alias := range aliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		if alias == packID {
+			return fmt.Errorf("metadata.aliases: %q duplicates metadata.id", alias)
+		}
+		candidateNamespaces[alias] = struct{}{}
+	}
+
+	for namespace, owner := range installedPackNamespaceOwners(installed, packID) {
+		if _, requested := candidateNamespaces[namespace]; requested {
+			return fmt.Errorf("metadata.aliases: namespace %q is already owned by installed pack %q", namespace, owner)
+		}
+	}
+
+	prefixes := packTopicPrefixes(packID, aliases)
+	candidateTopics := make(map[string]struct{}, len(topics))
+	for _, topic := range topics {
+		name := strings.TrimSpace(topic.Name)
+		if name != "" {
+			candidateTopics[name] = struct{}{}
+		}
+	}
+	for key, record := range installed {
+		owner := packRecordOwnerID(key, record)
+		if owner == "" || owner == packID {
+			continue
+		}
+		for _, topic := range record.Manifest.Topics {
+			name := strings.TrimSpace(topic.Name)
+			if name == "" {
+				continue
+			}
+			if _, exact := candidateTopics[name]; exact || hasAnyPrefix(name, prefixes) {
+				return fmt.Errorf("topic %q is already owned by installed pack %q", name, owner)
+			}
+		}
+	}
+	return nil
+}
+
+func installedPackNamespaceOwners(installed map[string]packRecord, currentPackID string) map[string]string {
+	owners := map[string]string{}
+	for key, record := range installed {
+		owner := packRecordOwnerID(key, record)
+		if owner == "" || owner == currentPackID {
+			continue
+		}
+		addNamespaceOwner(owners, strings.TrimSpace(key), owner)
+		addNamespaceOwner(owners, strings.TrimSpace(record.ID), owner)
+		addNamespaceOwner(owners, strings.TrimSpace(record.Manifest.Metadata.ID), owner)
+		for _, alias := range record.Manifest.Metadata.Aliases {
+			addNamespaceOwner(owners, strings.TrimSpace(alias), owner)
+		}
+	}
+	return owners
+}
+
+func packRecordOwnerID(key string, record packRecord) string {
+	if id := strings.TrimSpace(record.ID); id != "" {
+		return id
+	}
+	if id := strings.TrimSpace(record.Manifest.Metadata.ID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(key)
+}
+
+func addNamespaceOwner(owners map[string]string, namespace, owner string) {
+	if namespace == "" || owner == "" {
+		return
+	}
+	if _, exists := owners[namespace]; !exists {
+		owners[namespace] = owner
+	}
 }
 
 // packTopicPrefixes returns the set of "job.<x>." prefixes a pack may use

--- a/cmd/cordumctl/pack.go
+++ b/cmd/cordumctl/pack.go
@@ -52,10 +52,16 @@ type packManifest struct {
 }
 
 type packMetadata struct {
-	ID          string `yaml:"id"`
-	Version     string `yaml:"version"`
-	Title       string `yaml:"title"`
-	Description string `yaml:"description"`
+	ID          string   `yaml:"id"`
+	Version     string   `yaml:"version"`
+	Title       string   `yaml:"title"`
+	Description string   `yaml:"description"`
+	// Aliases declares additional namespace identifiers this pack owns,
+	// in addition to ID. When set, topic/pools-patch namespace checks
+	// accept `job.<id>.*` AND `job.<alias>.*` for each alias. Each alias
+	// must match `^[a-z][a-z0-9_-]{1,30}$`; max 8 entries. Existing packs
+	// that omit this field keep validating under the strict prefix rule.
+	Aliases []string `yaml:"aliases,omitempty"`
 }
 
 type packCompatibility struct {
@@ -373,7 +379,7 @@ func runPackInstall(args []string) error {
 		if shouldSkipConfigOverlay(*inactive, overlay) {
 			continue
 		}
-		applied, err := applyConfigOverlay(ctx, client, overlay, manifest.Metadata.ID, bundle.Dir)
+		applied, err := applyConfigOverlay(ctx, client, overlay, manifest.Metadata.ID, manifest.Metadata.Aliases, bundle.Dir)
 		if err != nil {
 			return rollback(err)
 		}
@@ -818,6 +824,88 @@ func loadPackManifest(dir string) (*packManifest, error) {
 	return &manifest, nil
 }
 
+// packAliasPattern bounds the alias namespace: leading lower-case letter,
+// followed by lower-case alnum / hyphen / underscore, up to 31 chars total.
+// Tight on purpose — prevents namespace squatting by forcing distinct,
+// auditable identifiers per alias declaration.
+var packAliasPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{1,30}$`)
+
+// maxPackAliases caps the number of alias entries a single pack may
+// declare. Eight is enough for legitimate "this pack owns sibling
+// namespaces" cases (e.g., cordclaw → openclaw) without enabling broad
+// namespace fan-out.
+const maxPackAliases = 8
+
+// validatePackAliases enforces the alias regex + cap. Returns nil when
+// the slice is empty; called from validatePackManifest before any topic
+// or pool prefix check so an alias typo fails install-time, not
+// emit-time.
+func validatePackAliases(aliases []string) error {
+	if len(aliases) == 0 {
+		return nil
+	}
+	if len(aliases) > maxPackAliases {
+		return fmt.Errorf("metadata.aliases: at most %d entries allowed, got %d", maxPackAliases, len(aliases))
+	}
+	seen := make(map[string]struct{}, len(aliases))
+	for _, alias := range aliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			return errors.New("metadata.aliases: empty alias not allowed")
+		}
+		if !packAliasPattern.MatchString(alias) {
+			return fmt.Errorf("metadata.aliases: %q must match %s", alias, packAliasPattern.String())
+		}
+		if _, dup := seen[alias]; dup {
+			return fmt.Errorf("metadata.aliases: duplicate entry %q", alias)
+		}
+		seen[alias] = struct{}{}
+	}
+	return nil
+}
+
+// packTopicPrefixes returns the set of "job.<x>." prefixes a pack may use
+// for its topics. Always includes "job.<id>."; each declared alias adds
+// "job.<alias>.". Callers iterate over the slice with HasPrefix; the slice
+// is small (<=9 entries given maxPackAliases) so linear scan is fine.
+func packTopicPrefixes(id string, aliases []string) []string {
+	prefixes := make([]string, 0, 1+len(aliases))
+	prefixes = append(prefixes, "job."+id+".")
+	for _, alias := range aliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		prefixes = append(prefixes, "job."+alias+".")
+	}
+	return prefixes
+}
+
+// hasAnyPrefix reports whether s starts with any prefix in the slice.
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// formatPrefixList formats a slice of `job.<x>.` prefixes for error
+// messages. Single prefix → `job.<x>.*`; multiple → `job.<a>.* or
+// job.<b>.* ...` so operators can see exactly which namespaces are
+// allowed. Glob suffix is added inline since errors mention `.*` patterns.
+func formatPrefixList(prefixes []string) string {
+	parts := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
+		parts[i] = prefix + "*"
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return strings.Join(parts, " or ")
+}
+
 func validatePackManifest(manifest *packManifest) error {
 	if manifest == nil {
 		return errors.New("pack manifest required")
@@ -829,6 +917,9 @@ func validatePackManifest(manifest *packManifest) error {
 	idPattern := regexp.MustCompile(`^[a-z0-9-]+$`)
 	if !idPattern.MatchString(id) {
 		return fmt.Errorf("metadata.id must match %s", idPattern.String())
+	}
+	if err := validatePackAliases(manifest.Metadata.Aliases); err != nil {
+		return err
 	}
 	if strings.TrimSpace(manifest.Metadata.Version) == "" {
 		return errors.New("metadata.version required")
@@ -843,12 +934,13 @@ func validatePackManifest(manifest *packManifest) error {
 			return fmt.Errorf("compatibility.maxCoreVersion must be semver: %q", maxVersion)
 		}
 	}
+	topicPrefixes := packTopicPrefixes(id, manifest.Metadata.Aliases)
 	for _, topic := range manifest.Topics {
 		if topic.Name == "" {
 			return errors.New("topic name required")
 		}
-		if !strings.HasPrefix(topic.Name, "job."+id+".") {
-			return fmt.Errorf("topic %q must be namespaced under job.%s.*", topic.Name, id)
+		if !hasAnyPrefix(topic.Name, topicPrefixes) {
+			return fmt.Errorf("topic %q must be namespaced under %s", topic.Name, formatPrefixList(topicPrefixes))
 		}
 	}
 	schemaIDs := make(map[string]struct{}, len(manifest.Resources.Schemas))
@@ -1137,7 +1229,7 @@ func topicPoolMappingsFromConfig(doc *configDoc) (map[string]string, error) {
 	return poolsCfg.TopicToPool(), nil
 }
 
-func applyConfigOverlay(ctx context.Context, client *restClient, overlay packConfigOverlay, packID, dir string) (appliedConfigChange, error) {
+func applyConfigOverlay(ctx context.Context, client *restClient, overlay packConfigOverlay, packID string, packAliases []string, dir string) (appliedConfigChange, error) {
 	key := strings.TrimSpace(overlay.Key)
 	if key == "" {
 		return appliedConfigChange{}, errors.New("config overlay key required")
@@ -1173,7 +1265,7 @@ func applyConfigOverlay(ctx context.Context, client *restClient, overlay packCon
 		doc.Data = map[string]any{}
 	}
 	current := normalizeJSON(doc.Data[key])
-	if err := validateConfigPatch(key, patchMap, packID, current); err != nil {
+	if err := validateConfigPatch(key, patchMap, packID, packAliases, current); err != nil {
 		return appliedConfigChange{}, fmt.Errorf("apply config overlay %s: %w", overlay.Name, err)
 	}
 	before := deepCopy(current)
@@ -1644,18 +1736,19 @@ func loadPatchFile(dir, relPath string) (any, error) {
 	return data, nil
 }
 
-func validateConfigPatch(key string, patch map[string]any, packID string, current any) error {
+func validateConfigPatch(key string, patch map[string]any, packID string, packAliases []string, current any) error {
 	switch strings.ToLower(key) {
 	case "pools":
-		return validatePoolsPatch(patch, packID, current)
+		return validatePoolsPatch(patch, packID, packAliases, current)
 	case "timeouts":
-		return validateTimeoutsPatch(patch, packID)
+		return validateTimeoutsPatch(patch, packID, packAliases)
 	default:
 		return fmt.Errorf("unsupported config overlay key %q", key)
 	}
 }
 
-func validatePoolsPatch(patch map[string]any, packID string, current any) error {
+func validatePoolsPatch(patch map[string]any, packID string, packAliases []string, current any) error {
+	topicPrefixes := packTopicPrefixes(packID, packAliases)
 	rawTopics := normalizeJSON(patch["topics"])
 	if rawTopics != nil {
 		topics, ok := rawTopics.(map[string]any)
@@ -1663,8 +1756,8 @@ func validatePoolsPatch(patch map[string]any, packID string, current any) error 
 			return errors.New("pools.topics must be a map")
 		}
 		for topic := range topics {
-			if !strings.HasPrefix(topic, "job."+packID+".") {
-				return fmt.Errorf("pools topic %q must be namespaced under job.%s.*", topic, packID)
+			if !hasAnyPrefix(topic, topicPrefixes) {
+				return fmt.Errorf("pools topic %q must be namespaced under %s", topic, formatPrefixList(topicPrefixes))
 			}
 		}
 	}
@@ -1709,7 +1802,8 @@ func extractPools(current any) map[string]struct{} {
 	return out
 }
 
-func validateTimeoutsPatch(patch map[string]any, packID string) error {
+func validateTimeoutsPatch(patch map[string]any, packID string, packAliases []string) error {
+	topicPrefixes := packTopicPrefixes(packID, packAliases)
 	rawTopics := normalizeJSON(patch["topics"])
 	if rawTopics != nil {
 		topics, ok := rawTopics.(map[string]any)
@@ -1717,8 +1811,8 @@ func validateTimeoutsPatch(patch map[string]any, packID string) error {
 			return errors.New("timeouts.topics must be a map")
 		}
 		for topic := range topics {
-			if !strings.HasPrefix(topic, "job."+packID+".") {
-				return fmt.Errorf("timeouts topic %q must be namespaced under job.%s.*", topic, packID)
+			if !hasAnyPrefix(topic, topicPrefixes) {
+				return fmt.Errorf("timeouts topic %q must be namespaced under %s", topic, formatPrefixList(topicPrefixes))
 			}
 		}
 	}

--- a/cmd/cordumctl/pack_aliases_test.go
+++ b/cmd/cordumctl/pack_aliases_test.go
@@ -9,12 +9,12 @@ import (
 // behavior on the happy path.
 func TestValidatePackAliasesAcceptsValidEntries(t *testing.T) {
 	cases := [][]string{
-		nil,                            // back-compat: no aliases is valid
-		{},                             // empty slice is valid
-		{"openclaw"},                   // single, plain lowercase
-		{"openclaw", "alt-pack"},       // hyphen
-		{"aa", "alt_pack"},             // 2-char min + underscore
-		{"a1", "alt-pack_v2"},          // digits + mix
+		nil,                      // back-compat: no aliases is valid
+		{},                       // empty slice is valid
+		{"openclaw"},             // single, plain lowercase
+		{"openclaw", "alt-pack"}, // hyphen
+		{"aa", "alt_pack"},       // 2-char min + underscore
+		{"a1", "alt-pack_v2"},    // digits + mix
 		{"a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8"}, // exactly maxPackAliases
 	}
 	for _, aliases := range cases {
@@ -30,13 +30,13 @@ func TestValidatePackAliasesRejectsMalformed(t *testing.T) {
 		alias string
 		want  string
 	}{
-		{"Openclaw", "must match"},     // uppercase rejected
-		{"open!claw", "must match"},    // symbol rejected
-		{"1openclaw", "must match"},    // leading digit rejected
-		{"-openclaw", "must match"},    // leading hyphen rejected
-		{"_openclaw", "must match"},    // leading underscore rejected
-		{"open claw", "must match"},    // space rejected
-		{"", "empty alias"},            // empty rejected
+		{"Openclaw", "must match"},              // uppercase rejected
+		{"open!claw", "must match"},             // symbol rejected
+		{"1openclaw", "must match"},             // leading digit rejected
+		{"-openclaw", "must match"},             // leading hyphen rejected
+		{"_openclaw", "must match"},             // leading underscore rejected
+		{"open claw", "must match"},             // space rejected
+		{"", "empty alias"},                     // empty rejected
 		{strings.Repeat("a", 32), "must match"}, // 32 chars (max is 31)
 	}
 	for _, tc := range cases {
@@ -116,6 +116,90 @@ func TestValidatePackManifestAcceptsAliasedTopics(t *testing.T) {
 	}
 	if err := validatePackManifest(mfWrongAlias); err == nil || !strings.Contains(err.Error(), "must be namespaced under") {
 		t.Errorf("validatePackManifest(cordbar topic) = %v; want namespace error", err)
+	}
+}
+
+func TestValidatePackAliasOwnershipRejectsInstalledNamespaceCollisions(t *testing.T) {
+	installed := map[string]packRecord{
+		"openclaw": {
+			ID: "openclaw",
+			Manifest: packRecordManifest{
+				Metadata: packMetadata{ID: "openclaw", Aliases: []string{"oc"}},
+				Topics:   []packTopic{{Name: "job.openclaw.exec"}, {Name: "job.oc.run"}},
+			},
+		},
+	}
+	cases := []struct {
+		name    string
+		packID  string
+		aliases []string
+		topics  []packTopic
+		want    string
+	}{
+		{
+			name:    "alias equals installed pack id",
+			packID:  "cordclaw",
+			aliases: []string{"openclaw"},
+			topics:  []packTopic{{Name: "job.openclaw.exec"}},
+			want:    "already owned",
+		},
+		{
+			name:    "alias equals installed alias",
+			packID:  "cordclaw",
+			aliases: []string{"oc"},
+			topics:  []packTopic{{Name: "job.oc.exec"}},
+			want:    "already owned",
+		},
+		{
+			name:    "candidate id equals installed alias",
+			packID:  "oc",
+			aliases: nil,
+			topics:  []packTopic{{Name: "job.oc.exec"}},
+			want:    "already owned",
+		},
+		{
+			name:    "topic under requested namespace already owned",
+			packID:  "cordclaw",
+			aliases: []string{"oc"},
+			topics:  []packTopic{{Name: "job.cordclaw.exec"}},
+			want:    "already owned",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePackAliasOwnership(tc.packID, tc.aliases, tc.topics, installed)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validatePackAliasOwnership() = %v; want error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidatePackAliasOwnershipAllowsSamePackUpgrade(t *testing.T) {
+	installed := map[string]packRecord{
+		"cordclaw": {
+			ID: "cordclaw",
+			Manifest: packRecordManifest{
+				Metadata: packMetadata{ID: "cordclaw", Aliases: []string{"openclaw"}},
+				Topics:   []packTopic{{Name: "job.openclaw.exec"}},
+			},
+		},
+	}
+	err := validatePackAliasOwnership(
+		"cordclaw",
+		[]string{"openclaw"},
+		[]packTopic{{Name: "job.openclaw.exec"}},
+		installed,
+	)
+	if err != nil {
+		t.Fatalf("same-pack alias upgrade rejected: %v", err)
+	}
+}
+
+func TestValidatePackAliasOwnershipRejectsAliasEqualToPackID(t *testing.T) {
+	err := validatePackAliasOwnership("cordclaw", []string{"cordclaw"}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "duplicates metadata.id") {
+		t.Fatalf("validatePackAliasOwnership(alias=id) = %v; want duplicate-id error", err)
 	}
 }
 

--- a/cmd/cordumctl/pack_aliases_test.go
+++ b/cmd/cordumctl/pack_aliases_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidatePackAliasesAcceptsValidEntries verifies the regex + cap
+// behavior on the happy path.
+func TestValidatePackAliasesAcceptsValidEntries(t *testing.T) {
+	cases := [][]string{
+		nil,                            // back-compat: no aliases is valid
+		{},                             // empty slice is valid
+		{"openclaw"},                   // single, plain lowercase
+		{"openclaw", "alt-pack"},       // hyphen
+		{"a", "alt_pack"},              // 1-char + underscore
+		{"a1", "alt-pack_v2"},          // digits + mix
+		{"a", "b", "c", "d", "e", "f", "g", "h"}, // exactly maxPackAliases
+	}
+	for _, aliases := range cases {
+		if err := validatePackAliases(aliases); err != nil {
+			t.Errorf("validatePackAliases(%v) = %v; want nil", aliases, err)
+		}
+	}
+}
+
+// TestValidatePackAliasesRejectsMalformed enforces the alias regex.
+func TestValidatePackAliasesRejectsMalformed(t *testing.T) {
+	cases := []struct {
+		alias string
+		want  string
+	}{
+		{"Openclaw", "must match"},     // uppercase rejected
+		{"open!claw", "must match"},    // symbol rejected
+		{"1openclaw", "must match"},    // leading digit rejected
+		{"-openclaw", "must match"},    // leading hyphen rejected
+		{"_openclaw", "must match"},    // leading underscore rejected
+		{"open claw", "must match"},    // space rejected
+		{"", "empty alias"},            // empty rejected
+		{strings.Repeat("a", 32), "must match"}, // 32 chars (max is 31)
+	}
+	for _, tc := range cases {
+		err := validatePackAliases([]string{tc.alias})
+		if err == nil {
+			t.Errorf("validatePackAliases([%q]) = nil; want error containing %q", tc.alias, tc.want)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("validatePackAliases([%q]) = %v; want error containing %q", tc.alias, err, tc.want)
+		}
+	}
+}
+
+// TestValidatePackAliasesEnforcesMaxAndUnique enforces the count cap +
+// dup detection.
+func TestValidatePackAliasesEnforcesMaxAndUnique(t *testing.T) {
+	tooMany := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"} // 9 > 8
+	if err := validatePackAliases(tooMany); err == nil || !strings.Contains(err.Error(), "at most") {
+		t.Errorf("validatePackAliases(9 aliases) = %v; want at-most error", err)
+	}
+	dup := []string{"openclaw", "openclaw"}
+	if err := validatePackAliases(dup); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("validatePackAliases(dup) = %v; want duplicate error", err)
+	}
+}
+
+// TestPackTopicPrefixesIncludesIDAndAliases verifies the prefix-set
+// construction matches the validator's contract.
+func TestPackTopicPrefixesIncludesIDAndAliases(t *testing.T) {
+	prefixes := packTopicPrefixes("cordclaw", []string{"openclaw", "alt-pack"})
+	want := []string{"job.cordclaw.", "job.openclaw.", "job.alt-pack."}
+	if len(prefixes) != len(want) {
+		t.Fatalf("packTopicPrefixes len=%d want %d (%v)", len(prefixes), len(want), prefixes)
+	}
+	for i, p := range prefixes {
+		if p != want[i] {
+			t.Errorf("packTopicPrefixes[%d]=%q want %q", i, p, want[i])
+		}
+	}
+}
+
+// TestValidatePackManifestAcceptsAliasedTopics covers the load-bearing
+// invariant: a pack with metadata.aliases=[openclaw] validates topics
+// under both job.<id>.* AND job.<alias>.*. Without aliases the strict
+// prefix rule fires (back-compat).
+func TestValidatePackManifestAcceptsAliasedTopics(t *testing.T) {
+	mfWithAlias := &packManifest{
+		Metadata: packMetadata{
+			ID:      "cordclaw",
+			Version: "1.0.0",
+			Aliases: []string{"openclaw"},
+		},
+		Compatibility: packCompatibility{ProtocolVersion: 0, MinCoreVersion: "0.1.0"},
+		Topics: []packTopic{
+			{Name: "job.cordclaw.exec"},
+			{Name: "job.openclaw.tool_call"},
+		},
+	}
+	// ProtocolVersion gates aren't applied by validatePackManifest;
+	// only the namespace check matters here.
+	if err := validatePackManifest(mfWithAlias); err != nil {
+		t.Errorf("validatePackManifest(with alias) = %v; want nil", err)
+	}
+
+	mfNoAlias := &packManifest{
+		Metadata: packMetadata{ID: "cordclaw", Version: "1.0.0"},
+		Topics:   []packTopic{{Name: "job.openclaw.tool_call"}},
+	}
+	if err := validatePackManifest(mfNoAlias); err == nil || !strings.Contains(err.Error(), "must be namespaced under") {
+		t.Errorf("validatePackManifest(no alias, openclaw topic) = %v; want namespace error", err)
+	}
+
+	mfWrongAlias := &packManifest{
+		Metadata: packMetadata{ID: "cordclaw", Version: "1.0.0", Aliases: []string{"openclaw"}},
+		Topics:   []packTopic{{Name: "job.cordbar.tool_call"}}, // not id and not alias
+	}
+	if err := validatePackManifest(mfWrongAlias); err == nil || !strings.Contains(err.Error(), "must be namespaced under") {
+		t.Errorf("validatePackManifest(cordbar topic) = %v; want namespace error", err)
+	}
+}
+
+// TestValidatePackManifestPreservesExistingInvariants asserts that the
+// alias-aware prefix check does not weaken the other validator checks
+// (id regex, version required, schema id prefix, workflow id prefix).
+func TestValidatePackManifestPreservesExistingInvariants(t *testing.T) {
+	// Empty id still rejected.
+	mfEmptyID := &packManifest{Metadata: packMetadata{Version: "1.0"}}
+	if err := validatePackManifest(mfEmptyID); err == nil {
+		t.Errorf("validatePackManifest(empty id) = nil; want id-required error")
+	}
+	// Empty version still rejected when id is set.
+	mfEmptyVer := &packManifest{Metadata: packMetadata{ID: "cordclaw"}}
+	if err := validatePackManifest(mfEmptyVer); err == nil {
+		t.Errorf("validatePackManifest(empty version) = nil; want version-required error")
+	}
+}

--- a/cmd/cordumctl/pack_aliases_test.go
+++ b/cmd/cordumctl/pack_aliases_test.go
@@ -13,9 +13,9 @@ func TestValidatePackAliasesAcceptsValidEntries(t *testing.T) {
 		{},                             // empty slice is valid
 		{"openclaw"},                   // single, plain lowercase
 		{"openclaw", "alt-pack"},       // hyphen
-		{"a", "alt_pack"},              // 1-char + underscore
+		{"aa", "alt_pack"},             // 2-char min + underscore
 		{"a1", "alt-pack_v2"},          // digits + mix
-		{"a", "b", "c", "d", "e", "f", "g", "h"}, // exactly maxPackAliases
+		{"a1", "b2", "c3", "d4", "e5", "f6", "g7", "h8"}, // exactly maxPackAliases
 	}
 	for _, aliases := range cases {
 		if err := validatePackAliases(aliases); err != nil {

--- a/cmd/cordumctl/pack_test.go
+++ b/cmd/cordumctl/pack_test.go
@@ -364,24 +364,24 @@ func TestValidatePoolsPatch(t *testing.T) {
 	patch := map[string]any{
 		"topics": map[string]any{"job.bad": map[string]any{}},
 	}
-	if err := validatePoolsPatch(patch, "pack1", nil); err == nil {
+	if err := validatePoolsPatch(patch, "pack1", nil, nil); err == nil {
 		t.Fatalf("expected namespacing error")
 	}
 
 	patch = map[string]any{
 		"pools": map[string]any{"shared": map[string]any{}},
 	}
-	if err := validatePoolsPatch(patch, "pack1", nil); err == nil {
+	if err := validatePoolsPatch(patch, "pack1", nil, nil); err == nil {
 		t.Fatalf("expected pool namespacing error")
 	}
 
 	current := map[string]any{"pools": map[string]any{"shared": map[string]any{}}}
-	if err := validatePoolsPatch(patch, "pack1", current); err != nil {
+	if err := validatePoolsPatch(patch, "pack1", nil, current); err != nil {
 		t.Fatalf("expected existing pool to be allowed: %v", err)
 	}
 
 	patch = map[string]any{"topics": map[string]any{"job.pack1.ok": map[string]any{}}, "extra": 1}
-	if err := validatePoolsPatch(patch, "pack1", nil); err == nil {
+	if err := validatePoolsPatch(patch, "pack1", nil, nil); err == nil {
 		t.Fatalf("expected unsupported key error")
 	}
 }
@@ -390,19 +390,19 @@ func TestValidateTimeoutsPatch(t *testing.T) {
 	patch := map[string]any{
 		"topics": map[string]any{"job.bad": map[string]any{}},
 	}
-	if err := validateTimeoutsPatch(patch, "pack1"); err == nil {
+	if err := validateTimeoutsPatch(patch, "pack1", nil); err == nil {
 		t.Fatalf("expected namespacing error")
 	}
 
 	patch = map[string]any{
 		"workflows": map[string]any{"bad.workflow": map[string]any{}},
 	}
-	if err := validateTimeoutsPatch(patch, "pack1"); err == nil {
+	if err := validateTimeoutsPatch(patch, "pack1", nil); err == nil {
 		t.Fatalf("expected workflow namespacing error")
 	}
 
 	patch = map[string]any{"topics": map[string]any{"job.pack1.ok": map[string]any{}}, "extra": 1}
-	if err := validateTimeoutsPatch(patch, "pack1"); err == nil {
+	if err := validateTimeoutsPatch(patch, "pack1", nil); err == nil {
 		t.Fatalf("expected unsupported key error")
 	}
 
@@ -410,7 +410,7 @@ func TestValidateTimeoutsPatch(t *testing.T) {
 		"topics":    map[string]any{"job.pack1.ok": map[string]any{}},
 		"workflows": map[string]any{"pack1.workflow": map[string]any{}},
 	}
-	if err := validateTimeoutsPatch(patch, "pack1"); err != nil {
+	if err := validateTimeoutsPatch(patch, "pack1", nil); err != nil {
 		t.Fatalf("expected valid timeouts patch: %v", err)
 	}
 }

--- a/core/controlplane/gateway/handlers_packs.go
+++ b/core/controlplane/gateway/handlers_packs.go
@@ -257,7 +257,7 @@ func (s *server) installPackFromDir(ctx context.Context, bundleDir string, opts 
 		if packs.ShouldSkipConfigOverlay(opts.Inactive, overlay) {
 			continue
 		}
-		applied, err := s.applyConfigOverlay(ctx, overlay, manifest.Metadata.ID, bundleDir)
+		applied, err := s.applyConfigOverlay(ctx, overlay, manifest.Metadata.ID, manifest.Metadata.Aliases, bundleDir)
 		if err != nil {
 			rollback()
 			return packs.PackRecord{}, nil, &packs.PackInstallError{Status: http.StatusBadRequest, Err: err}
@@ -752,7 +752,7 @@ func (s *server) rollbackWorkflow(ctx context.Context, plan packs.WorkflowPlan) 
 	return s.workflowStore.DeleteWorkflow(ctx, plan.ID)
 }
 
-func (s *server) applyConfigOverlay(ctx context.Context, overlay packs.PackConfigOverlay, packID, dir string) (packs.AppliedConfigChange, error) {
+func (s *server) applyConfigOverlay(ctx context.Context, overlay packs.PackConfigOverlay, packID string, packAliases []string, dir string) (packs.AppliedConfigChange, error) {
 	key := strings.TrimSpace(overlay.Key)
 	if key == "" {
 		return packs.AppliedConfigChange{}, errors.New("config overlay key required")
@@ -785,7 +785,7 @@ func (s *server) applyConfigOverlay(ctx context.Context, overlay packs.PackConfi
 		doc.Data = map[string]any{}
 	}
 	current := packs.NormalizeJSON(doc.Data[key])
-	if err := packs.ValidateConfigPatch(key, patchMap, packID, current); err != nil {
+	if err := packs.ValidateConfigPatch(key, patchMap, packID, packAliases, current); err != nil {
 		return packs.AppliedConfigChange{}, err
 	}
 	before := packs.DeepCopy(current)

--- a/core/controlplane/gateway/handlers_packs.go
+++ b/core/controlplane/gateway/handlers_packs.go
@@ -181,6 +181,14 @@ func (s *server) installPackFromDir(ctx context.Context, bundleDir string, opts 
 	}
 	defer release()
 
+	installed, _, err := s.loadPackRegistry(ctx)
+	if err != nil {
+		return packs.PackRecord{}, nil, &packs.PackInstallError{Status: http.StatusInternalServerError, Err: fmt.Errorf("load pack registry: %w", err)}
+	}
+	if err := packs.ValidateAliasOwnership(manifest.Metadata.ID, manifest.Metadata.Aliases, manifest.Topics, installed); err != nil {
+		return packs.PackRecord{}, nil, &packs.PackInstallError{Status: http.StatusConflict, Err: err}
+	}
+
 	schemaPlans, err := s.planSchemas(ctx, bundleDir, manifest, opts.Upgrade)
 	if err != nil {
 		return packs.PackRecord{}, nil, &packs.PackInstallError{Status: http.StatusBadRequest, Err: err}
@@ -314,6 +322,15 @@ func (s *server) installPackFromDir(ctx context.Context, bundleDir string, opts 
 		if err != nil {
 			rollback()
 			return packs.PackRecord{}, nil, &packs.PackInstallError{Status: http.StatusBadRequest, Err: err}
+		}
+		snapshot, err := s.topicRegistry.List(ctx)
+		if err != nil {
+			rollback()
+			return packs.PackRecord{}, nil, &packs.PackInstallError{Status: http.StatusInternalServerError, Err: fmt.Errorf("load topic registry: %w", err)}
+		}
+		if err := validatePackTopicRegistryOwnership(manifest.Metadata.ID, manifest.Metadata.Aliases, regs, snapshot.Items); err != nil {
+			rollback()
+			return packs.PackRecord{}, nil, &packs.PackInstallError{Status: http.StatusConflict, Err: err}
 		}
 		if err := s.topicRegistry.SetMany(ctx, regs); err != nil {
 			rollback()
@@ -487,6 +504,36 @@ func (s *server) packTopicRegistrations(ctx context.Context, manifest *packs.Pac
 		})
 	}
 	return out, nil
+}
+
+func validatePackTopicRegistryOwnership(packID string, aliases []string, regs []topicregistry.Registration, existing []topicregistry.Registration) error {
+	packID = strings.TrimSpace(packID)
+	if packID == "" {
+		return errors.New("pack id required")
+	}
+	prefixes := packs.PackTopicPrefixes(packID, aliases)
+	candidateNames := make(map[string]struct{}, len(regs))
+	for _, reg := range regs {
+		if name := strings.TrimSpace(reg.Name); name != "" {
+			candidateNames[name] = struct{}{}
+		}
+	}
+	for _, reg := range existing {
+		name := strings.TrimSpace(reg.Name)
+		if name == "" {
+			continue
+		}
+		owner := strings.TrimSpace(reg.PackID)
+		if owner == "" || owner == packID {
+			continue
+		}
+		_, exact := candidateNames[name]
+		if !exact && !packs.HasAnyPrefix(name, prefixes) {
+			continue
+		}
+		return fmt.Errorf("topic %q is already registered by %s", name, owner)
+	}
+	return nil
 }
 
 func (s *server) issuePackWorkerCredential(ctx context.Context, packID string, regs []topicregistry.Registration) (*packWorkerCredentialResponse, error) {

--- a/core/controlplane/gateway/packs/aliases_test.go
+++ b/core/controlplane/gateway/packs/aliases_test.go
@@ -74,6 +74,90 @@ func TestValidatePackManifestGatewayBackcompat(t *testing.T) {
 	}
 }
 
+func TestValidateAliasOwnershipRejectsInstalledNamespaceCollisions(t *testing.T) {
+	installed := map[string]PackRecord{
+		"openclaw": {
+			ID: "openclaw",
+			Manifest: PackRecordManifest{
+				Metadata: PackMetadata{ID: "openclaw", Aliases: []string{"oc"}},
+				Topics:   []PackTopic{{Name: "job.openclaw.exec"}, {Name: "job.oc.run"}},
+			},
+		},
+	}
+	cases := []struct {
+		name    string
+		packID  string
+		aliases []string
+		topics  []PackTopic
+		want    string
+	}{
+		{
+			name:    "alias equals installed pack id",
+			packID:  "cordclaw",
+			aliases: []string{"openclaw"},
+			topics:  []PackTopic{{Name: "job.openclaw.exec"}},
+			want:    "already owned",
+		},
+		{
+			name:    "alias equals installed alias",
+			packID:  "cordclaw",
+			aliases: []string{"oc"},
+			topics:  []PackTopic{{Name: "job.oc.exec"}},
+			want:    "already owned",
+		},
+		{
+			name:    "candidate id equals installed alias",
+			packID:  "oc",
+			aliases: nil,
+			topics:  []PackTopic{{Name: "job.oc.exec"}},
+			want:    "already owned",
+		},
+		{
+			name:    "topic under requested namespace already owned",
+			packID:  "cordclaw",
+			aliases: []string{"oc"},
+			topics:  []PackTopic{{Name: "job.cordclaw.exec"}},
+			want:    "already owned",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAliasOwnership(tc.packID, tc.aliases, tc.topics, installed)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ValidateAliasOwnership() = %v; want error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateAliasOwnershipAllowsSamePackUpgrade(t *testing.T) {
+	installed := map[string]PackRecord{
+		"cordclaw": {
+			ID: "cordclaw",
+			Manifest: PackRecordManifest{
+				Metadata: PackMetadata{ID: "cordclaw", Aliases: []string{"openclaw"}},
+				Topics:   []PackTopic{{Name: "job.openclaw.exec"}},
+			},
+		},
+	}
+	err := ValidateAliasOwnership(
+		"cordclaw",
+		[]string{"openclaw"},
+		[]PackTopic{{Name: "job.openclaw.exec"}},
+		installed,
+	)
+	if err != nil {
+		t.Fatalf("same-pack alias upgrade rejected: %v", err)
+	}
+}
+
+func TestValidateAliasOwnershipRejectsAliasEqualToPackID(t *testing.T) {
+	err := ValidateAliasOwnership("cordclaw", []string{"cordclaw"}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "duplicates metadata.id") {
+		t.Fatalf("ValidateAliasOwnership(alias=id) = %v; want duplicate-id error", err)
+	}
+}
+
 func TestValidatePoolsPatchHonorsAliases(t *testing.T) {
 	patch := map[string]any{
 		"topics": map[string]any{"job.openclaw.tool_call": "openclaw-pool"},

--- a/core/controlplane/gateway/packs/aliases_test.go
+++ b/core/controlplane/gateway/packs/aliases_test.go
@@ -1,0 +1,99 @@
+package packs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePackAliasesGatewayAcceptsValidEntries(t *testing.T) {
+	cases := [][]string{
+		nil,
+		{},
+		{"openclaw"},
+		{"openclaw", "alt-pack"},
+		{"a", "alt_pack_v2"},
+	}
+	for _, aliases := range cases {
+		if err := ValidatePackAliases(aliases); err != nil {
+			t.Errorf("ValidatePackAliases(%v) = %v; want nil", aliases, err)
+		}
+	}
+}
+
+func TestValidatePackAliasesGatewayRejectsMalformed(t *testing.T) {
+	cases := []string{"Openclaw", "open!claw", "1openclaw", "-openclaw", strings.Repeat("a", 32)}
+	for _, alias := range cases {
+		if err := ValidatePackAliases([]string{alias}); err == nil {
+			t.Errorf("ValidatePackAliases([%q]) = nil; want regex error", alias)
+		}
+	}
+}
+
+func TestValidatePackAliasesGatewayEnforcesCap(t *testing.T) {
+	tooMany := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	err := ValidatePackAliases(tooMany)
+	if err == nil || !strings.Contains(err.Error(), "at most") {
+		t.Errorf("ValidatePackAliases(9 aliases) = %v; want at-most error", err)
+	}
+}
+
+func TestPackTopicPrefixesGateway(t *testing.T) {
+	prefixes := PackTopicPrefixes("cordclaw", []string{"openclaw"})
+	if len(prefixes) != 2 || prefixes[0] != "job.cordclaw." || prefixes[1] != "job.openclaw." {
+		t.Errorf("PackTopicPrefixes = %v; want [job.cordclaw. job.openclaw.]", prefixes)
+	}
+}
+
+func TestValidatePackManifestGatewayAcceptsAliasedTopics(t *testing.T) {
+	mf := &PackManifest{
+		Metadata: PackMetadata{ID: "cordclaw", Version: "1.0.0", Aliases: []string{"openclaw"}},
+		Topics: []PackTopic{
+			{Name: "job.cordclaw.exec"},
+			{Name: "job.openclaw.tool_call"},
+		},
+	}
+	if err := ValidatePackManifest(mf); err != nil {
+		t.Errorf("ValidatePackManifest(with alias) = %v; want nil", err)
+	}
+}
+
+func TestValidatePackManifestGatewayBackcompat(t *testing.T) {
+	mf := &PackManifest{
+		Metadata: PackMetadata{ID: "cordclaw", Version: "1.0.0"},
+		Topics:   []PackTopic{{Name: "job.cordclaw.exec"}},
+	}
+	if err := ValidatePackManifest(mf); err != nil {
+		t.Errorf("ValidatePackManifest(no alias, id topic) = %v; want nil", err)
+	}
+	mfBad := &PackManifest{
+		Metadata: PackMetadata{ID: "cordclaw", Version: "1.0.0"},
+		Topics:   []PackTopic{{Name: "job.openclaw.tool_call"}},
+	}
+	if err := ValidatePackManifest(mfBad); err == nil {
+		t.Errorf("ValidatePackManifest(no alias, openclaw topic) = nil; want error")
+	}
+}
+
+func TestValidatePoolsPatchHonorsAliases(t *testing.T) {
+	patch := map[string]any{
+		"topics": map[string]any{"job.openclaw.tool_call": "openclaw-pool"},
+	}
+	if err := ValidatePoolsPatch(patch, "cordclaw", []string{"openclaw"}, nil); err != nil {
+		t.Errorf("ValidatePoolsPatch(aliased topic) = %v; want nil", err)
+	}
+	if err := ValidatePoolsPatch(patch, "cordclaw", nil, nil); err == nil {
+		t.Errorf("ValidatePoolsPatch(no aliases) = nil; want error")
+	}
+}
+
+func TestValidateTimeoutsPatchHonorsAliases(t *testing.T) {
+	patch := map[string]any{
+		"topics": map[string]any{"job.openclaw.tool_call": map[string]any{}},
+	}
+	if err := ValidateTimeoutsPatch(patch, "cordclaw", []string{"openclaw"}); err != nil {
+		t.Errorf("ValidateTimeoutsPatch(aliased topic) = %v; want nil", err)
+	}
+	if err := ValidateTimeoutsPatch(patch, "cordclaw", nil); err == nil {
+		t.Errorf("ValidateTimeoutsPatch(no aliases) = nil; want error")
+	}
+}

--- a/core/controlplane/gateway/packs/aliases_test.go
+++ b/core/controlplane/gateway/packs/aliases_test.go
@@ -11,7 +11,7 @@ func TestValidatePackAliasesGatewayAcceptsValidEntries(t *testing.T) {
 		{},
 		{"openclaw"},
 		{"openclaw", "alt-pack"},
-		{"a", "alt_pack_v2"},
+		{"aa", "alt_pack_v2"},
 	}
 	for _, aliases := range cases {
 		if err := ValidatePackAliases(aliases); err != nil {

--- a/core/controlplane/gateway/packs/types.go
+++ b/core/controlplane/gateway/packs/types.go
@@ -18,6 +18,12 @@ type PackMetadata struct {
 	Version     string `yaml:"version" json:"version"`
 	Title       string `yaml:"title" json:"title"`
 	Description string `yaml:"description" json:"description"`
+	// Aliases declares additional namespace identifiers this pack owns,
+	// in addition to ID. When set, topic/pools-patch namespace checks
+	// accept `job.<id>.*` AND `job.<alias>.*` for each alias. Each alias
+	// must match `^[a-z][a-z0-9_-]{1,30}$`; max 8 entries. Existing packs
+	// that omit this field keep validating under the strict prefix rule.
+	Aliases []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
 }
 
 // PackCompatibility declares protocol and core version requirements.

--- a/core/controlplane/gateway/packs/validate.go
+++ b/core/controlplane/gateway/packs/validate.go
@@ -103,6 +103,96 @@ func ValidatePackAliases(aliases []string) error {
 	return nil
 }
 
+// ValidateAliasOwnership rejects namespace hijacks before a pack is installed.
+// Alias syntax alone is not enough: an alias becomes authority over
+// job.<alias>.* topics, so it must not collide with an installed pack id,
+// another pack's alias, or topics already recorded under that namespace.
+// The current pack id is ignored to allow idempotent upgrades/reinstalls.
+func ValidateAliasOwnership(packID string, aliases []string, topics []PackTopic, installed map[string]PackRecord) error {
+	packID = strings.TrimSpace(packID)
+	if packID == "" {
+		return errors.New("metadata.id required")
+	}
+	candidateNamespaces := map[string]struct{}{packID: {}}
+	for _, alias := range aliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		if alias == packID {
+			return fmt.Errorf("metadata.aliases: %q duplicates metadata.id", alias)
+		}
+		candidateNamespaces[alias] = struct{}{}
+	}
+
+	for namespace, owner := range installedNamespaceOwners(installed, packID) {
+		if _, requested := candidateNamespaces[namespace]; requested {
+			return fmt.Errorf("metadata.aliases: namespace %q is already owned by installed pack %q", namespace, owner)
+		}
+	}
+
+	prefixes := PackTopicPrefixes(packID, aliases)
+	candidateTopics := make(map[string]struct{}, len(topics))
+	for _, topic := range topics {
+		name := strings.TrimSpace(topic.Name)
+		if name != "" {
+			candidateTopics[name] = struct{}{}
+		}
+	}
+	for key, record := range installed {
+		owner := packRecordOwnerID(key, record)
+		if owner == "" || owner == packID {
+			continue
+		}
+		for _, topic := range record.Manifest.Topics {
+			name := strings.TrimSpace(topic.Name)
+			if name == "" {
+				continue
+			}
+			if _, exact := candidateTopics[name]; exact || HasAnyPrefix(name, prefixes) {
+				return fmt.Errorf("topic %q is already owned by installed pack %q", name, owner)
+			}
+		}
+	}
+	return nil
+}
+
+func installedNamespaceOwners(installed map[string]PackRecord, currentPackID string) map[string]string {
+	owners := map[string]string{}
+	for key, record := range installed {
+		owner := packRecordOwnerID(key, record)
+		if owner == "" || owner == currentPackID {
+			continue
+		}
+		addNamespaceOwner(owners, strings.TrimSpace(key), owner)
+		addNamespaceOwner(owners, strings.TrimSpace(record.ID), owner)
+		addNamespaceOwner(owners, strings.TrimSpace(record.Manifest.Metadata.ID), owner)
+		for _, alias := range record.Manifest.Metadata.Aliases {
+			addNamespaceOwner(owners, strings.TrimSpace(alias), owner)
+		}
+	}
+	return owners
+}
+
+func packRecordOwnerID(key string, record PackRecord) string {
+	if id := strings.TrimSpace(record.ID); id != "" {
+		return id
+	}
+	if id := strings.TrimSpace(record.Manifest.Metadata.ID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(key)
+}
+
+func addNamespaceOwner(owners map[string]string, namespace, owner string) {
+	if namespace == "" || owner == "" {
+		return
+	}
+	if _, exists := owners[namespace]; !exists {
+		owners[namespace] = owner
+	}
+}
+
 // PackTopicPrefixes returns the set of "job.<x>." prefixes a pack may
 // use for its topics. Always includes "job.<id>."; each declared alias
 // adds "job.<alias>.". The slice is small (<=9 entries given

--- a/core/controlplane/gateway/packs/validate.go
+++ b/core/controlplane/gateway/packs/validate.go
@@ -66,6 +66,84 @@ func LoadPackManifest(dir string) (*PackManifest, error) {
 	return &manifest, nil
 }
 
+// PackAliasPattern bounds the alias namespace: leading lower-case letter,
+// followed by lower-case alnum / hyphen / underscore, up to 31 chars total.
+// Tight on purpose — prevents namespace squatting by forcing distinct,
+// auditable identifiers per alias declaration.
+var PackAliasPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{1,30}$`)
+
+// MaxPackAliases caps the number of alias entries a single pack may
+// declare. Eight is enough for legitimate "this pack owns sibling
+// namespaces" cases without enabling broad namespace fan-out.
+const MaxPackAliases = 8
+
+// ValidatePackAliases enforces the alias regex + cap. Returns nil when
+// the slice is empty (back-compat for packs that omit metadata.aliases).
+func ValidatePackAliases(aliases []string) error {
+	if len(aliases) == 0 {
+		return nil
+	}
+	if len(aliases) > MaxPackAliases {
+		return fmt.Errorf("metadata.aliases: at most %d entries allowed, got %d", MaxPackAliases, len(aliases))
+	}
+	seen := make(map[string]struct{}, len(aliases))
+	for _, alias := range aliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			return errors.New("metadata.aliases: empty alias not allowed")
+		}
+		if !PackAliasPattern.MatchString(alias) {
+			return fmt.Errorf("metadata.aliases: %q must match %s", alias, PackAliasPattern.String())
+		}
+		if _, dup := seen[alias]; dup {
+			return fmt.Errorf("metadata.aliases: duplicate entry %q", alias)
+		}
+		seen[alias] = struct{}{}
+	}
+	return nil
+}
+
+// PackTopicPrefixes returns the set of "job.<x>." prefixes a pack may
+// use for its topics. Always includes "job.<id>."; each declared alias
+// adds "job.<alias>.". The slice is small (<=9 entries given
+// MaxPackAliases) so linear-scan membership is fine.
+func PackTopicPrefixes(id string, aliases []string) []string {
+	prefixes := make([]string, 0, 1+len(aliases))
+	prefixes = append(prefixes, "job."+id+".")
+	for _, alias := range aliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		prefixes = append(prefixes, "job."+alias+".")
+	}
+	return prefixes
+}
+
+// HasAnyPrefix reports whether s starts with any prefix in the slice.
+func HasAnyPrefix(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatPrefixList formats a slice of "job.<x>." prefixes for error
+// messages. Single → "job.<x>.*"; multiple → "job.<a>.* or job.<b>.* ..."
+// so operators can see exactly which namespaces are allowed.
+func FormatPrefixList(prefixes []string) string {
+	parts := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
+		parts[i] = prefix + "*"
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return strings.Join(parts, " or ")
+}
+
 // ValidatePackManifest checks that the manifest has all required fields.
 func ValidatePackManifest(manifest *PackManifest) error {
 	if manifest == nil {
@@ -79,15 +157,19 @@ func ValidatePackManifest(manifest *PackManifest) error {
 	if !idPattern.MatchString(id) {
 		return fmt.Errorf("metadata.id must match %s", idPattern.String())
 	}
+	if err := ValidatePackAliases(manifest.Metadata.Aliases); err != nil {
+		return err
+	}
 	if strings.TrimSpace(manifest.Metadata.Version) == "" {
 		return errors.New("metadata.version required")
 	}
+	topicPrefixes := PackTopicPrefixes(id, manifest.Metadata.Aliases)
 	for _, topic := range manifest.Topics {
 		if topic.Name == "" {
 			return errors.New("topic name required")
 		}
-		if !strings.HasPrefix(topic.Name, "job."+id+".") {
-			return fmt.Errorf("topic %q must be namespaced under job.%s.*", topic.Name, id)
+		if !HasAnyPrefix(topic.Name, topicPrefixes) {
+			return fmt.Errorf("topic %q must be namespaced under %s", topic.Name, FormatPrefixList(topicPrefixes))
 		}
 	}
 	schemaIDs := make(map[string]struct{}, len(manifest.Resources.Schemas))
@@ -218,19 +300,26 @@ func HasPoolOverlay(overlays []PackAppliedConfigOverlay) bool {
 }
 
 // ValidateConfigPatch dispatches validation based on the config key.
-func ValidateConfigPatch(key string, patch map[string]any, packID string, current any) error {
+//
+// packAliases is the optional list of namespace identifiers a pack owns
+// in addition to packID; pass nil for back-compat with callers that
+// don't yet thread aliases.
+func ValidateConfigPatch(key string, patch map[string]any, packID string, packAliases []string, current any) error {
 	switch strings.ToLower(key) {
 	case "pools":
-		return ValidatePoolsPatch(patch, packID, current)
+		return ValidatePoolsPatch(patch, packID, packAliases, current)
 	case "timeouts":
-		return ValidateTimeoutsPatch(patch, packID)
+		return ValidateTimeoutsPatch(patch, packID, packAliases)
 	default:
 		return fmt.Errorf("unsupported config overlay key %q", key)
 	}
 }
 
-// ValidatePoolsPatch validates a pools config overlay.
-func ValidatePoolsPatch(patch map[string]any, packID string, current any) error {
+// ValidatePoolsPatch validates a pools config overlay. packAliases is
+// the optional list of additional namespace identifiers a pack owns;
+// topics under `job.<alias>.*` are accepted when listed there.
+func ValidatePoolsPatch(patch map[string]any, packID string, packAliases []string, current any) error {
+	topicPrefixes := PackTopicPrefixes(packID, packAliases)
 	rawTopics := NormalizeJSON(patch["topics"])
 	if rawTopics != nil {
 		topics, ok := rawTopics.(map[string]any)
@@ -238,8 +327,8 @@ func ValidatePoolsPatch(patch map[string]any, packID string, current any) error 
 			return errors.New("pools.topics must be a map")
 		}
 		for topic := range topics {
-			if !strings.HasPrefix(topic, "job."+packID+".") {
-				return fmt.Errorf("pools topic %q must be namespaced under job.%s.*", topic, packID)
+			if !HasAnyPrefix(topic, topicPrefixes) {
+				return fmt.Errorf("pools topic %q must be namespaced under %s", topic, FormatPrefixList(topicPrefixes))
 			}
 		}
 	}
@@ -285,11 +374,14 @@ func ExtractPools(current any) map[string]struct{} {
 	return out
 }
 
-// ValidateTimeoutsPatch validates a timeouts config overlay.
-func ValidateTimeoutsPatch(patch map[string]any, packID string) error {
+// ValidateTimeoutsPatch validates a timeouts config overlay. packAliases
+// is the optional list of additional namespace identifiers; pass nil for
+// back-compat with callers that don't yet thread aliases.
+func ValidateTimeoutsPatch(patch map[string]any, packID string, packAliases []string) error {
 	if patch == nil {
 		return nil
 	}
+	topicPrefixes := PackTopicPrefixes(packID, packAliases)
 	rawTopics := NormalizeJSON(patch["topics"])
 	if rawTopics != nil {
 		topics, ok := rawTopics.(map[string]any)
@@ -297,8 +389,8 @@ func ValidateTimeoutsPatch(patch map[string]any, packID string) error {
 			return errors.New("timeouts.topics must be a map")
 		}
 		for topic := range topics {
-			if !strings.HasPrefix(topic, "job."+packID+".") {
-				return fmt.Errorf("timeouts topic %q must be namespaced under job.%s.*", topic, packID)
+			if !HasAnyPrefix(topic, topicPrefixes) {
+				return fmt.Errorf("timeouts topic %q must be namespaced under %s", topic, FormatPrefixList(topicPrefixes))
 			}
 		}
 	}

--- a/core/controlplane/gateway/packs_helpers_test.go
+++ b/core/controlplane/gateway/packs_helpers_test.go
@@ -96,13 +96,13 @@ func TestValidateTimeoutsPatch(t *testing.T) {
 	patch := map[string]any{
 		"topics": map[string]any{"job.bad": map[string]any{}},
 	}
-	if err := packs.ValidateTimeoutsPatch(patch, "pack1"); err == nil {
+	if err := packs.ValidateTimeoutsPatch(patch, "pack1", nil); err == nil {
 		t.Fatalf("expected namespacing error")
 	}
 	patch = map[string]any{
 		"topics": map[string]any{"job.pack1.ok": map[string]any{}},
 	}
-	if err := packs.ValidateTimeoutsPatch(patch, "pack1"); err != nil {
+	if err := packs.ValidateTimeoutsPatch(patch, "pack1", nil); err != nil {
 		t.Fatalf("expected valid timeouts patch: %v", err)
 	}
 }

--- a/core/controlplane/gateway/packs_test.go
+++ b/core/controlplane/gateway/packs_test.go
@@ -168,6 +168,32 @@ func TestHandleInstallPack(t *testing.T) {
 	}
 }
 
+func TestValidatePackTopicRegistryOwnershipRejectsExistingNamespaces(t *testing.T) {
+	regs := []topicregistry.Registration{
+		{Name: "job.openclaw.exec", PackID: "cordclaw"},
+	}
+	existing := []topicregistry.Registration{
+		{Name: "job.openclaw.exec", PackID: "openclaw"},
+		{Name: "job.openclaw.other", PackID: "openclaw"},
+	}
+	err := validatePackTopicRegistryOwnership("cordclaw", []string{"openclaw"}, regs, existing)
+	if err == nil || !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("validatePackTopicRegistryOwnership() = %v; want collision error", err)
+	}
+}
+
+func TestValidatePackTopicRegistryOwnershipAllowsSamePackUpgrade(t *testing.T) {
+	regs := []topicregistry.Registration{
+		{Name: "job.openclaw.exec", PackID: "cordclaw"},
+	}
+	existing := []topicregistry.Registration{
+		{Name: "job.openclaw.exec", PackID: "cordclaw"},
+	}
+	if err := validatePackTopicRegistryOwnership("cordclaw", []string{"openclaw"}, regs, existing); err != nil {
+		t.Fatalf("same-pack topic registry ownership rejected: %v", err)
+	}
+}
+
 func TestPackBundlesSurviveConfigPushAfterInstall(t *testing.T) {
 	s, _, _ := newTestGateway(t)
 	installTestPack(t, s)

--- a/core/infra/config/safety_policy_constraints_test.go
+++ b/core/infra/config/safety_policy_constraints_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSafetyPolicyAcceptsNewConstraintFields verifies the schema extension
+// permits max_output_bytes, allowed_destinations, and redact_patterns
+// under rule.constraints. These are the CONSTRAIN-extension primitives
+// the unified Decision.Type = allow_with_constraints path emits.
+func TestSafetyPolicyAcceptsNewConstraintFields(t *testing.T) {
+	yaml := `
+version: "1"
+default_tenant: default
+rules:
+  - id: rule-result-gating
+    decision: allow_with_constraints
+    reason: enforce output gating
+    match:
+      topics: ["job.openclaw.result_gating"]
+    constraints:
+      max_output_bytes: 65536
+      allowed_destinations:
+        - "file://workspace/*"
+        - "s3://artifacts/*"
+      redact_patterns:
+        - "secret_[a-z0-9]+"
+        - "(?i)password=\\S+"
+`
+	policy, err := ParseSafetyPolicy([]byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseSafetyPolicy() error = %v; want nil", err)
+	}
+	if policy == nil {
+		t.Fatal("ParseSafetyPolicy() returned nil policy")
+	}
+}
+
+// TestSafetyPolicyAcceptsZeroMaxOutputBytes verifies the minimum bound
+// (0) is honored — zero is a valid policy meaning "no output allowed".
+func TestSafetyPolicyAcceptsZeroMaxOutputBytes(t *testing.T) {
+	yaml := `
+version: "1"
+default_tenant: default
+rules:
+  - id: rule-zero-budget
+    decision: allow_with_constraints
+    match:
+      topics: ["job.openclaw.result_gating"]
+    constraints:
+      max_output_bytes: 0
+`
+	if _, err := ParseSafetyPolicy([]byte(yaml)); err != nil {
+		t.Errorf("ParseSafetyPolicy(zero max_output_bytes) error = %v; want nil", err)
+	}
+}
+
+// TestSafetyPolicyRejectsOversizedMaxOutputBytes enforces the 16MiB cap.
+// >16777216 must be rejected by the schema.
+func TestSafetyPolicyRejectsOversizedMaxOutputBytes(t *testing.T) {
+	yaml := `
+version: "1"
+default_tenant: default
+rules:
+  - id: rule-oversized
+    decision: allow_with_constraints
+    match:
+      topics: ["job.openclaw.result_gating"]
+    constraints:
+      max_output_bytes: 16777217
+`
+	_, err := ParseSafetyPolicy([]byte(yaml))
+	if err == nil {
+		t.Fatal("ParseSafetyPolicy(>16MiB max_output_bytes) returned nil error; want schema error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "max_output_bytes") &&
+		!strings.Contains(strings.ToLower(err.Error()), "maximum") {
+		t.Errorf("ParseSafetyPolicy(>16MiB) error = %v; want max-bound error", err)
+	}
+}
+
+// TestSafetyPolicyRejectsNegativeMaxOutputBytes enforces the minimum bound.
+func TestSafetyPolicyRejectsNegativeMaxOutputBytes(t *testing.T) {
+	yaml := `
+version: "1"
+default_tenant: default
+rules:
+  - id: rule-negative
+    decision: allow_with_constraints
+    match:
+      topics: ["job.openclaw.result_gating"]
+    constraints:
+      max_output_bytes: -1
+`
+	if _, err := ParseSafetyPolicy([]byte(yaml)); err == nil {
+		t.Error("ParseSafetyPolicy(negative max_output_bytes) returned nil error; want minimum-bound error")
+	}
+}
+
+// TestSafetyPolicyBackcompatNoNewFields verifies that policies without
+// the new constraint fields keep validating. Crucial for the additive-
+// only contract — existing safety policies in the wild must not break.
+func TestSafetyPolicyBackcompatNoNewFields(t *testing.T) {
+	yaml := `
+version: "1"
+default_tenant: default
+rules:
+  - id: rule-legacy
+    decision: allow_with_constraints
+    match:
+      topics: ["job.pack.action"]
+    constraints:
+      redaction_level: "moderate"
+      budgets:
+        max_runtime_ms: 30000
+`
+	if _, err := ParseSafetyPolicy([]byte(yaml)); err != nil {
+		t.Errorf("ParseSafetyPolicy(legacy constraints) error = %v; want nil", err)
+	}
+}
+
+// TestSafetyPolicyRejectsUnknownConstraintFields confirms the strict
+// additionalProperties:false is preserved — typos like max_output_byte
+// (missing 's') still fail.
+func TestSafetyPolicyRejectsUnknownConstraintFields(t *testing.T) {
+	yaml := `
+version: "1"
+default_tenant: default
+rules:
+  - id: rule-typo
+    decision: allow_with_constraints
+    match:
+      topics: ["job.pack.action"]
+    constraints:
+      max_output_byte: 1024
+`
+	if _, err := ParseSafetyPolicy([]byte(yaml)); err == nil {
+		t.Error("ParseSafetyPolicy(typo'd field) returned nil; want unknown-field error")
+	}
+}

--- a/core/infra/config/schema/safety_policy.schema.json
+++ b/core/infra/config/schema/safety_policy.schema.json
@@ -265,7 +265,10 @@
         "sandbox": {"$ref": "#/definitions/sandboxProfile"},
         "toolchain": {"$ref": "#/definitions/toolchainConstraints"},
         "diff": {"$ref": "#/definitions/diffConstraints"},
-        "redaction_level": {"type": "string"}
+        "redaction_level": {"type": "string"},
+        "max_output_bytes": {"type": "integer", "minimum": 0, "maximum": 16777216},
+        "allowed_destinations": {"type": "array", "items": {"type": "string"}},
+        "redact_patterns": {"type": "array", "items": {"type": "string"}}
       }
     },
     "budgetConstraints": {

--- a/docs/operations/pack-aliases.md
+++ b/docs/operations/pack-aliases.md
@@ -1,0 +1,109 @@
+# Pack `metadata.aliases`
+
+A pack manifest declares a single `metadata.id` that scopes the
+namespaces the pack owns. By default, every topic the pack registers must
+sit under `job.<metadata.id>.*` — so pack `cordclaw` can only own
+`job.cordclaw.*` topics.
+
+Some packs legitimately want to own multiple sibling namespaces. The
+canonical case is CordClaw, which intercepts every OpenClaw hook event
+and emits it as a Cordum job under `job.openclaw.*` topics — but the pack
+itself is named `cordclaw` and the renames would conflict with existing
+CordClaw rules under `job.cordclaw.*`.
+
+`metadata.aliases` solves this without weakening the namespace rule for
+everyone else.
+
+## Field shape
+
+```yaml
+metadata:
+  id: cordclaw
+  version: "1.2.0"
+  aliases:
+    - openclaw
+```
+
+| Constraint | Value |
+| --- | --- |
+| Regex | `^[a-z][a-z0-9_-]{1,30}$` (lowercase letter first; lowercase alnum / `-` / `_` after; 2-31 chars) |
+| Max entries | 8 |
+| Duplicates | rejected |
+| Optional | yes — packs without `aliases` keep validating under the strict prefix rule (back-compat) |
+
+## Validator behavior
+
+When `aliases` is set:
+
+- Topic namespace check accepts `job.<id>.*` AND `job.<alias>.*` for
+  each declared alias.
+- Pool-overlay `topics` map (`overlays/pools.patch.yaml`) accepts the
+  same set.
+- Timeouts-overlay `topics` map accepts the same set.
+- Sibling invariants (schema id prefix, workflow id prefix, pool name
+  prefix, pack-id regex) are unchanged — only the topic namespace check
+  honors aliases.
+
+When `aliases` is absent or empty:
+
+- The strict `job.<id>.*` rule applies (unchanged from prior behavior).
+
+## Rationale
+
+### Why declared aliases, not a weakened prefix check
+
+A globally relaxed prefix rule lets any pack claim any namespace at
+install time. With declared aliases, the namespaces a pack owns are
+auditable in the manifest itself; ops can grep `metadata.aliases:`
+across the pack registry to inventory cross-namespace ownership.
+
+### Why the regex cap
+
+The lowercase-only / hyphen-or-underscore-only pattern matches the same
+character class the pack-id regex uses (`^[a-z0-9-]+$`), so aliases are
+visually consistent with pack IDs. The 31-char cap matches the practical
+maximum we see in pack IDs.
+
+### Why 8 entries
+
+Eight is enough for the realistic "this pack owns N sibling namespaces"
+cases (CordClaw + OpenClaw is 2; a hypothetical pack bridging four
+upstream tools could use 5). Capping at 8 prevents the alias list from
+becoming a back-door way to register arbitrary topics.
+
+### What aliases do NOT change
+
+- `metadata.id` is still the pack's identity for install/uninstall and
+  for the `cordumctl pack list` output.
+- Pool names still need to be prefixed with `metadata.id` (NOT aliases).
+- Schema IDs and workflow IDs still namespace under `metadata.id`.
+- Aliases are not advertised over the pack discovery API as a way to
+  resolve a pack — only the canonical `metadata.id` is.
+
+## Example: cordclaw pack with openclaw alias
+
+```yaml
+apiVersion: cordum.io/v1
+kind: Pack
+metadata:
+  id: cordclaw
+  version: "1.2.0"
+  title: CordClaw
+  aliases:
+    - openclaw
+topics:
+  - name: job.cordclaw.exec
+    requires: []
+  - name: job.openclaw.tool_call
+    requires: []
+  - name: job.openclaw.prompt_build
+    requires: []
+overlays:
+  config:
+    - key: pools
+      strategy: json_merge_patch
+      path: overlays/pools.patch.yaml
+```
+
+The `overlays/pools.patch.yaml` may declare `job.openclaw.*` topic
+mappings under the same pack-install transaction.

--- a/docs/operations/safetykernel-constraints.md
+++ b/docs/operations/safetykernel-constraints.md
@@ -1,0 +1,81 @@
+# Safety policy `constraints` extensions
+
+`rule.constraints` on the safety policy schema accepts three additional
+fields used by the CONSTRAIN-extension primitives Cord-Claw ships:
+
+- `max_output_bytes` — caps the size of outputs an action can produce.
+- `allowed_destinations` — allowlist of destinations (file paths, URLs,
+  topic targets) the action may write to.
+- `redact_patterns` — regex patterns whose matches in output get
+  redacted before downstream emission.
+
+These fields live alongside the existing `budgets`, `sandbox`,
+`toolchain`, `diff`, and `redaction_level` constraint primitives.
+
+## Schema bounds
+
+| Field | Type | Bounds |
+| --- | --- | --- |
+| `max_output_bytes` | integer | `[0, 16777216]` (0 to 16 MiB) |
+| `allowed_destinations` | array of string | unbounded count; each entry is an opaque string the consumer interprets |
+| `redact_patterns` | array of string | unbounded count; each entry is a regex pattern the consumer interprets |
+
+The 16 MiB upper bound on `max_output_bytes` is hard-enforced by the
+schema to prevent OOM via misconfigured large outputs. Operators who
+need higher caps should configure them via per-deployment policy
+overrides, not via per-rule constraints.
+
+`additionalProperties: false` stays on the `constraints` object, so
+typos like `max_output_byte` (missing `s`) still fail validation. The
+schema is the single source of truth for the constraint vocabulary.
+
+## Emission semantics
+
+These constraints fire when the safety kernel emits a Decision with
+`Type = allow_with_constraints`. The unified Decision shape (see
+`core/policy/types.go`) carries the constraints payload to downstream
+enforcement, which:
+
+1. Truncates outputs exceeding `max_output_bytes` and tags the
+   truncation in the Decision trace.
+2. Rejects writes to destinations not present in `allowed_destinations`
+   (when the list is non-empty).
+3. Applies `redact_patterns` to the output stream before persistence
+   and downstream emission.
+
+## Backward compatibility
+
+Existing policy fragments without any of these three fields validate
+unchanged. The extension is additive only — there is no schema-version
+bump and no migration step. Operators can adopt the new fields
+incrementally as their packs need them.
+
+## Example: result-gating rule
+
+```yaml
+version: "1"
+default_tenant: default
+rules:
+  - id: openclaw-result-gating
+    decision: allow_with_constraints
+    reason: enforce output budget + redact secrets
+    match:
+      topics: ["job.openclaw.result_gating"]
+    constraints:
+      max_output_bytes: 65536
+      allowed_destinations:
+        - "file://workspace/*"
+        - "s3://artifacts/*"
+      redact_patterns:
+        - "secret_[a-z0-9]+"
+        - "(?i)password=\\S+"
+```
+
+## Why these are explicit properties
+
+Setting them as explicit schema properties (rather than relaxing
+`additionalProperties` to `true`) preserves the strict-by-default
+posture of the constraints object. Future constraint primitives go
+through the same explicit-property addition path; operators can rely on
+typo detection to surface mistakes at install time rather than at
+emit time.


### PR DESCRIPTION
Unblocks task-1e446868 (OpenClaw pack config) DoD #5/#6.

## Summary

Two additive Cordum-core schema relaxations:

1. **Pack manifest `metadata.aliases`** — optional `[]string` field. When set, topic / pools-patch / timeouts-patch namespace checks accept `job.<id>.*` AND `job.<alias>.*`. Regex `^[a-z][a-z0-9_-]{1,30}$`, max 8 entries, duplicates rejected. Unblocks the CordClaw pack owning `job.openclaw.*` topics under `metadata.id: cordclaw`.

2. **Safety-policy `rule.constraints`** — three new fields:
   - `max_output_bytes` (integer, 0–16 777 216 / 16 MiB)
   - `allowed_destinations` ([]string)
   - `redact_patterns` ([]string)

Both changes are additive only — no schema-version bump. Existing packs without aliases AND existing policy fragments without the new constraint fields keep validating unchanged.

## Files

- `cmd/cordumctl/pack.go` — `packMetadata.Aliases` + `validatePackAliases` + alias-aware topic prefix set in `validatePackManifest`. Pools-patch + timeouts-patch validators thread aliases through.
- `core/controlplane/gateway/packs/types.go` + `validate.go` — mirror-updated.
- `core/controlplane/gateway/handlers_packs.go` — `applyConfigOverlay` threads aliases from manifest into validator.
- `core/infra/config/schema/safety_policy.schema.json` — three new fields added to `constraints.properties`. `additionalProperties: false` preserved.
- Tests:
  - `cmd/cordumctl/pack_aliases_test.go` (NEW) — alias regex, count cap, duplicates, manifest topic acceptance, sibling-invariant preservation.
  - `core/controlplane/gateway/packs/aliases_test.go` (NEW) — mirror gateway-side coverage + pools/timeouts patch acceptance.
  - `core/infra/config/safety_policy_constraints_test.go` (NEW) — all three new fields validate; oversized + negative + typo'd field rejected; back-compat (no new fields) still validates.
  - `core/controlplane/gateway/packs_helpers_test.go` (existing) — updated for new `ValidateTimeoutsPatch` signature (now accepts `packAliases []string`, pass `nil` for back-compat).
- `CHANGELOG.md` — entry under `## [Unreleased] / ### Added`.
- `docs/operations/pack-aliases.md` (NEW) + `docs/operations/safetykernel-constraints.md` (NEW).

## Invariants preserved

- Pack-id regex `^[a-z0-9-]+$` unchanged.
- Schema-id prefix `<packID>/` unchanged.
- Workflow-id prefix `<packID>.` unchanged.
- Pool-name prefix `<packID>` unchanged.
- `additionalProperties: false` on the safety-policy `constraints` object preserved — typos like `max_output_byte` still fail.

## Test plan

- [x] Local: cannot run `make test` (per `feedback_no_branch_switch_in_workers` no checkout); CI runs `make build` + `make test` + targeted `-count=3` on `cmd/cordumctl/...`, `core/controlplane/gateway/packs/...`, `core/infra/config/...`.
- [ ] CI: `make build` + `make test` GREEN.
- [ ] CI: `go test -count=3 -timeout 240s ./cmd/cordumctl/... ./core/controlplane/gateway/packs/... ./core/infra/config/...` GREEN.
- [ ] End-to-end smoke (post-merge): `cordumctl pack install -dry-run D:/Cordum/Cord-Claw/pack` accepts `job.openclaw.*` topics; `docker logs cordum-safety-kernel-1 | grep -i 'schema validation failed'` returns no new entries after the CordClaw policy fragment loads.

Refs epic-5ecafd00 task-e4e9489c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Packs can declare metadata aliases to allow topic namespaces like job.<alias>.* in addition to job.<id>.*.
  * Safety policies accept new constraint fields: max_output_bytes (≤16 MiB), allowed_destinations, and redact_patterns.

* **Validation / Reliability**
  * Install and config validation now enforce alias-aware namespace ownership and reject alias/namespace collisions.

* **Documentation**
  * Added guides for pack aliases and safety policy constraints.

* **Tests**
  * Added unit tests covering alias handling, namespace validation, and safety-policy constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/261)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->