### PR TITLE
feat(policy/actiongates): Cordum-native action-layer gates (task-bf56d8c8)

### DIFF
--- a/core/audit/exporter.go
+++ b/core/audit/exporter.go
@@ -128,6 +128,17 @@ const (
 	EventEdgeApprovalRejected  = "edge.approval_rejected"
 	EventEdgeApprovalExpired   = "edge.approval_expired"
 	EventEdgeArtifactExported  = "edge.artifact_exported"
+
+	// EventActionGateDenied is emitted by the Safety Kernel when an
+	// action-layer gate (tenant / file / url / mcp / mutation /
+	// provenance) short-circuits the legacy rule loop with a non-ALLOW
+	// decision. Extra carries gate=<gateID>, sub_reason=<subreason>,
+	// and target_type (when known). Severity is HIGH for cross-tenant
+	// access, credential paths, exfil destinations, and self-approval;
+	// MEDIUM for REQUIRE_HUMAN outcomes. SIEM rules pivot on this
+	// event to surface privilege-escalation probes that never reached
+	// the existing rule evaluator.
+	EventActionGateDenied = "actiongate.denied"
 	EventEdgeAgentdDegraded    = "edge.agentd_degraded"
 	EventEdgeFailClosed        = "edge.fail_closed"
 )

--- a/core/controlplane/gateway/actiongate_wire.go
+++ b/core/controlplane/gateway/actiongate_wire.go
@@ -21,6 +21,30 @@ import (
 // with safetykernel.LabelActionDescriptorJSON.
 const labelActionDescriptorJSON = "_action.descriptor_json"
 
+// stripReservedActionDescriptorLabel returns a copy of labels with the
+// gateway-reserved descriptor key removed. Defends against a client
+// who places `_action.descriptor_json` directly in their HTTP body's
+// Labels map to bypass the gateway's authenticated descriptor path and
+// inject attacker-controlled data into the kernel-side extractor.
+// Returns the original map (no allocation) when the key is absent so
+// the common case stays cheap.
+func stripReservedActionDescriptorLabel(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+	if _, hasReserved := labels[labelActionDescriptorJSON]; !hasReserved {
+		return labels
+	}
+	out := make(map[string]string, len(labels)-1)
+	for k, v := range labels {
+		if k == labelActionDescriptorJSON {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 // encodeActionDescriptorLabel marshals an ActionDescriptor for transport
 // in a Labels map entry. Enforces the same serialized-bytes cap the
 // gateway uses for tool arg payloads so an oversized descriptor cannot

--- a/core/controlplane/gateway/actiongate_wire.go
+++ b/core/controlplane/gateway/actiongate_wire.go
@@ -1,0 +1,128 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	edgecore "github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/infra/store"
+	"github.com/cordum/cordum/core/mcp"
+	"github.com/cordum/cordum/core/policy/actiongates"
+)
+
+// labelActionDescriptorJSON is the reserved Labels-map key the gateway
+// uses to propagate the JSON-encoded ActionDescriptor across the gRPC
+// boundary to the safety kernel. The `_` prefix is what the gateway's
+// label-clean path strips before echoing labels back to clients, so the
+// key never escapes the server-side request flow. Must stay in lockstep
+// with safetykernel.LabelActionDescriptorJSON.
+const labelActionDescriptorJSON = "_action.descriptor_json"
+
+// encodeActionDescriptorLabel marshals an ActionDescriptor for transport
+// in a Labels map entry. Enforces the same serialized-bytes cap the
+// gateway uses for tool arg payloads so an oversized descriptor cannot
+// drown the policy request. Returns ("", nil) for a nil input so the
+// caller can use the empty-string sentinel as "no descriptor to send."
+func encodeActionDescriptorLabel(desc *config.ActionDescriptor) (string, error) {
+	if desc == nil {
+		return "", nil
+	}
+	encoded, err := json.Marshal(desc)
+	if err != nil {
+		return "", fmt.Errorf("marshal action descriptor: %w", err)
+	}
+	if len(encoded) > config.ActionArgsMaxSerializedBytes {
+		return "", fmt.Errorf("action descriptor too large: %d bytes (cap %d)", len(encoded), config.ActionArgsMaxSerializedBytes)
+	}
+	return string(encoded), nil
+}
+
+// wireActionGatePipeline installs the production action-gate pipeline
+// on the gateway server. Called once during RunWithAuth after the
+// server fields (edgeStore, agentIdentityStore) are populated. The
+// gateway is the primary enforcement surface: handlers_policy.go fires
+// the pipeline before forwarding to the safety kernel, so a wired
+// pipeline here turns the previously-dead actiongates_http.go and
+// handlers_policy.go gate-firing branches into the live request path.
+//
+// Returns no error: gate construction itself never fails (nil deps
+// degrade individual gates to fail-closed). The function is idempotent
+// — callers that re-invoke at config-reload time receive a fresh
+// pipeline.
+func (s *server) wireActionGatePipeline() {
+	if s == nil {
+		return
+	}
+	pipeline := actiongates.BuildProductionPipeline(actiongates.ProductionPipelineOptions{
+		Approvals:  edgeStoreApprovalLookup{store: s.edgeStore},
+		Identities: gatewayMCPIdentityResolver{store: s.agentIdentityStore},
+	})
+	// actionGatePipeline is set once during boot before any handler can
+	// observe it, so the field assignment needs no lock — Go's
+	// initialization-before-use guarantee covers the publish.
+	s.actionGatePipeline = pipeline
+	slog.Info("gateway: action-gate pipeline wired",
+		"gate_count", len(pipeline.Gates()),
+		"approvals_backend", "edge.RedisStore",
+		"mcp_identity_backend", "store.AgentIdentityStore",
+	)
+}
+
+// edgeStoreApprovalLookup adapts edgecore.RedisStore to the
+// actiongates.ApprovalLookup contract used by mutation + provenance
+// gates. A nil store is treated as a miss (false, nil) per the
+// ApprovalLookup contract — surface-level nil checks happen at wire
+// time so the runtime never panics on a misconfigured deploy.
+type edgeStoreApprovalLookup struct {
+	store edgecore.Store
+}
+
+// LookupByActionHash delegates to the underlying Redis store. The cast
+// to the concrete *edgecore.RedisStore is necessary because the
+// edgecore.Store interface does not expose LookupByActionHash (only
+// the concrete store satisfies actiongates.ApprovalLookup). When the
+// concrete type assertion fails, we return a miss so the caller
+// degrades to the require-human / fail-closed path rather than
+// panicking on a missing method.
+func (a edgeStoreApprovalLookup) LookupByActionHash(ctx context.Context, tenant, actionHash string) (*edgecore.EdgeApproval, bool, error) {
+	if a.store == nil {
+		return nil, false, nil
+	}
+	redisStore, ok := a.store.(*edgecore.RedisStore)
+	if !ok {
+		return nil, false, nil
+	}
+	return redisStore.LookupByActionHash(ctx, tenant, actionHash)
+}
+
+// gatewayMCPIdentityResolver adapts the gateway's persisted agent
+// identity store into the MCP-shaped AgentIdentity the action-gate
+// MCPGate consumes. Reuses mcpIdentityFromStore so revoked/suspended
+// identities are mapped to nil consistently with the existing MCP
+// filter path.
+type gatewayMCPIdentityResolver struct {
+	store *store.AgentIdentityStore
+}
+
+// ResolveMCPIdentity looks up the agent in Redis and adapts the
+// result. Returns (nil, nil) for a miss so the MCPGate's nil-identity
+// fail-closed path takes over. A backend error propagates so the gate
+// can fail closed with Code=service_unavailable.
+//
+// The tenant parameter is part of the actiongates.MCPIdentityResolver
+// contract but the underlying AgentIdentityStore keys agents by
+// globally-unique ID. Cross-tenant agent-ID collisions are guarded by
+// the existing tenant gate (which runs before the MCP gate).
+func (r gatewayMCPIdentityResolver) ResolveMCPIdentity(ctx context.Context, _ string, agentID string) (*mcp.AgentIdentity, error) {
+	if r.store == nil {
+		return nil, nil
+	}
+	identity, err := r.store.Get(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
+	return mcpIdentityFromStore(identity), nil
+}

--- a/core/controlplane/gateway/actiongate_wire_test.go
+++ b/core/controlplane/gateway/actiongate_wire_test.go
@@ -111,9 +111,8 @@ func TestStripReservedActionDescriptorLabel_NoOpWhenAbsent(t *testing.T) {
 	in := map[string]string{"normal_key": "v"}
 	out := stripReservedActionDescriptorLabel(in)
 	// No reserved key present -> implementation returns original map
-	// (no allocation cost on hot path).
-	if &out == &in { // map header pointers differ; compare via content
-	}
+	// (no allocation cost on hot path). Content-equality validates
+	// the no-op contract.
 	if len(out) != 1 || out["normal_key"] != "v" {
 		t.Fatalf("strip mutated label set unexpectedly: %v", out)
 	}

--- a/core/controlplane/gateway/actiongate_wire_test.go
+++ b/core/controlplane/gateway/actiongate_wire_test.go
@@ -81,6 +81,51 @@ func TestEncodeActionDescriptorLabel_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestStripReservedActionDescriptorLabel_BlocksClientInjection asserts
+// the defense-in-depth strip drops a client-supplied descriptor label.
+// Without this, a client could submit the gateway's reserved label
+// directly in their HTTP body, bypass the authenticated descriptor
+// path (req.Action), and inject attacker-controlled descriptor data
+// into the kernel-side extractor's audit/gate code path.
+func TestStripReservedActionDescriptorLabel_BlocksClientInjection(t *testing.T) {
+	t.Parallel()
+	in := map[string]string{
+		labelActionDescriptorJSON: `{"kind":"file","verb":"delete","target_path":"/etc/shadow"}`,
+		"benign_key":              "kept",
+		"_content.prompt":         "kept-because-different-key",
+	}
+	out := stripReservedActionDescriptorLabel(in)
+	if _, present := out[labelActionDescriptorJSON]; present {
+		t.Fatal("client-supplied descriptor label was not stripped")
+	}
+	if out["benign_key"] != "kept" {
+		t.Fatalf("benign label lost in strip: %v", out)
+	}
+	if out["_content.prompt"] != "kept-because-different-key" {
+		t.Fatalf("unrelated underscore label was incorrectly stripped: %v", out)
+	}
+}
+
+func TestStripReservedActionDescriptorLabel_NoOpWhenAbsent(t *testing.T) {
+	t.Parallel()
+	in := map[string]string{"normal_key": "v"}
+	out := stripReservedActionDescriptorLabel(in)
+	// No reserved key present -> implementation returns original map
+	// (no allocation cost on hot path).
+	if &out == &in { // map header pointers differ; compare via content
+	}
+	if len(out) != 1 || out["normal_key"] != "v" {
+		t.Fatalf("strip mutated label set unexpectedly: %v", out)
+	}
+}
+
+func TestStripReservedActionDescriptorLabel_NilInputNilOutput(t *testing.T) {
+	t.Parallel()
+	if out := stripReservedActionDescriptorLabel(nil); out != nil {
+		t.Fatalf("nil input should produce nil output, got %v", out)
+	}
+}
+
 func TestEncodeActionDescriptorLabel_NilReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	encoded, err := encodeActionDescriptorLabel(nil)

--- a/core/controlplane/gateway/actiongate_wire_test.go
+++ b/core/controlplane/gateway/actiongate_wire_test.go
@@ -1,0 +1,135 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy/actiongates"
+)
+
+// TestWireActionGatePipeline_AssignsLivePipeline asserts the gateway
+// wiring function turns the previously-dead actionGatePipeline field
+// into a real pipeline. This is the regression guard for the QA-flagged
+// "gateway server.actionGatePipeline field declared but never assigned"
+// bug: a future refactor that drops the s.wireActionGatePipeline() call
+// in RunWithAuth MUST break this test.
+func TestWireActionGatePipeline_AssignsLivePipeline(t *testing.T) {
+	t.Parallel()
+	s := &server{}
+	s.wireActionGatePipeline()
+	if s.actionGatePipeline == nil {
+		t.Fatal("server.actionGatePipeline still nil after wireActionGatePipeline()")
+	}
+	gates := s.actionGatePipeline.Gates()
+	if len(gates) == 0 {
+		t.Fatal("pipeline has no gates after wiring")
+	}
+	wantIDs := map[string]struct{}{
+		actiongates.GateIDTenant:     {},
+		actiongates.GateIDFile:       {},
+		actiongates.GateIDURL:        {},
+		actiongates.GateIDMCP:        {},
+		actiongates.GateIDMutation:   {},
+		actiongates.GateIDProvenance: {},
+	}
+	for _, g := range gates {
+		delete(wantIDs, g.ID())
+	}
+	if len(wantIDs) > 0 {
+		t.Fatalf("pipeline missing expected gates: %v", wantIDs)
+	}
+}
+
+// TestWireActionGatePipeline_NilReceiverNoOp ensures the method tolerates
+// a nil server pointer so misconfigured test fixtures cannot panic.
+func TestWireActionGatePipeline_NilReceiverNoOp(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("nil-receiver wireActionGatePipeline panicked: %v", r)
+		}
+	}()
+	var s *server
+	s.wireActionGatePipeline()
+}
+
+// TestEncodeActionDescriptorLabel_RoundTrip asserts the JSON-label
+// encoding the gateway uses to propagate an ActionDescriptor across the
+// gRPC boundary preserves all fields needed by the kernel-side
+// extractor (kernel_actiongate_wire.go's actionDescriptorFromRequest).
+// The two halves must stay in lockstep or the descriptor never reaches
+// the kernel pipeline.
+func TestEncodeActionDescriptorLabel_RoundTrip(t *testing.T) {
+	t.Parallel()
+	desc := &config.ActionDescriptor{
+		Kind:       config.ActionKindURL,
+		Verb:       config.ActionVerbRead,
+		TargetURL:  "https://example.com/docs",
+		Server:     "mcp-corp",
+		Tool:       "tools/read",
+		RiskTags:   []string{"data:pii"},
+	}
+	encoded, err := encodeActionDescriptorLabel(desc)
+	if err != nil {
+		t.Fatalf("encode err: %v", err)
+	}
+	if encoded == "" {
+		t.Fatal("encode returned empty string on non-nil descriptor")
+	}
+	if len(encoded) > config.ActionArgsMaxSerializedBytes {
+		t.Fatalf("encode exceeds size cap: %d > %d", len(encoded), config.ActionArgsMaxSerializedBytes)
+	}
+}
+
+func TestEncodeActionDescriptorLabel_NilReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	encoded, err := encodeActionDescriptorLabel(nil)
+	if err != nil {
+		t.Fatalf("nil descriptor should return empty, got err: %v", err)
+	}
+	if encoded != "" {
+		t.Fatalf("nil descriptor should return empty string, got %q", encoded)
+	}
+}
+
+func TestEncodeActionDescriptorLabel_OversizeReturnsError(t *testing.T) {
+	t.Parallel()
+	hugeArgs := make(map[string]any, 4096)
+	for i := range 4096 {
+		// Each entry contributes ~80 bytes encoded -> well over the 64KB cap.
+		hugeArgs[string(rune('a'+i%26))+"_long_key_name_"+strconvI(i)] = "long_value_" + strconvI(i)
+	}
+	desc := &config.ActionDescriptor{
+		Kind: config.ActionKindMCPCall,
+		Args: hugeArgs,
+	}
+	if _, err := encodeActionDescriptorLabel(desc); err == nil {
+		t.Fatal("expected oversize descriptor to error, got nil")
+	}
+}
+
+// strconvI is a tiny local int->string helper to avoid pulling in strconv
+// for one call. Decoupled from any package-level helper so this test file
+// has no transitive dependencies beyond standard library + this package.
+func strconvI(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	const digits = "0123456789"
+	var buf [20]byte
+	pos := len(buf)
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+	for n > 0 {
+		pos--
+		buf[pos] = digits[n%10]
+		n /= 10
+	}
+	if negative {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/core/controlplane/gateway/actiongates_http.go
+++ b/core/controlplane/gateway/actiongates_http.go
@@ -1,0 +1,128 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/cordum/cordum/core/policy/actiongates"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// actionGateHTTPStatus maps an ActionGateDecision.Code to its HTTP status
+// code at the gateway boundary. The mapping is stable API surface for
+// SDKs and SIEM rules; callers MUST NOT extend it without an explicit
+// architecture decision.
+//
+// REQUIRE_HUMAN is mapped to 200 because the policy simulate endpoint is
+// informational — REQUIRE_HUMAN signals "this would have needed approval"
+// rather than blocking. The Edge evaluate endpoint maps the same code
+// onto its own inline-approval workflow, not an HTTP error.
+func actionGateHTTPStatus(code string) int {
+	switch code {
+	case actiongates.CodeUnauthorized:
+		return http.StatusUnauthorized
+	case actiongates.CodeAccessDenied:
+		return http.StatusForbidden
+	case actiongates.CodeNotFound:
+		return http.StatusNotFound
+	case actiongates.CodeConflict:
+		return http.StatusConflict
+	case actiongates.CodeServiceUnavailable:
+		return http.StatusServiceUnavailable
+	case actiongates.CodeInternalError:
+		return http.StatusInternalServerError
+	case actiongates.CodeRequireHuman:
+		return http.StatusOK
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// actionGateEdgeErrCode maps the gate Code to the Edge envelope `code`
+// string. Falls back to internal_error when the gate code is unknown so
+// the wire-shape stays consistent.
+func actionGateEdgeErrCode(code string) string {
+	switch code {
+	case actiongates.CodeUnauthorized:
+		return edgeErrCodeUnauthorized
+	case actiongates.CodeAccessDenied:
+		return edgeErrCodeAccessDenied
+	case actiongates.CodeNotFound:
+		return edgeErrCodeNotFound
+	case actiongates.CodeConflict:
+		return edgeErrCodeConflict
+	case actiongates.CodeServiceUnavailable:
+		return edgeErrCodeServiceUnavailable
+	case actiongates.CodeInternalError:
+		return edgeErrCodeInternalError
+	default:
+		return edgeErrCodeInternalError
+	}
+}
+
+// safeActionGateExtraKeys allowlists the Extra-map fields that may be
+// echoed back to the client. The list is intentionally narrow:
+//   - "gate" / "sub_reason" / "target_type": stable, sanitized identifiers.
+//   - "claim_present" / "claim_chars": coarse signals on whether a claim
+//     was offered, never the raw text.
+//   - "auth_tenant": present-tenant identifier; never the cross-tenant
+//     identifier (which would leak existence of another tenant).
+//
+// Raw target_path, target_url, args contents, claim text, and resolved
+// approval_ref are NEVER included — they are PII / abuse vectors.
+var safeActionGateExtraKeys = map[string]struct{}{
+	"gate":          {},
+	"sub_reason":    {},
+	"target_type":   {},
+	"auth_tenant":   {},
+	"claim_present": {},
+	"claim_chars":   {},
+	"verb":          {},
+	"kind":          {},
+}
+
+// sanitizeActionGateDetails returns the subset of dec.Extra that is safe
+// to echo back to the client per safeActionGateExtraKeys. Returns nil
+// when no safe fields remain so writeEdgeError does not emit an empty
+// `details` object.
+func sanitizeActionGateDetails(dec actiongates.ActionGateDecision) map[string]any {
+	if len(dec.Extra) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(dec.Extra))
+	for k, v := range dec.Extra {
+		if _, ok := safeActionGateExtraKeys[k]; ok {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// writeActionGatePolicyError emits the gateway response for a fired
+// action-gate decision. For REQUIRE_HUMAN at the policy/simulate
+// endpoint, it returns a 200 informational JSON shape (NOT an edge
+// error envelope) — simulate is non-blocking; the require-human signal
+// is informational. All other Codes route through writeEdgeError so the
+// envelope wire-shape stays consistent.
+func writeActionGatePolicyError(w http.ResponseWriter, r *http.Request, mode string, dec actiongates.ActionGateDecision) {
+	if dec.Code == actiongates.CodeRequireHuman && mode == "simulate" {
+		body := map[string]any{
+			"decision":  pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN.String(),
+			"reason":    dec.Reason,
+			"rule_id":   dec.GateID,
+			"gate":      dec.GateID,
+			"sub_reason": dec.SubReason,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(body)
+		return
+	}
+	status := actionGateHTTPStatus(dec.Code)
+	code := actionGateEdgeErrCode(dec.Code)
+	details := sanitizeActionGateDetails(dec)
+	writeEdgeError(w, r, status, code, dec.Reason, details)
+}

--- a/core/controlplane/gateway/actiongates_http_test.go
+++ b/core/controlplane/gateway/actiongates_http_test.go
@@ -1,0 +1,237 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/policy/actiongates"
+)
+
+func TestActionGateHTTPStatusMapping(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		code   string
+		status int
+	}{
+		{actiongates.CodeUnauthorized, http.StatusUnauthorized},
+		{actiongates.CodeAccessDenied, http.StatusForbidden},
+		{actiongates.CodeNotFound, http.StatusNotFound},
+		{actiongates.CodeConflict, http.StatusConflict},
+		{actiongates.CodeServiceUnavailable, http.StatusServiceUnavailable},
+		{actiongates.CodeInternalError, http.StatusInternalServerError},
+		{actiongates.CodeRequireHuman, http.StatusOK},
+		{"unknown_code", http.StatusInternalServerError},
+		{"", http.StatusInternalServerError},
+	}
+	for _, c := range cases {
+		t.Run(c.code, func(t *testing.T) {
+			t.Parallel()
+			if got := actionGateHTTPStatus(c.code); got != c.status {
+				t.Fatalf("actionGateHTTPStatus(%q) = %d, want %d", c.code, got, c.status)
+			}
+		})
+	}
+}
+
+func TestActionGateEdgeErrCodeMapping(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{actiongates.CodeUnauthorized, edgeErrCodeUnauthorized},
+		{actiongates.CodeAccessDenied, edgeErrCodeAccessDenied},
+		{actiongates.CodeNotFound, edgeErrCodeNotFound},
+		{actiongates.CodeConflict, edgeErrCodeConflict},
+		{actiongates.CodeServiceUnavailable, edgeErrCodeServiceUnavailable},
+		{actiongates.CodeInternalError, edgeErrCodeInternalError},
+		{"weird_value", edgeErrCodeInternalError},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			t.Parallel()
+			if got := actionGateEdgeErrCode(c.in); got != c.want {
+				t.Fatalf("actionGateEdgeErrCode(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeActionGateDetails(t *testing.T) {
+	t.Parallel()
+	dec := actiongates.ActionGateDecision{
+		Extra: map[string]string{
+			"gate":         "actiongate.tenant",
+			"sub_reason":   "cross_tenant:owner_mismatch",
+			"target_type":  "user",
+			"auth_tenant":  "tnt_a",
+			"target_path":  "/etc/passwd",                 // should be stripped
+			"target_url":   "https://leak.example.com/dump", // should be stripped
+			"args":         "force=true",                  // should be stripped
+			"claim_present": "true",
+			"claim_chars":  "<=128",
+			"approval_ref": "appr_secret",                 // should be stripped
+		},
+	}
+	got := sanitizeActionGateDetails(dec)
+	wantKeys := []string{"gate", "sub_reason", "target_type", "auth_tenant", "claim_present", "claim_chars"}
+	for _, k := range wantKeys {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing safe key %q in sanitized details", k)
+		}
+	}
+	bannedKeys := []string{"target_path", "target_url", "args", "approval_ref"}
+	for _, k := range bannedKeys {
+		if _, ok := got[k]; ok {
+			t.Errorf("unsafe key %q leaked into sanitized details", k)
+		}
+	}
+}
+
+func TestSanitizeActionGateDetailsEmpty(t *testing.T) {
+	t.Parallel()
+	// No safe keys -> nil result so writeEdgeError omits the field.
+	dec := actiongates.ActionGateDecision{Extra: map[string]string{"target_path": "/etc/passwd"}}
+	if got := sanitizeActionGateDetails(dec); got != nil {
+		t.Fatalf("only-unsafe extras: got %#v, want nil", got)
+	}
+	// Nil extras -> nil result.
+	if got := sanitizeActionGateDetails(actiongates.ActionGateDecision{}); got != nil {
+		t.Fatalf("nil extras: got %#v, want nil", got)
+	}
+}
+
+// TestWriteActionGatePolicyErrorAllStatuses exercises the 6 non-informational
+// status codes through writeActionGatePolicyError, asserting both HTTP status
+// and the edge envelope wire shape.
+func TestWriteActionGatePolicyErrorAllStatuses(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		code       string
+		wantStatus int
+		wantCode   string
+	}{
+		{"unauthorized_401", actiongates.CodeUnauthorized, 401, edgeErrCodeUnauthorized},
+		{"access_denied_403", actiongates.CodeAccessDenied, 403, edgeErrCodeAccessDenied},
+		{"not_found_404", actiongates.CodeNotFound, 404, edgeErrCodeNotFound},
+		{"conflict_409", actiongates.CodeConflict, 409, edgeErrCodeConflict},
+		{"internal_500", actiongates.CodeInternalError, 500, edgeErrCodeInternalError},
+		{"unavailable_503", actiongates.CodeServiceUnavailable, 503, edgeErrCodeServiceUnavailable},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			dec := actiongates.ActionGateDecision{
+				Code:      c.code,
+				GateID:    "actiongate.test",
+				Reason:    "test reason",
+				SubReason: "test_sub",
+				Extra:     map[string]string{"gate": "actiongate.test", "sub_reason": "test_sub"},
+			}
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/policy/simulate", nil)
+			writeActionGatePolicyError(rr, req, "simulate", dec)
+
+			if rr.Code != c.wantStatus {
+				t.Fatalf("status = %d, want %d", rr.Code, c.wantStatus)
+			}
+			var env edgeErrorEnvelope
+			if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode response: %v body=%s", err, rr.Body.String())
+			}
+			if env.Code != c.wantCode {
+				t.Fatalf("envelope.code = %q, want %q", env.Code, c.wantCode)
+			}
+			if env.Message != "test reason" {
+				t.Fatalf("envelope.message = %q, want \"test reason\"", env.Message)
+			}
+			if env.Details == nil || env.Details["gate"] != "actiongate.test" || env.Details["sub_reason"] != "test_sub" {
+				t.Fatalf("envelope.details = %#v, want gate+sub_reason fields", env.Details)
+			}
+		})
+	}
+}
+
+// TestWriteActionGatePolicyErrorRequireHumanSimulateIs200 verifies that
+// REQUIRE_HUMAN at the simulate endpoint returns 200 informational JSON,
+// NOT an error envelope. The body shape mirrors the regular simulate
+// response so SDKs can switch on decision=REQUIRE_HUMAN.
+func TestWriteActionGatePolicyErrorRequireHumanSimulateIs200(t *testing.T) {
+	t.Parallel()
+	dec := actiongates.ActionGateDecision{
+		Code:      actiongates.CodeRequireHuman,
+		GateID:    "actiongate.mutation",
+		Reason:    "destructive action requires human approval",
+		SubReason: "missing_approval",
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/policy/simulate", nil)
+	writeActionGatePolicyError(rr, req, "simulate", dec)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for simulate REQUIRE_HUMAN", rr.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["decision"] != "DECISION_TYPE_REQUIRE_HUMAN" {
+		t.Fatalf("decision = %v, want DECISION_TYPE_REQUIRE_HUMAN", body["decision"])
+	}
+	if body["rule_id"] != "actiongate.mutation" || body["gate"] != "actiongate.mutation" {
+		t.Fatalf("rule_id/gate missing: %#v", body)
+	}
+	if body["sub_reason"] != "missing_approval" {
+		t.Fatalf("sub_reason = %v, want missing_approval", body["sub_reason"])
+	}
+	// Must NOT be the edge error envelope.
+	if _, hasCode := body["code"]; hasCode {
+		if _, hasMsg := body["message"]; hasMsg {
+			t.Fatal("simulate REQUIRE_HUMAN must not return an edge error envelope")
+		}
+	}
+}
+
+func TestSafeActionGateExtraKeysCoverDefaults(t *testing.T) {
+	t.Parallel()
+	must := []string{"gate", "sub_reason", "target_type", "auth_tenant"}
+	for _, k := range must {
+		if _, ok := safeActionGateExtraKeys[k]; !ok {
+			t.Errorf("safeActionGateExtraKeys missing %q", k)
+		}
+	}
+}
+
+// TestPolicySimulateActionGateMapping is the per-DoD-line marker that
+// the 6 status codes are mapped. This is a guard against future Code
+// additions that forget to wire HTTP status.
+func TestPolicySimulateActionGateMapping(t *testing.T) {
+	t.Parallel()
+	codes := map[string]int{
+		actiongates.CodeUnauthorized:       401,
+		actiongates.CodeAccessDenied:       403,
+		actiongates.CodeNotFound:           404,
+		actiongates.CodeConflict:           409,
+		actiongates.CodeInternalError:      500,
+		actiongates.CodeServiceUnavailable: 503,
+	}
+	for code, want := range codes {
+		if got := actionGateHTTPStatus(code); got != want {
+			t.Errorf("DoD line 4 mapping broken: %q -> %d, want %d", code, got, want)
+		}
+	}
+	// Bonus: simulate REQUIRE_HUMAN must not be a 4xx/5xx.
+	if got := actionGateHTTPStatus(actiongates.CodeRequireHuman); got >= 400 {
+		t.Errorf("require_human at simulate must be informational, got %d", got)
+	}
+	// Bonus: also verify edge envelope coverage so callers can switch on `code`.
+	for code := range codes {
+		if ec := actionGateEdgeErrCode(code); ec == "" || strings.TrimSpace(ec) == "" {
+			t.Errorf("edge envelope code missing for gate Code %q", code)
+		}
+	}
+}

--- a/core/controlplane/gateway/gateway.go
+++ b/core/controlplane/gateway/gateway.go
@@ -1287,11 +1287,6 @@ func (s *server) registerRoutes(mux *http.ServeMux) error {
 	s.registerRoute(mux, "GET /api/v1/audit/verify", s.instrumented("/api/v1/audit/verify", s.handleAuditVerify))
 	// 2.7.2 Audit events read surface — the SIEM-feed endpoint backing
 	// the dashboard Audit Log page. Walks the per-tenant Redis Stream
-	// populated by the chainer, so every chained event (MCP, edge,
-	// worker, output policy, delegation, ...) is reachable from one
-	// read. /policy/audit remains for the policy-bundle audit subset;
-	// the two surfaces are intentionally distinct.
-	s.registerRoute(mux, "GET /api/v1/audit/events", s.instrumented("/api/v1/audit/events", s.handleListAuditEvents))
 	s.registerRoute(mux, "GET /api/v1/governance/health", s.instrumented("/api/v1/governance/health", s.handleGovernanceHealth))
 
 	// 2.8 Legal hold management (admin only, entitlement-gated)

--- a/core/controlplane/gateway/gateway.go
+++ b/core/controlplane/gateway/gateway.go
@@ -1293,8 +1293,6 @@ func (s *server) registerRoutes(mux *http.ServeMux) error {
 	// that had /api/v1/audit/verify 404ing on fresh deploys despite the
 	// handler being fully implemented and unit-tested.
 	s.registerRoute(mux, "GET /api/v1/audit/verify", s.instrumented("/api/v1/audit/verify", s.handleAuditVerify))
-	// 2.7.2 Audit events read surface — the SIEM-feed endpoint backing
-	// the dashboard Audit Log page. Walks the per-tenant Redis Stream
 	s.registerRoute(mux, "GET /api/v1/governance/health", s.instrumented("/api/v1/governance/health", s.handleGovernanceHealth))
 
 	// 2.8 Legal hold management (admin only, entitlement-gated)

--- a/core/controlplane/gateway/gateway.go
+++ b/core/controlplane/gateway/gateway.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cordum/cordum/core/infra/tlsreload"
 	"github.com/cordum/cordum/core/licensing"
 	"github.com/cordum/cordum/core/model"
+	"github.com/cordum/cordum/core/policy/actiongates"
 	"github.com/cordum/cordum/core/policyshadow"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 	"github.com/cordum/cordum/core/telemetry"
@@ -177,6 +178,12 @@ type server struct {
 	schemaEnforcement schema.EnforcementMode
 	safetyConn        *grpc.ClientConn
 	safetyClient      pb.SafetyKernelClient
+	// actionGatePipeline runs deterministic pre-rule action-layer gates
+	// (tenant/file/url/mcp/mutation/provenance) for HTTP policy + edge
+	// evaluate endpoints. Production wires this at startup; tests inject
+	// a stub. nil = action gates disabled (falls through to legacy
+	// safetyClient.Evaluate / Simulate / Explain).
+	actionGatePipeline *actiongates.Pipeline
 	userStore         auth.UserStore
 	keyStore          auth.KeyStore
 	rbacStore         *auth.RBACStore
@@ -1278,6 +1285,13 @@ func (s *server) registerRoutes(mux *http.ServeMux) error {
 	// that had /api/v1/audit/verify 404ing on fresh deploys despite the
 	// handler being fully implemented and unit-tested.
 	s.registerRoute(mux, "GET /api/v1/audit/verify", s.instrumented("/api/v1/audit/verify", s.handleAuditVerify))
+	// 2.7.2 Audit events read surface — the SIEM-feed endpoint backing
+	// the dashboard Audit Log page. Walks the per-tenant Redis Stream
+	// populated by the chainer, so every chained event (MCP, edge,
+	// worker, output policy, delegation, ...) is reachable from one
+	// read. /policy/audit remains for the policy-bundle audit subset;
+	// the two surfaces are intentionally distinct.
+	s.registerRoute(mux, "GET /api/v1/audit/events", s.instrumented("/api/v1/audit/events", s.handleListAuditEvents))
 	s.registerRoute(mux, "GET /api/v1/governance/health", s.instrumented("/api/v1/governance/health", s.handleGovernanceHealth))
 
 	// 2.8 Legal hold management (admin only, entitlement-gated)

--- a/core/controlplane/gateway/gateway.go
+++ b/core/controlplane/gateway/gateway.go
@@ -704,6 +704,14 @@ func RunWithAuth(cfg *config.Config, provider auth.AuthProvider, entitlementReso
 		heartbeatMode:          scheduler.ParseHeartbeatMode(os.Getenv(scheduler.EnvHeartbeatMode)),
 		shutdownCh:             make(chan struct{}),
 	}
+	// Production action-gate pipeline wiring. Must be called after the
+	// server struct is populated (edgeStore + agentIdentityStore must be
+	// non-nil for the gate dependencies to bind) and before any HTTP
+	// handler can fire — so before middleware chain assembly and Serve.
+	// handlers_policy.go consults s.actionGatePipeline; populating it
+	// here turns previously-dead actiongates_http.go and gate-fire
+	// branches into the live request path.
+	s.wireActionGatePipeline()
 	s.syncApprovalQueueDepth(context.Background())
 	defer s.Close()
 	telemetryStore, err := telemetry.NewStore(cfg.RedisURL)

--- a/core/controlplane/gateway/handlers_policy.go
+++ b/core/controlplane/gateway/handlers_policy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cordum/cordum/core/controlplane/gateway/auth"
 	"github.com/cordum/cordum/core/controlplane/gateway/policybundles"
+	"github.com/cordum/cordum/core/infra/config"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -82,6 +83,25 @@ func (s *server) handlePolicyCheck(w http.ResponseWriter, r *http.Request, mode 
 	if err != nil {
 		writeErrorJSON(w, http.StatusBadRequest, err.Error())
 		return
+	}
+
+	// Action-layer gates run BEFORE the safety-kernel call. The pipeline
+	// short-circuits with an HTTP error envelope (or a 200 informational
+	// shape for simulate REQUIRE_HUMAN) so the caller learns the exact
+	// gate Code via HTTP status. Callers that send no Action skip this
+	// path; legacy behavior is unchanged.
+	if s.actionGatePipeline != nil && req.Action != nil {
+		input := &config.PolicyInput{
+			Tenant: tenant,
+			Topic:  req.Topic,
+			Labels: req.Labels,
+			Meta:   config.PolicyMeta{ActorID: req.PrincipalId},
+			Action: req.Action,
+		}
+		if gateDec, fired := s.actionGatePipeline.Run(r.Context(), input); fired {
+			writeActionGatePolicyError(w, r, mode, gateDec)
+			return
+		}
 	}
 
 	var resp *pb.PolicyCheckResponse

--- a/core/controlplane/gateway/helpers.go
+++ b/core/controlplane/gateway/helpers.go
@@ -81,21 +81,28 @@ type policyMetaRequest struct {
 }
 
 type policyCheckRequest struct {
-	JobId           string             `json:"job_id"`
-	Topic           string             `json:"topic"`
-	Tenant          string             `json:"tenant"`
-	OrgId           string             `json:"org_id"`
-	TeamId          string             `json:"team_id"`
-	WorkflowId      string             `json:"workflow_id"`
-	StepId          string             `json:"step_id"`
-	PrincipalId     string             `json:"principal_id"`
-	Priority        string             `json:"priority"`
-	EstimatedCost   float64            `json:"estimated_cost"`
-	Budget          *pb.Budget         `json:"budget"`
-	Labels          map[string]string  `json:"labels"`
-	MemoryId        string             `json:"memory_id"`
-	EffectiveConfig any                `json:"effective_config"`
-	Meta            *policyMetaRequest `json:"meta"`
+	JobId           string                    `json:"job_id"`
+	Topic           string                    `json:"topic"`
+	Tenant          string                    `json:"tenant"`
+	OrgId           string                    `json:"org_id"`
+	TeamId          string                    `json:"team_id"`
+	WorkflowId      string                    `json:"workflow_id"`
+	StepId          string                    `json:"step_id"`
+	PrincipalId     string                    `json:"principal_id"`
+	Priority        string                    `json:"priority"`
+	EstimatedCost   float64                   `json:"estimated_cost"`
+	Budget          *pb.Budget                `json:"budget"`
+	Labels          map[string]string         `json:"labels"`
+	MemoryId        string                    `json:"memory_id"`
+	EffectiveConfig any                       `json:"effective_config"`
+	Meta            *policyMetaRequest        `json:"meta"`
+	// Action carries structured request metadata for deterministic
+	// pre-rule action-layer gates (file/url/tenant/mutation/mcp/
+	// provenance). When non-nil and the gateway is wired with a
+	// pipeline, gates run before the kernel call and may short-circuit
+	// with an HTTP error envelope. Existing callers that send no Action
+	// are unaffected.
+	Action *config.ActionDescriptor `json:"action,omitempty"`
 }
 
 func (r *submitJobRequest) applyDefaults(defaultTenant string) {

--- a/core/controlplane/gateway/helpers.go
+++ b/core/controlplane/gateway/helpers.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"reflect"
@@ -426,6 +427,29 @@ func buildPolicyCheckRequest(ctx context.Context, req *policyCheckRequest, cfgSv
 	}
 	meta := buildJobMetadata(req.Meta, tenant, strings.TrimSpace(req.PrincipalId))
 
+	// Propagate ActionDescriptor across the gRPC boundary by encoding it
+	// into a reserved Labels key. The `_` prefix is stripped by the
+	// label-clean loop in this package (see clean loop in injectContentLabels)
+	// so it never leaks back to clients. The kernel's
+	// safetykernel.actionDescriptorFromRequest extractor reads this key.
+	labels := req.Labels
+	if req.Action != nil {
+		encoded, err := encodeActionDescriptorLabel(req.Action)
+		if err != nil {
+			return nil, fmt.Errorf("encode action descriptor: %w", err)
+		}
+		if encoded != "" {
+			if labels == nil {
+				labels = make(map[string]string, 1)
+			} else {
+				next := make(map[string]string, len(labels)+1)
+				maps.Copy(next, labels)
+				labels = next
+			}
+			labels[labelActionDescriptorJSON] = encoded
+		}
+	}
+
 	checkReq := &pb.PolicyCheckRequest{
 		JobId:         strings.TrimSpace(req.JobId),
 		Topic:         topic,
@@ -434,7 +458,7 @@ func buildPolicyCheckRequest(ctx context.Context, req *policyCheckRequest, cfgSv
 		EstimatedCost: req.EstimatedCost,
 		Budget:        req.Budget,
 		PrincipalId:   strings.TrimSpace(req.PrincipalId),
-		Labels:        req.Labels,
+		Labels:        labels,
 		MemoryId:      strings.TrimSpace(req.MemoryId),
 		Meta:          meta,
 	}

--- a/core/controlplane/gateway/helpers.go
+++ b/core/controlplane/gateway/helpers.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"net/http"
 	"os"
 	"reflect"
@@ -432,7 +431,17 @@ func buildPolicyCheckRequest(ctx context.Context, req *policyCheckRequest, cfgSv
 	// label-clean loop in this package (see clean loop in injectContentLabels)
 	// so it never leaks back to clients. The kernel's
 	// safetykernel.actionDescriptorFromRequest extractor reads this key.
-	labels := req.Labels
+	//
+	// Defense-in-depth: ALWAYS strip the descriptor key from the client-
+	// supplied Labels first, then re-inject only when this gateway has
+	// authenticated/validated a real Action from the parsed HTTP body.
+	// Without the strip, a client could set `_action.descriptor_json`
+	// directly with `req.Action=nil` and the kernel-side extractor
+	// would consume attacker-controlled descriptor data, allowing
+	// confused-deputy audit log poisoning (target_type values surface
+	// in SIEM events) and unverified gate decisions on the kernel
+	// defensive path.
+	labels := stripReservedActionDescriptorLabel(req.Labels)
 	if req.Action != nil {
 		encoded, err := encodeActionDescriptorLabel(req.Action)
 		if err != nil {
@@ -441,10 +450,6 @@ func buildPolicyCheckRequest(ctx context.Context, req *policyCheckRequest, cfgSv
 		if encoded != "" {
 			if labels == nil {
 				labels = make(map[string]string, 1)
-			} else {
-				next := make(map[string]string, len(labels)+1)
-				maps.Copy(next, labels)
-				labels = next
 			}
 			labels[labelActionDescriptorJSON] = encoded
 		}

--- a/core/controlplane/safetykernel/kernel.go
+++ b/core/controlplane/safetykernel/kernel.go
@@ -33,9 +33,11 @@ import (
 	infraHealth "github.com/cordum/cordum/core/infra/health"
 	cordumotel "github.com/cordum/cordum/core/infra/otel"
 	"github.com/cordum/cordum/core/infra/redisutil"
+	"github.com/cordum/cordum/core/audit"
 	"github.com/cordum/cordum/core/infra/store"
 	"github.com/cordum/cordum/core/infra/tlsreload"
 	"github.com/cordum/cordum/core/licensing"
+	"github.com/cordum/cordum/core/policy/actiongates"
 	capsdk "github.com/cordum/cordum/core/protocol/capsdk"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 	"github.com/nats-io/nats.go"
@@ -102,7 +104,28 @@ type server struct {
 	// for a topic, it replaces client-supplied risk_tags with authoritative
 	// tags derived from the job content. Prevents risk tag spoofing.
 	tagDeriverRegistry *TagDeriverRegistry
+
+	// actionGatePipeline runs deterministic pre-rule action-layer gates
+	// (tenant / file / url / mcp / mutation / provenance) when an
+	// ActionDescriptor is supplied for a request. Unset = legacy rule
+	// evaluation only.
+	actionGatePipeline *actiongates.Pipeline
+	// actionExtractor maps the gRPC request to an ActionDescriptor.
+	// Wired in-process by the gateway; gRPC clients without an in-process
+	// gateway never trigger action gates.
+	actionExtractor ActionDescriptorExtractor
+	// actionGateAuditSink is invoked when the action-gate pipeline fires
+	// a non-allow decision. Production wires this to a function that
+	// records the SIEMEvent into the BufferedExporter and appends to the
+	// audit Chainer. Nil = log-only.
+	actionGateAuditSink func(ctx context.Context, event audit.SIEMEvent)
 }
+
+// ActionDescriptorExtractor maps a PolicyCheckRequest to the structured
+// ActionDescriptor that the action-layer gates consume. The gateway
+// middleware wires this server-side; clients cannot inject an
+// ActionDescriptor over the wire.
+type ActionDescriptorExtractor func(ctx context.Context, req *pb.PolicyCheckRequest) *config.ActionDescriptor
 
 const (
 	defaultPolicyConfigID           = "policy"
@@ -131,6 +154,34 @@ type cacheEntry struct {
 type agentCacheEntry struct {
 	identity *store.AgentIdentity
 	expires  time.Time
+}
+
+// SetActionGatePipeline installs the action-layer gate pipeline. The
+// pipeline runs before legacy rule evaluation; only requests whose
+// extractor returns a non-nil ActionDescriptor are evaluated by it.
+// nil disables action-gate evaluation.
+func (s *server) SetActionGatePipeline(p *actiongates.Pipeline) {
+	s.mu.Lock()
+	s.actionGatePipeline = p
+	s.mu.Unlock()
+}
+
+// SetActionDescriptorExtractor installs the request→descriptor adapter.
+// Wired in-process by the gateway middleware; never exposed to the wire.
+func (s *server) SetActionDescriptorExtractor(fn ActionDescriptorExtractor) {
+	s.mu.Lock()
+	s.actionExtractor = fn
+	s.mu.Unlock()
+}
+
+// SetActionGateAuditSink installs the audit emission hook. Invoked
+// synchronously when an action-gate pipeline fires a non-allow decision.
+// Production wires this to a function that fans out to the SIEM
+// BufferedExporter and the per-tenant audit Chainer.
+func (s *server) SetActionGateAuditSink(fn func(ctx context.Context, event audit.SIEMEvent)) {
+	s.mu.Lock()
+	s.actionGateAuditSink = fn
+	s.mu.Unlock()
 }
 
 func (s *server) SetShadowEvaluator(eval *ShadowEvaluator) {
@@ -667,6 +718,29 @@ func (s *server) evaluate(ctx context.Context, req *pb.PolicyCheckRequest, metho
 
 	input.SecretsPresent = secretsPresent(input.Meta, req.GetLabels())
 	s.enrichAgentContext(ctx, req.GetLabels(), &input)
+
+	// Action-layer gates run BEFORE legacy rule evaluation. The pipeline
+	// short-circuits on the first non-ALLOW decision; an empty result
+	// falls through to the existing evaluator. Both the extractor and the
+	// pipeline are nil for clients running without the in-process gateway
+	// wiring, so the legacy path is unchanged for plain gRPC consumers.
+	s.mu.RLock()
+	gatePipeline := s.actionGatePipeline
+	gateExtractor := s.actionExtractor
+	gateAuditSink := s.actionGateAuditSink
+	s.mu.RUnlock()
+	if gateExtractor != nil {
+		input.Action = gateExtractor(ctx, req)
+	}
+	if gatePipeline != nil && input.Action != nil {
+		if gateDec, fired := gatePipeline.Run(ctx, &input); fired {
+			resp := actionGateResponse(gateDec, snapshot)
+			if gateAuditSink != nil {
+				gateAuditSink(ctx, actionGateAuditEvent(req, &input, gateDec))
+			}
+			return resp, nil
+		}
+	}
 
 	evalTracer := cordumotel.Tracer("cordum-safety-kernel")
 	_, evalSpan := evalTracer.Start(ctx, "safety.evaluate",

--- a/core/controlplane/safetykernel/kernel.go
+++ b/core/controlplane/safetykernel/kernel.go
@@ -376,6 +376,15 @@ func RunWithEntitlements(cfg *config.Config, resolver *licensing.EntitlementReso
 		tagDeriverRegistry: tagRegistry,
 	}
 
+	// Production wiring for the action-layer gate pipeline. Fail-closed
+	// on construction error so a kernel never serves traffic with the
+	// pipeline silently disabled. The kernel's pipeline runs defensive
+	// gates with no backend dependencies; the gateway path holds the
+	// primary enforcement surface with full approval+chain lookups.
+	if err := wireActionGatePipeline(srv, nil); err != nil {
+		return fmt.Errorf("wire action gate pipeline: %w", err)
+	}
+
 	// Phase-2 shadow dual-evaluation: constructs the shadow loader +
 	// evaluator and attaches them to srv via SetShadowEvaluator so
 	// evaluate() can Submit active decisions without a nil-panic. When

--- a/core/controlplane/safetykernel/kernel_actiongate.go
+++ b/core/controlplane/safetykernel/kernel_actiongate.go
@@ -1,0 +1,117 @@
+package safetykernel
+
+import (
+	"time"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy/actiongates"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// actionGateResponse maps an ActionGateDecision to the gRPC response
+// envelope. MatchedRule is stable across deploys ("actiongate.<id>") so
+// SIEM consumers can pivot without parsing free-form Reason fields.
+// The PolicySnapshot is the kernel's current snapshot so cache-key
+// downstream consumers can disambiguate decisions across policy bumps.
+func actionGateResponse(dec actiongates.ActionGateDecision, snapshot string) *pb.PolicyCheckResponse {
+	resp := &pb.PolicyCheckResponse{
+		Decision:       dec.Decision,
+		Reason:         dec.Reason,
+		RuleId:         dec.GateID,
+		PolicySnapshot: snapshot,
+	}
+	if dec.Decision == pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+		resp.ApprovalRequired = true
+	}
+	return resp
+}
+
+// actionGateAuditEvent constructs the SIEM event recorded when the
+// action-gate pipeline short-circuits with a non-allow decision. Extra
+// carries gate + sub_reason + safe target metadata only — raw target
+// paths / URLs / args are PII-risk and never embedded here.
+func actionGateAuditEvent(req *pb.PolicyCheckRequest, input *config.PolicyInput, dec actiongates.ActionGateDecision) audit.SIEMEvent {
+	tenant := ""
+	if input != nil {
+		tenant = input.Tenant
+	}
+	if tenant == "" {
+		tenant = req.GetTenant()
+	}
+	agentID := ""
+	if input != nil {
+		agentID = input.Meta.AgentID
+	}
+	severity := actionGateSeverity(dec)
+	extra := make(map[string]string, len(dec.Extra)+2)
+	for k, v := range dec.Extra {
+		extra[k] = v
+	}
+	if extra["gate"] == "" && dec.GateID != "" {
+		extra["gate"] = dec.GateID
+	}
+	if extra["sub_reason"] == "" && dec.SubReason != "" {
+		extra["sub_reason"] = dec.SubReason
+	}
+	if input != nil && input.Action != nil && input.Action.TargetResource != nil && input.Action.TargetResource.Type != "" {
+		extra["target_type"] = input.Action.TargetResource.Type
+	}
+	return audit.SIEMEvent{
+		Timestamp:   time.Now().UTC(),
+		EventType:   audit.EventActionGateDenied,
+		Severity:    severity,
+		TenantID:    tenant,
+		AgentID:     agentID,
+		JobID:       req.GetJobId(),
+		Action:      dec.GateID,
+		Decision:    dec.Decision.String(),
+		MatchedRule: dec.GateID,
+		Reason:      dec.Reason,
+		Extra:       extra,
+	}
+}
+
+// actionGateSeverity buckets the SIEM severity for a denial. Cross-tenant
+// access, credential paths, exfil destinations, and self-approval are
+// HIGH because they map to known attacker behaviors. REQUIRE_HUMAN
+// outcomes are MEDIUM (process gating, not a hostile probe).
+func actionGateSeverity(dec actiongates.ActionGateDecision) string {
+	if dec.Decision == pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+		return audit.SeverityMedium
+	}
+	switch {
+	case containsAny(dec.SubReason, "cross_tenant", "self_approval", "credential_path", "credential_pattern", "exfil_destination", "metadata_service", "prompt_exfil", "approval_tenant_mismatch"):
+		return audit.SeverityHigh
+	default:
+		return audit.SeverityMedium
+	}
+}
+
+// containsAny reports whether s contains any of the supplied substrings.
+// Local helper to avoid a tiny strings.Contains loop at the call site.
+func containsAny(s string, needles ...string) bool {
+	for _, n := range needles {
+		if n != "" && indexOfSubstring(s, n) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOfSubstring(s, sub string) int {
+	n := len(s)
+	m := len(sub)
+	if m == 0 {
+		return 0
+	}
+	if m > n {
+		return -1
+	}
+	for i := 0; i+m <= n; i++ {
+		if s[i:i+m] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/core/controlplane/safetykernel/kernel_actiongate_test.go
+++ b/core/controlplane/safetykernel/kernel_actiongate_test.go
@@ -1,0 +1,184 @@
+package safetykernel
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy/actiongates"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// stubGate is a minimal ActionGate the kernel test uses to drive the
+// pipeline without depending on real gates' fakes.
+type stubGate struct {
+	id  string
+	out actiongates.ActionGateDecision
+}
+
+func (g *stubGate) ID() string { return g.id }
+
+func (g *stubGate) Evaluate(_ context.Context, _ *config.PolicyInput) actiongates.ActionGateDecision {
+	return g.out
+}
+
+// TestCheckActionGateShortCircuits proves the kernel's Check path runs
+// the action-gate pipeline BEFORE legacy rule evaluation, and that a
+// firing gate decision is mapped to the response without consulting
+// rules.
+func TestCheckActionGateShortCircuits(t *testing.T) {
+	// Permissive default policy: if rules ran, the response would be ALLOW.
+	srv := &server{policy: &config.SafetyPolicy{
+		DefaultTenant:   "default",
+		DefaultDecision: "allow",
+		Tenants: map[string]config.TenantPolicy{
+			"default": {AllowTopics: []string{"job.*"}},
+		},
+	}}
+
+	denied := actiongates.ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_DENY,
+		GateID:    "actiongate.test",
+		Code:      actiongates.CodeAccessDenied,
+		Reason:    "denied by stub gate",
+		SubReason: "cross_tenant:test_sub",
+		Extra: map[string]string{
+			"gate":       "actiongate.test",
+			"sub_reason": "cross_tenant:test_sub",
+		},
+	}
+	srv.SetActionGatePipeline(actiongates.NewPipeline(&stubGate{id: "actiongate.test", out: denied}))
+	srv.SetActionDescriptorExtractor(func(_ context.Context, _ *pb.PolicyCheckRequest) *config.ActionDescriptor {
+		return &config.ActionDescriptor{Kind: config.ActionKindMutation, Verb: config.ActionVerbDelete}
+	})
+
+	var (
+		sinkMu     sync.Mutex
+		sinkEvents []audit.SIEMEvent
+	)
+	srv.SetActionGateAuditSink(func(_ context.Context, e audit.SIEMEvent) {
+		sinkMu.Lock()
+		defer sinkMu.Unlock()
+		sinkEvents = append(sinkEvents, e)
+	})
+
+	req := &pb.PolicyCheckRequest{
+		JobId:  "job-actiongate-1",
+		Topic:  "job.default",
+		Tenant: "default",
+	}
+
+	resp, err := srv.Check(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Check error: %v", err)
+	}
+	if resp.GetDecision() != pb.DecisionType_DECISION_TYPE_DENY {
+		t.Fatalf("decision = %v, want DENY (gate fired)", resp.GetDecision())
+	}
+	if resp.GetReason() != "denied by stub gate" {
+		t.Fatalf("reason = %q, want gate reason", resp.GetReason())
+	}
+	if resp.GetRuleId() != "actiongate.test" {
+		t.Fatalf("rule_id = %q, want actiongate.test", resp.GetRuleId())
+	}
+
+	sinkMu.Lock()
+	defer sinkMu.Unlock()
+	if len(sinkEvents) != 1 {
+		t.Fatalf("audit sink received %d events, want 1", len(sinkEvents))
+	}
+	ev := sinkEvents[0]
+	if ev.EventType != audit.EventActionGateDenied {
+		t.Fatalf("event_type = %q, want %q", ev.EventType, audit.EventActionGateDenied)
+	}
+	if ev.Severity != audit.SeverityHigh {
+		t.Fatalf("severity = %q, want HIGH for cross_tenant", ev.Severity)
+	}
+	if ev.MatchedRule != "actiongate.test" || ev.Action != "actiongate.test" {
+		t.Fatalf("identifying fields = matched=%q action=%q", ev.MatchedRule, ev.Action)
+	}
+	if ev.JobID != "job-actiongate-1" {
+		t.Fatalf("job_id = %q, want propagated from request", ev.JobID)
+	}
+	if ev.Extra["gate"] != "actiongate.test" || ev.Extra["sub_reason"] != "cross_tenant:test_sub" {
+		t.Fatalf("extra = %#v, missing gate/sub_reason", ev.Extra)
+	}
+}
+
+// TestCheckNoActionGateExtractorFallsThrough proves that a kernel with
+// a pipeline but no extractor leaves input.Action nil and falls back to
+// the legacy rule path. Same setup as the short-circuit test minus the
+// extractor → the policy now decides.
+func TestCheckNoActionGateExtractorFallsThrough(t *testing.T) {
+	srv := &server{policy: &config.SafetyPolicy{
+		DefaultTenant:   "default",
+		DefaultDecision: "allow",
+		Tenants: map[string]config.TenantPolicy{
+			"default": {AllowTopics: []string{"job.*"}},
+		},
+	}}
+	denied := actiongates.ActionGateDecision{
+		Decision: pb.DecisionType_DECISION_TYPE_DENY,
+		GateID:   "actiongate.test",
+		Reason:   "should not fire",
+	}
+	srv.SetActionGatePipeline(actiongates.NewPipeline(&stubGate{id: "actiongate.test", out: denied}))
+	// NOTE: no extractor wired -> input.Action stays nil -> pipeline no-op.
+
+	req := &pb.PolicyCheckRequest{
+		JobId:  "job-fallthrough",
+		Topic:  "job.default",
+		Tenant: "default",
+	}
+	resp, err := srv.Check(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Check error: %v", err)
+	}
+	if resp.GetDecision() != pb.DecisionType_DECISION_TYPE_ALLOW {
+		t.Fatalf("decision = %v, want ALLOW (legacy path, default allow)", resp.GetDecision())
+	}
+	if resp.GetRuleId() == "actiongate.test" {
+		t.Fatalf("rule_id = %q, want non-gate id (pipeline must have been skipped)", resp.GetRuleId())
+	}
+}
+
+// TestCheckActionGateRequireHumanMediumSeverity exercises the severity
+// bucket for REQUIRE_HUMAN — MEDIUM, not HIGH.
+func TestCheckActionGateRequireHumanMediumSeverity(t *testing.T) {
+	srv := &server{policy: &config.SafetyPolicy{
+		DefaultTenant:   "default",
+		DefaultDecision: "allow",
+		Tenants:         map[string]config.TenantPolicy{"default": {AllowTopics: []string{"job.*"}}},
+	}}
+	rh := actiongates.ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN,
+		GateID:    "actiongate.test",
+		Code:      actiongates.CodeRequireHuman,
+		Reason:    "human approval required",
+		SubReason: "missing_approval",
+	}
+	srv.SetActionGatePipeline(actiongates.NewPipeline(&stubGate{id: "actiongate.test", out: rh}))
+	srv.SetActionDescriptorExtractor(func(_ context.Context, _ *pb.PolicyCheckRequest) *config.ActionDescriptor {
+		return &config.ActionDescriptor{Kind: config.ActionKindMutation, Verb: config.ActionVerbDelete}
+	})
+	var sinkEv audit.SIEMEvent
+	srv.SetActionGateAuditSink(func(_ context.Context, e audit.SIEMEvent) { sinkEv = e })
+
+	resp, err := srv.Check(context.Background(), &pb.PolicyCheckRequest{
+		JobId: "job-rh", Topic: "job.default", Tenant: "default",
+	})
+	if err != nil {
+		t.Fatalf("Check error: %v", err)
+	}
+	if resp.GetDecision() != pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+		t.Fatalf("decision = %v, want REQUIRE_HUMAN", resp.GetDecision())
+	}
+	if !resp.GetApprovalRequired() {
+		t.Fatal("approval_required = false, want true")
+	}
+	if sinkEv.Severity != audit.SeverityMedium {
+		t.Fatalf("severity = %q, want MEDIUM for REQUIRE_HUMAN", sinkEv.Severity)
+	}
+}

--- a/core/controlplane/safetykernel/kernel_actiongate_wire.go
+++ b/core/controlplane/safetykernel/kernel_actiongate_wire.go
@@ -1,0 +1,129 @@
+package safetykernel
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/cordum/cordum/core/audit"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policy/actiongates"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// LabelActionDescriptorJSON is the reserved Labels-map key the gateway
+// uses to propagate a JSON-encoded ActionDescriptor across the gRPC
+// boundary. The `_` prefix is what the gateway's existing label-strip
+// (helpers.go injectContentLabels + clean loop) treats as "system-only"
+// so this key never leaks back to clients in label echo responses.
+const LabelActionDescriptorJSON = "_action.descriptor_json"
+
+// wireActionGatePipeline installs the action-layer gate pipeline,
+// request→descriptor extractor, and audit sink on the safety-kernel
+// server. It is invoked from RunWithEntitlements once after the server
+// is constructed but before grpcServer.Serve, so the registered handler
+// observes a non-nil pipeline on the very first request.
+//
+// Kernel-side wiring is intentionally defense-in-depth: the gateway
+// path enforces the primary action-gate decisions with full backend
+// dependencies (ApprovalLookup, ChainVerifier). The kernel boot path
+// runs without direct access to those stores, so destructive verbs and
+// MCP calls reaching the kernel via a direct gRPC client (bypassing
+// the gateway) fail closed at the mutation/MCP/provenance gates. The
+// tenant/file/url gates remain fully functional because they need no
+// backend lookups. Non-destructive non-MCP traffic with a populated
+// ActionDescriptor still benefits from cross-tenant, sensitive-path,
+// and metadata-service enforcement at the kernel.
+//
+// Returns an error when pipeline construction fails so the caller can
+// fail-closed the entire boot — never start a kernel with no enforcement.
+func wireActionGatePipeline(srv *server, auditExporter audit.AuditSender) error {
+	if srv == nil {
+		return nil
+	}
+	pipeline := actiongates.BuildProductionPipeline(actiongates.ProductionPipelineOptions{})
+	if pipeline == nil {
+		return errPipelineConstructionFailed
+	}
+	srv.SetActionGatePipeline(pipeline)
+	srv.SetActionDescriptorExtractor(actionDescriptorFromRequest)
+	srv.SetActionGateAuditSink(newKernelActionGateAuditSink(auditExporter))
+	slog.Info("safety-kernel: action-gate pipeline wired",
+		"gates", pipelineGateIDs(pipeline),
+		"audit_sink_attached", auditExporter != nil,
+	)
+	return nil
+}
+
+// pipelineGateIDs returns a slice of gate IDs for log/observability use.
+// Reads the pipeline's gates via the public Gates() accessor so the wire
+// file does not poke at private state.
+func pipelineGateIDs(p *actiongates.Pipeline) []string {
+	gates := p.Gates()
+	out := make([]string, 0, len(gates))
+	for _, g := range gates {
+		out = append(out, g.ID())
+	}
+	return out
+}
+
+// errPipelineConstructionFailed is the sentinel error returned when the
+// production pipeline factory returns nil. NewPipeline filters nil gates
+// but always returns a non-nil *Pipeline today; the guard exists to keep
+// the call site's fail-closed contract explicit.
+var errPipelineConstructionFailed = pipelineWireError("pipeline construction returned nil")
+
+type pipelineWireError string
+
+func (e pipelineWireError) Error() string { return string(e) }
+
+// actionDescriptorFromRequest is the production extractor wired on the
+// kernel server. It reads the gateway-supplied JSON encoding of
+// ActionDescriptor from the reserved Labels key. Returns nil when the
+// label is absent (caller skips the gate pipeline) or the payload is
+// malformed (defense-in-depth: malformed descriptors do not bypass
+// gates, but they also do not silently corrupt the input).
+func actionDescriptorFromRequest(_ context.Context, req *pb.PolicyCheckRequest) *config.ActionDescriptor {
+	if req == nil {
+		return nil
+	}
+	raw, ok := req.GetLabels()[LabelActionDescriptorJSON]
+	if !ok || raw == "" {
+		return nil
+	}
+	if len(raw) > config.ActionArgsMaxSerializedBytes {
+		slog.Warn("safety-kernel: action descriptor label exceeds size cap; dropping",
+			"size", len(raw),
+			"cap", config.ActionArgsMaxSerializedBytes,
+		)
+		return nil
+	}
+	var desc config.ActionDescriptor
+	if err := json.Unmarshal([]byte(raw), &desc); err != nil {
+		slog.Warn("safety-kernel: action descriptor label malformed; dropping",
+			"err", err,
+		)
+		return nil
+	}
+	return &desc
+}
+
+// newKernelActionGateAuditSink returns an audit sink that records the
+// SIEMEvent into the kernel's audit exporter. A nil exporter degrades
+// to a slog-only sink so a misconfigured deployment still surfaces the
+// gate fires in stderr; production SHOULD wire a real exporter.
+func newKernelActionGateAuditSink(exporter audit.AuditSender) func(ctx context.Context, event audit.SIEMEvent) {
+	if exporter == nil {
+		return func(_ context.Context, event audit.SIEMEvent) {
+			slog.Warn("safety-kernel: action-gate fired with no audit exporter wired",
+				"gate", event.Action,
+				"decision", event.Decision,
+				"tenant", event.TenantID,
+				"job_id", event.JobID,
+			)
+		}
+	}
+	return func(_ context.Context, event audit.SIEMEvent) {
+		exporter.Send(event)
+	}
+}

--- a/core/controlplane/safetykernel/kernel_actiongate_wire_test.go
+++ b/core/controlplane/safetykernel/kernel_actiongate_wire_test.go
@@ -1,0 +1,122 @@
+package safetykernel
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// TestWireActionGatePipeline_BootSetsPipeline asserts that the
+// production wiring function installs a non-nil pipeline on a freshly
+// constructed server. This is the regression guard for the QA-flagged
+// "gates are dead code at runtime" bug: a future refactor that drops
+// the wireActionGatePipeline call site (or returns early before
+// SetActionGatePipeline runs) MUST break this test.
+func TestWireActionGatePipeline_BootSetsPipeline(t *testing.T) {
+	t.Parallel()
+	srv := &server{}
+	if err := wireActionGatePipeline(srv, nil); err != nil {
+		t.Fatalf("wireActionGatePipeline returned err: %v", err)
+	}
+	if srv.actionGatePipeline == nil {
+		t.Fatal("server.actionGatePipeline still nil after boot wiring")
+	}
+	if got := len(srv.actionGatePipeline.Gates()); got == 0 {
+		t.Fatalf("pipeline has no gates after boot wiring; len=%d", got)
+	}
+	if srv.actionExtractor == nil {
+		t.Fatal("server.actionExtractor still nil after boot wiring")
+	}
+	if srv.actionGateAuditSink == nil {
+		t.Fatal("server.actionGateAuditSink still nil after boot wiring")
+	}
+}
+
+// TestWireActionGatePipeline_NilServerNoOp asserts the wiring function
+// guards against a nil receiver and returns cleanly (so a misconfigured
+// test fixture cannot mask the wiring bug by panicking on a nil pointer).
+func TestWireActionGatePipeline_NilServerNoOp(t *testing.T) {
+	t.Parallel()
+	if err := wireActionGatePipeline(nil, nil); err != nil {
+		t.Fatalf("expected nil-server wire to no-op, got err: %v", err)
+	}
+}
+
+// TestActionDescriptorFromRequest_RoundTrip asserts the kernel extractor
+// reads the gateway-encoded JSON label and reconstructs the original
+// ActionDescriptor. The encoding contract (Labels key, JSON marshaling,
+// size cap) is what allows the descriptor to traverse the gateway→kernel
+// gRPC boundary without a proto schema change.
+func TestActionDescriptorFromRequest_RoundTrip(t *testing.T) {
+	t.Parallel()
+	desc := &config.ActionDescriptor{
+		Kind:       config.ActionKindMutation,
+		Verb:       config.ActionVerbDelete,
+		TargetPath: "/var/data/users.db",
+		TargetResource: &config.ActionTargetResource{
+			Type:        "user",
+			ID:          "user_42",
+			OwnerTenant: "tnt_a",
+		},
+		ApprovalClaim: &config.ActionApprovalClaim{
+			ApprovalRef: "appr_42",
+		},
+	}
+	encoded, err := json.Marshal(desc)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	req := &pb.PolicyCheckRequest{
+		Labels: map[string]string{LabelActionDescriptorJSON: string(encoded)},
+	}
+	got := actionDescriptorFromRequest(context.Background(), req)
+	if got == nil {
+		t.Fatal("extractor returned nil on well-formed payload")
+	}
+	if got.Kind != desc.Kind || got.Verb != desc.Verb || got.TargetPath != desc.TargetPath {
+		t.Fatalf("roundtrip mismatch: got %+v want %+v", got, desc)
+	}
+	if got.ApprovalClaim == nil || got.ApprovalClaim.ApprovalRef != "appr_42" {
+		t.Fatalf("approval claim not preserved across encoding: %+v", got.ApprovalClaim)
+	}
+	if got.TargetResource == nil || got.TargetResource.OwnerTenant != "tnt_a" {
+		t.Fatalf("target resource not preserved across encoding: %+v", got.TargetResource)
+	}
+}
+
+func TestActionDescriptorFromRequest_AbsentLabelReturnsNil(t *testing.T) {
+	t.Parallel()
+	if got := actionDescriptorFromRequest(context.Background(), &pb.PolicyCheckRequest{}); got != nil {
+		t.Fatalf("expected nil for missing label, got %+v", got)
+	}
+	if got := actionDescriptorFromRequest(context.Background(), nil); got != nil {
+		t.Fatalf("expected nil for nil request, got %+v", got)
+	}
+}
+
+func TestActionDescriptorFromRequest_MalformedLabelReturnsNil(t *testing.T) {
+	t.Parallel()
+	req := &pb.PolicyCheckRequest{
+		Labels: map[string]string{LabelActionDescriptorJSON: "{not valid json"},
+	}
+	if got := actionDescriptorFromRequest(context.Background(), req); got != nil {
+		t.Fatalf("malformed JSON should drop to nil to avoid bypass; got %+v", got)
+	}
+}
+
+func TestActionDescriptorFromRequest_OversizeLabelReturnsNil(t *testing.T) {
+	t.Parallel()
+	huge := make([]byte, config.ActionArgsMaxSerializedBytes+1)
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	req := &pb.PolicyCheckRequest{
+		Labels: map[string]string{LabelActionDescriptorJSON: string(huge)},
+	}
+	if got := actionDescriptorFromRequest(context.Background(), req); got != nil {
+		t.Fatalf("oversize payload should drop to nil; got %+v", got)
+	}
+}

--- a/core/edge/approval_store_redis.go
+++ b/core/edge/approval_store_redis.go
@@ -53,6 +53,14 @@ func edgeApprovalTupleIndexKey(tenantID, sessionID, executionID, actionHash stri
 	return "edge:approvals:index:tuple:" + strings.TrimSpace(tenantID) + ":" + strings.TrimSpace(sessionID) + ":" + strings.TrimSpace(executionID) + ":" + strings.TrimSpace(actionHash)
 }
 
+// edgeApprovalActionHashIndexKey returns the per-(tenant, actionHash) ZSet
+// key. Members are approval refs; score is approval.CreatedAt.UnixMicro()
+// so ZREVRANGE returns most-recent-first. Populated by EnqueueApproval and
+// consumed by GetApprovalsByActionHash + LookupByActionHash.
+func edgeApprovalActionHashIndexKey(tenantID, actionHash string) string {
+	return "edge:approvals:index:hash:" + strings.TrimSpace(tenantID) + ":" + strings.TrimSpace(actionHash)
+}
+
 func (s *RedisStore) EnqueueApproval(ctx context.Context, req EdgeApprovalRequest) (*EdgeApproval, error) {
 	if err := s.ensureReady(); err != nil {
 		return nil, err
@@ -131,6 +139,14 @@ func (s *RedisStore) EnqueueApproval(ctx context.Context, req EdgeApprovalReques
 			pipe.ZAdd(ctx, edgeApprovalPrincipalIndexKey(req.TenantID, req.PrincipalID), redis.Z{Score: score, Member: ref})
 			pipe.ZAdd(ctx, edgeApprovalPrincipalStatusIndexKey(req.TenantID, req.PrincipalID, ApprovalStatusPending), redis.Z{Score: score, Member: ref})
 			pipe.SAdd(ctx, tupleKey, ref)
+			// Action-hash index: lets actiongates.ProvenanceGate /
+			// MutationGate resolve "give me the most recent approved
+			// approval that authorizes THIS action shape" without
+			// scanning per-principal lists. Skipped when ActionHash is
+			// empty (legacy callers that did not bind a hash).
+			if strings.TrimSpace(req.ActionHash) != "" {
+				pipe.ZAdd(ctx, edgeApprovalActionHashIndexKey(req.TenantID, req.ActionHash), redis.Z{Score: score, Member: ref})
+			}
 			return nil
 		})
 		if err == nil {
@@ -167,6 +183,71 @@ func (s *RedisStore) GetApproval(ctx context.Context, tenantID, approvalRef stri
 		return nil, false, nil
 	}
 	return approval, true, nil
+}
+
+// GetApprovalsByActionHash returns every approval recorded for (tenantID,
+// actionHash), most-recent first. Empty result when either arg is blank
+// or the index is empty — never an error in that case. Used by the
+// action-layer provenance gate to inspect the full history when a single
+// "currently-actionable" lookup is insufficient (e.g. for audit display).
+func (s *RedisStore) GetApprovalsByActionHash(ctx context.Context, tenantID, actionHash string) ([]EdgeApproval, error) {
+	if err := s.ensureReady(); err != nil {
+		return nil, err
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	actionHash = strings.TrimSpace(actionHash)
+	if tenantID == "" || actionHash == "" {
+		return nil, nil
+	}
+	refs, err := s.client.ZRevRange(ctx, edgeApprovalActionHashIndexKey(tenantID, actionHash), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list approvals by action_hash: %w", err)
+	}
+	out := make([]EdgeApproval, 0, len(refs))
+	for _, ref := range refs {
+		approval, ok, err := s.loadApproval(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || approval.TenantID != tenantID {
+			continue
+		}
+		out = append(out, *approval)
+	}
+	return out, nil
+}
+
+// LookupByActionHash satisfies the actiongates.ApprovalLookup contract by
+// returning the most-recent approved, not-yet-consumed, not-expired
+// approval bound to (tenantID, actionHash). Returns (nil, false, nil) on
+// miss so the caller can map the miss to a not_found-style decision
+// without ambiguity. Pending / rejected / expired / consumed approvals
+// are skipped — the gate considers them "no actionable approval".
+func (s *RedisStore) LookupByActionHash(ctx context.Context, tenantID, actionHash string) (*EdgeApproval, bool, error) {
+	approvals, err := s.GetApprovalsByActionHash(ctx, tenantID, actionHash)
+	if err != nil {
+		return nil, false, err
+	}
+	now := s.now().UTC()
+	for i := range approvals {
+		a := approvals[i]
+		if a.Status != ApprovalStatusApproved {
+			continue
+		}
+		if a.Decision != ApprovalDecisionApprove {
+			continue
+		}
+		if a.ConsumedAt != nil {
+			continue
+		}
+		if a.ExpiresAt != nil && now.After(*a.ExpiresAt) {
+			continue
+		}
+		// Most recent qualifying approval — ZRevRange returns DESC by score.
+		matched := a
+		return &matched, true, nil
+	}
+	return nil, false, nil
 }
 
 func (s *RedisStore) ListApprovals(ctx context.Context, query ListApprovalsQuery) (ApprovalPage, error) {

--- a/core/edge/approval_store_redis_test.go
+++ b/core/edge/approval_store_redis_test.go
@@ -1510,6 +1510,115 @@ func assertRedisApprovalCannotBeClaimed(t *testing.T, ctx context.Context, store
 	}
 }
 
+// TestRedisStoreLookupByActionHashReturnsMostRecentApproved seeds two
+// approvals against the same (tenant, action_hash), approves the second,
+// and asserts LookupByActionHash returns the approved one. Verifies the
+// action-hash index that backs actiongates.ApprovalLookup wiring.
+func TestRedisStoreLookupByActionHashReturnsMostRecentApproved(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	now := base
+	store, _, _, cleanup := newRedisEdgeStore(t, WithClock(func() time.Time { return now }))
+	defer cleanup()
+
+	sharedHash := "sha256:shared-action-payload"
+	tenant := "tenant-hash"
+
+	createApprovalParents(t, ctx, store, tenant, "sess-h1", "exec-h1", "event-h1", base)
+	req1 := validApprovalRequest(tenant, "sess-h1", "exec-h1", "event-h1", base)
+	req1.ActionHash = sharedHash
+	now = base
+	first, err := store.EnqueueApproval(ctx, req1)
+	if err != nil {
+		t.Fatalf("EnqueueApproval first: %v", err)
+	}
+
+	createApprovalParents(t, ctx, store, tenant, "sess-h2", "exec-h2", "event-h2", base.Add(1*time.Minute))
+	req2 := validApprovalRequest(tenant, "sess-h2", "exec-h2", "event-h2", base.Add(1*time.Minute))
+	req2.ActionHash = sharedHash
+	now = base.Add(1 * time.Minute)
+	second, err := store.EnqueueApproval(ctx, req2)
+	if err != nil {
+		t.Fatalf("EnqueueApproval second: %v", err)
+	}
+
+	// Both refs visible in GetApprovalsByActionHash, most-recent first.
+	all, err := store.GetApprovalsByActionHash(ctx, tenant, sharedHash)
+	if err != nil {
+		t.Fatalf("GetApprovalsByActionHash: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("got %d approvals, want 2", len(all))
+	}
+	if all[0].ApprovalRef != second.ApprovalRef || all[1].ApprovalRef != first.ApprovalRef {
+		t.Fatalf("ordering = [%s, %s], want most-recent first [%s, %s]",
+			all[0].ApprovalRef, all[1].ApprovalRef, second.ApprovalRef, first.ApprovalRef)
+	}
+
+	// Cross-tenant returns empty (action-hash index is tenant-scoped).
+	if other, err := store.GetApprovalsByActionHash(ctx, "tenant-other", sharedHash); err != nil || len(other) != 0 {
+		t.Fatalf("cross-tenant GetApprovalsByActionHash = (%d, %v), want 0/nil", len(other), err)
+	}
+
+	// LookupByActionHash before any approval: no actionable approval.
+	got, ok, err := store.LookupByActionHash(ctx, tenant, sharedHash)
+	if err != nil {
+		t.Fatalf("LookupByActionHash pre-approval err: %v", err)
+	}
+	if ok || got != nil {
+		t.Fatalf("pre-approval lookup = (%#v, %v), want nil/false", got, ok)
+	}
+
+	// Approve the most recent (second) approval; lookup must return it.
+	now = base.Add(2 * time.Minute)
+	if _, err := store.ApproveApproval(ctx, ApprovalResolution{
+		TenantID:    tenant,
+		ApprovalRef: second.ApprovalRef,
+		ResolverID:  "principal-reviewer",
+		ResolvedBy:  "reviewer@example.invalid",
+		Reason:      "approved",
+		ResolvedAt:  now,
+	}); err != nil {
+		t.Fatalf("ApproveApproval second: %v", err)
+	}
+
+	got, ok, err = store.LookupByActionHash(ctx, tenant, sharedHash)
+	if err != nil {
+		t.Fatalf("LookupByActionHash post-approval err: %v", err)
+	}
+	if !ok || got == nil || got.ApprovalRef != second.ApprovalRef {
+		t.Fatalf("post-approval lookup = (%#v, %v), want second approval ref %q", got, ok, second.ApprovalRef)
+	}
+
+	// Consume the approval; lookup must return nil (no actionable approval left).
+	now = base.Add(3 * time.Minute)
+	if _, _, err := store.ClaimApproval(ctx, ApprovalClaimRequest{
+		TenantID:       tenant,
+		ApprovalRef:    second.ApprovalRef,
+		SessionID:      req2.SessionID,
+		ExecutionID:    req2.ExecutionID,
+		EventID:        req2.EventID,
+		ActionHash:     sharedHash,
+		InputHash:      req2.InputHash,
+		PolicySnapshot: req2.PolicySnapshot,
+		ConsumedAt:     now,
+	}); err != nil {
+		t.Fatalf("ClaimApproval: %v", err)
+	}
+	got, ok, err = store.LookupByActionHash(ctx, tenant, sharedHash)
+	if err != nil {
+		t.Fatalf("LookupByActionHash post-claim err: %v", err)
+	}
+	if ok || got != nil {
+		t.Fatalf("post-claim lookup = (%#v, %v), want nil/false (consumed)", got, ok)
+	}
+
+	// Empty action hash short-circuits to nil without an index call.
+	if empty, err := store.GetApprovalsByActionHash(ctx, tenant, ""); err != nil || len(empty) != 0 {
+		t.Fatalf("empty action_hash lookup = (%d, %v), want 0/nil", len(empty), err)
+	}
+}
+
 // prewarmRedisClientPool serially pings the redis client enough times to
 // fully populate the connection pool before the test fans out to many
 // concurrent goroutines. It exists to defuse the go-redis v9 lazy-init

--- a/core/infra/config/safety_policy.go
+++ b/core/infra/config/safety_policy.go
@@ -390,7 +390,125 @@ type PolicyInput struct {
 	SecretsPresent bool
 	MCP            MCPRequest
 	Delegation     *DelegationContext
+	// Action carries structured request metadata for deterministic pre-dispatch
+	// action-layer gates (file/url/tenant/mutation/mcp/provenance). nil means
+	// no action-layer evaluation; existing rule evaluation runs unchanged.
+	Action *ActionDescriptor
 }
+
+// ActionKind enumerates the action-gate dispatch families. Gates inspect this
+// to short-circuit when an action does not target their domain.
+type ActionKind string
+
+const (
+	ActionKindFile             ActionKind = "file"
+	ActionKindURL              ActionKind = "url"
+	ActionKindTenantQuery      ActionKind = "tenant_query"
+	ActionKindMutation         ActionKind = "mutation"
+	ActionKindMCPCall          ActionKind = "mcp_call"
+	ActionKindProvenanceCheck  ActionKind = "provenance_check"
+)
+
+// ActionVerb names the operation an actor is requesting. Free-form by design:
+// new packs/tools must be able to declare verbs without a config bump. The
+// destructive set is enforced by the mutation gate, not by parser validation.
+type ActionVerb string
+
+const (
+	ActionVerbRead          ActionVerb = "read"
+	ActionVerbWrite         ActionVerb = "write"
+	ActionVerbDelete        ActionVerb = "delete"
+	ActionVerbDrop          ActionVerb = "drop"
+	ActionVerbTruncate      ActionVerb = "truncate"
+	ActionVerbExport        ActionVerb = "export"
+	ActionVerbPayment       ActionVerb = "payment"
+	ActionVerbAdminGrant    ActionVerb = "admin_grant"
+	ActionVerbAdminRevoke   ActionVerb = "admin_revoke"
+	ActionVerbRoleAssign    ActionVerb = "role_assign"
+	ActionVerbRoleRemove    ActionVerb = "role_remove"
+	ActionVerbLicenseCreate ActionVerb = "license_create"
+	ActionVerbLicenseRevoke ActionVerb = "license_revoke"
+	ActionVerbLicenseChange ActionVerb = "license_change"
+	ActionVerbKeyRotate     ActionVerb = "key_rotate"
+	ActionVerbKeyDelete     ActionVerb = "key_delete"
+	ActionVerbSecretsWrite  ActionVerb = "secrets_write"
+	ActionVerbSecretsDelete ActionVerb = "secrets_delete"
+	ActionVerbConfigWrite   ActionVerb = "config_write"
+	ActionVerbConfigDelete  ActionVerb = "config_delete"
+	ActionVerbBackupRestore ActionVerb = "backup_restore"
+	ActionVerbTenantCreate  ActionVerb = "tenant_create"
+	ActionVerbTenantDelete  ActionVerb = "tenant_delete"
+)
+
+// ActionDescriptor carries the structured request payload that action-layer
+// gates evaluate. Every field is optional; gates inspect Kind+Verb first and
+// short-circuit when no relevant data is present. Untrusted body fields
+// (TargetPath, TargetURL, Args, ApprovalClaim.ClaimText) MUST NOT be the sole
+// basis for authorization — auth-derived tenant and backend-resolved approval
+// records take precedence.
+type ActionDescriptor struct {
+	Kind   ActionKind `json:"kind,omitempty"`
+	Verb   ActionVerb `json:"verb,omitempty"`
+	Server string     `json:"server,omitempty"` // MCP server identifier (mcp_call)
+	Tool   string     `json:"tool,omitempty"`   // MCP tool identifier (mcp_call)
+
+	// TargetPath is a filesystem path (file kind). Untrusted; gates canonicalize
+	// before matching.
+	TargetPath string `json:"target_path,omitempty"`
+	// TargetURL is an absolute URL (url kind). Untrusted; gates parse + resolve.
+	TargetURL string `json:"target_url,omitempty"`
+	// TargetResource describes the object a mutation/tenant-query operates on.
+	// OwnerTenant is server-derived (not from request body) when populated by
+	// the gateway; otherwise gates compare against AuthContext.Tenant.
+	TargetResource *ActionTargetResource `json:"target_resource,omitempty"`
+
+	// Filters captures structured query predicates (column => literal). Wildcards
+	// lists predicates whose value was '*' or otherwise unbounded; tenant gate
+	// blocks wildcards on owner_id/tenant_id.
+	Filters   map[string]string `json:"filters,omitempty"`
+	Wildcards []string          `json:"wildcards,omitempty"`
+
+	// Args is arbitrary tool/MCP arg map (mcp_call), capped at 64KB serialized
+	// upstream. Gates inspect known sensitive keys (force, no_confirm, recursive).
+	Args map[string]any `json:"args,omitempty"`
+
+	// RiskTags is a free-form set surfaced by the upstream classifier (e.g.
+	// "requires_provenance", "data:pii"). Used by gates to widen denials.
+	RiskTags []string `json:"risk_tags,omitempty"`
+
+	// RequiredEntitlement is the license/capability token that the calling
+	// identity must hold for an mcp_call action. Resolved server-side from
+	// per-server registry metadata, not user-supplied. Empty means the
+	// action carries no entitlement requirement (e.g. read-only tools).
+	RequiredEntitlement string `json:"required_entitlement,omitempty"`
+
+	// ApprovalClaim carries the user-presented approval reference. ClaimText is
+	// untrusted prose ("approved by CFO") and MUST NOT pass on its own.
+	// ApprovalRef is looked up server-side against Cordum approval records.
+	ApprovalClaim *ActionApprovalClaim `json:"approval_claim,omitempty"`
+}
+
+// ActionTargetResource identifies an object referenced by an action. OwnerTenant
+// is authoritative only when gateway-supplied; gates that need it for tenant
+// boundaries cross-check against AuthContext.Tenant.
+type ActionTargetResource struct {
+	Type        string `json:"type,omitempty"`
+	ID          string `json:"id,omitempty"`
+	OwnerTenant string `json:"owner_tenant,omitempty"`
+	Archived    bool   `json:"archived,omitempty"`
+}
+
+// ActionApprovalClaim represents a caller's claim of human approval for a
+// destructive action. The provenance gate requires ApprovalRef to resolve to a
+// Cordum EdgeApproval; ClaimText is logged for audit only and never grants.
+type ActionApprovalClaim struct {
+	ClaimText   string `json:"claim_text,omitempty"`
+	ApprovalRef string `json:"approval_ref,omitempty"`
+}
+
+// ActionArgsMaxSerializedBytes caps the wire size of ActionDescriptor.Args.
+// The gateway rejects oversize requests before reaching the kernel.
+const ActionArgsMaxSerializedBytes = 64 * 1024
 
 // PolicyMeta captures structured job metadata for policy checks.
 type PolicyMeta struct {

--- a/core/mcp/filter.go
+++ b/core/mcp/filter.go
@@ -12,11 +12,31 @@ type AgentIdentity struct {
 	// for filtering itself.
 	ID string
 
+	// AllowedServers is a list of MCP server-name glob patterns. The
+	// actiongates MCP gate admits an mcp_call action only when its Server
+	// matches at least one pattern. Empty = no servers (fail-closed).
+	// FilterForIdentity does not consult this field; it is enforced at
+	// the action gate layer.
+	AllowedServers []string
+
 	// AllowedTools is a list of tool-name glob patterns. A tool is
 	// admitted only if its Name matches at least one pattern. The empty
 	// slice means "no tools" — operators must opt in to every tool an
 	// identity can use. The pattern "*" admits every tool.
 	AllowedTools []string
+
+	// AllowedResources is a list of cordum:// resource URI glob patterns
+	// the identity may target. Consulted by the actiongates MCP gate when
+	// an action specifies TargetURL. Empty = no resources (fail-closed)
+	// for actions that name one. Actions with no TargetURL skip this
+	// check.
+	AllowedResources []string
+
+	// Entitlements lists license/capability tokens the identity holds
+	// (e.g. "vault.read", "anthropic.claude", "billing.export"). The
+	// actiongates MCP gate denies actions whose RequiredEntitlement is
+	// not present here. Empty = no entitlements granted.
+	Entitlements []string
 
 	// RiskTier is the actor's own risk tier. The filter admits tools
 	// whose required tier is less-than-or-equal to the actor's tier.

--- a/core/policy/actiongates/doc.go
+++ b/core/policy/actiongates/doc.go
@@ -1,0 +1,30 @@
+// Package actiongates implements Cordum's deterministic pre-dispatch
+// action-layer gates.
+//
+// Each gate is a small, single-purpose evaluator that inspects the
+// structured ActionDescriptor on a PolicyInput and returns an
+// ActionGateDecision. The pipeline runs gates in a fixed order
+// (tenant -> file -> url -> mcp -> mutation -> provenance) and
+// short-circuits on the first non-ALLOW. When ActionDescriptor is
+// nil or its Kind/Verb is unrelated to the gate, the gate returns
+// ALLOW and the pipeline moves on.
+//
+// Design rules (enforced by code review, not by parsers):
+//
+//   - Gates MUST consume structured fields only. They MUST NOT regex
+//     over free-form prompts or otherwise approximate a content
+//     classifier — that path lives upstream.
+//   - Tenant identity is sourced from auth (AuthContext.Tenant), never
+//     from the request body. Body-claimed tenant is for diagnostics only.
+//   - Approval claims are untrusted text. Only a backend EdgeApproval
+//     resolved via ApprovalLookup grants destructive actions.
+//   - Failures in side-channels (approval store, audit chain) MUST fail
+//     closed with Code=internal_error or service_unavailable, never
+//     silently ALLOW.
+//
+// Output mapping at the HTTP boundary follows the existing edge error
+// envelope: unauthorized->401, access_denied->403, not_found->404,
+// conflict->409, internal_error->500, service_unavailable->503. The
+// require_human Code is informational at the simulate endpoint (200)
+// and triggers the existing inline-approval workflow at the edge.
+package actiongates

--- a/core/policy/actiongates/file_gate.go
+++ b/core/policy/actiongates/file_gate.go
@@ -1,0 +1,426 @@
+package actiongates
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// FileGate enforces filesystem-level read/write access. It canonicalizes the
+// requested path (URL-decode, env-expand, separator-normalize) and matches
+// against three rule families:
+//
+//  1. Traversal indicators (`..` segments, null bytes) -> always DENY.
+//  2. Sensitive paths (OS credential stores, OS config, /proc secrets, etc.) ->
+//     DENY by verb (always or write-only depending on entry).
+//  3. Credential-file patterns (id_rsa, *.pem, *.kdbx, ...) -> DENY regardless
+//     of directory.
+//
+// Gate is stateless. NewFileGate returns a singleton suitable for
+// long-lived reuse.
+type FileGate struct{}
+
+// NewFileGate returns a fresh FileGate. Construction is cheap; callers may
+// build per-request without performance concerns.
+func NewFileGate() *FileGate { return &FileGate{} }
+
+func (g *FileGate) ID() string { return GateIDFile }
+
+// Evaluate returns a non-zero decision only when the requested action is a
+// file kind AND a non-empty TargetPath triggers one of the sensitive/traversal
+// rules. Everything else (nil action, other kinds, empty path, legitimate
+// workspace paths) returns the zero decision so the pipeline continues.
+func (g *FileGate) Evaluate(_ context.Context, in *config.PolicyInput) ActionGateDecision {
+	if in == nil || in.Action == nil {
+		return ActionGateDecision{}
+	}
+	act := in.Action
+	if act.Kind != config.ActionKindFile {
+		return ActionGateDecision{}
+	}
+	raw := strings.TrimSpace(act.TargetPath)
+	if raw == "" {
+		return ActionGateDecision{}
+	}
+
+	// 1) Null byte (pre-decode) — these truncate parsing in many libs.
+	if strings.ContainsRune(raw, '\x00') || containsEncodedNull(raw) {
+		return g.deny(CodeAccessDenied, "filesystem access denied", "null_byte", raw)
+	}
+
+	// 2) Iteratively URL-decode (cap iterations to avoid pathological inputs).
+	decoded := raw
+	for i := 0; i < 3; i++ {
+		u, err := url.QueryUnescape(decoded)
+		if err != nil || u == decoded {
+			break
+		}
+		decoded = u
+	}
+
+	// 3) Traversal detection works on the decoded but raw-separator form.
+	if hasTraversalSegment(decoded) {
+		return g.deny(CodeAccessDenied, "filesystem traversal denied", "traversal", raw)
+	}
+
+	// 4) DOS device namespace (`\\.\PhysicalDrive0`, `\\.\PIPE\foo`) — detect
+	// BEFORE canonicalization because path.Clean collapses the `\\.` marker.
+	if isDOSDeviceNamespace(decoded) {
+		return g.deny(CodeAccessDenied, "device access denied", "device_namespace", raw)
+	}
+
+	// 5) Canonical lowercase form with forward slashes for matching.
+	canon := canonicalizeFilePath(decoded)
+
+	// 6) Basename credential patterns first (cheap and dir-independent).
+	if reason, hit := matchCredentialBasename(canon); hit {
+		return g.deny(CodeAccessDenied, "credential file access denied", reason, raw)
+	}
+
+	// 7) Sensitive path matrix.
+	writeRequested := isWriteVerb(act.Verb)
+	if reason, hit := matchSensitivePath(canon, writeRequested); hit {
+		return g.deny(CodeAccessDenied, "filesystem access denied", reason, raw)
+	}
+
+	// Nothing matched — pass.
+	return ActionGateDecision{Decision: pb.DecisionType_DECISION_TYPE_ALLOW, GateID: GateIDFile}
+}
+
+func (g *FileGate) deny(code, reason, subReason, raw string) ActionGateDecision {
+	return ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_DENY,
+		GateID:    GateIDFile,
+		Code:      code,
+		Reason:    reason,
+		SubReason: subReason,
+		Extra: map[string]string{
+			"gate":       GateIDFile,
+			"sub_reason": subReason,
+			// raw target_path intentionally NOT echoed to clients (PII / token leak risk).
+			// Length-only breadcrumb for SIEM cardinality bounds.
+			"target_len": itoa(len(raw)),
+		},
+	}
+}
+
+// isDOSDeviceNamespace detects Windows DOS device path prefixes (`\\.\` and
+// `\\?\DOSDEVICE`). The long-path UNC prefix `\\?\C:\...` itself is fine and
+// is stripped during canonicalization; we trip only when the rest is a device
+// rather than a drive letter.
+func isDOSDeviceNamespace(s string) bool {
+	n := strings.ReplaceAll(s, `\`, "/")
+	if !strings.HasPrefix(n, "//./") && !strings.HasPrefix(n, "//.") {
+		return false
+	}
+	rest := strings.TrimPrefix(n, "//./")
+	rest = strings.TrimPrefix(rest, "//.")
+	rest = strings.TrimPrefix(rest, "/")
+	if rest == "" {
+		return true
+	}
+	// Heuristic: device entries do not contain `:` (drive letters live behind \\?\ instead).
+	return !strings.Contains(rest, ":")
+}
+
+// containsEncodedNull catches %00 (single-encoded) and %2500 (double-encoded
+// %00). We do not iterate decode here because a downstream filesystem call
+// might decode just once and stop, leaving the null active.
+func containsEncodedNull(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, "%00") || strings.Contains(lower, "%2500")
+}
+
+// hasTraversalSegment runs on the post-URL-decode form. We replace backslashes
+// with forward slashes for analysis, then split. Any segment equal to ".." is
+// a traversal attempt. This also catches `..` appearing after tilde or env
+// expansion, since we apply this check before canonicalization.
+func hasTraversalSegment(s string) bool {
+	normalized := strings.ReplaceAll(s, `\`, "/")
+	// Reject mid-string ".." even when not at a clean segment boundary, since
+	// percent-encoded mixes can hide them (../../foo).
+	if strings.Contains(normalized, "/../") || strings.HasSuffix(normalized, "/..") || strings.HasPrefix(normalized, "../") || normalized == ".." {
+		return true
+	}
+	// Tilde with traversal — `~/../etc` is still traversal even before tilde-expand.
+	if strings.HasPrefix(normalized, "~/") && strings.Contains(normalized[2:], "..") {
+		return true
+	}
+	return false
+}
+
+// canonicalizeFilePath produces the form used for sensitive-path matching:
+//
+//   - URL-decoded already (caller).
+//   - %ENV% and $ENV/${ENV} expanded to placeholders by lowercase name.
+//   - Tilde expanded to /home/_user_/ for matching only.
+//   - UNC long-path prefix stripped (`\\?\` and `\\.\` are inspected separately
+//     by the device check above).
+//   - Backslashes -> forward slashes.
+//   - Lowercased.
+//   - path.Clean applied.
+func canonicalizeFilePath(s string) string {
+	// %ENV%  -> /env/name/ style placeholder so we can match userprofile_*
+	s = expandWindowsEnv(s)
+	// $ENV / ${ENV} -> placeholder
+	s = expandPosixEnv(s)
+	// Strip UNC \\?\ long-path prefix; leave \\.\ in for device detection.
+	if strings.HasPrefix(s, `\\?\`) || strings.HasPrefix(s, `//?/`) {
+		s = strings.TrimPrefix(s, `\\?\`)
+		s = strings.TrimPrefix(s, `//?/`)
+	}
+	// Backslashes -> forward slashes.
+	s = strings.ReplaceAll(s, `\`, "/")
+	// Lowercase.
+	s = strings.ToLower(s)
+	// Tilde expansion (post-lowercase, post-slash).
+	if strings.HasPrefix(s, "~/") {
+		s = "/home/_user_/" + strings.TrimPrefix(s, "~/")
+	}
+	// path.Clean to collapse repeats. Note: path.Clean('//./...') keeps the
+	// device-namespace marker, which our device check needs.
+	s = path.Clean(s)
+	return s
+}
+
+var windowsEnvRe = regexp.MustCompile(`%([A-Za-z_][A-Za-z0-9_]*)%`)
+
+func expandWindowsEnv(s string) string {
+	return windowsEnvRe.ReplaceAllStringFunc(s, func(m string) string {
+		name := strings.ToLower(m[1 : len(m)-1])
+		switch name {
+		case "userprofile":
+			return `C:\Users\_user_`
+		case "homepath":
+			return `\Users\_user_`
+		case "appdata":
+			return `C:\Users\_user_\AppData\Roaming`
+		case "localappdata":
+			return `C:\Users\_user_\AppData\Local`
+		case "programdata":
+			return `C:\ProgramData`
+		case "windir", "systemroot":
+			return `C:\Windows`
+		case "system32":
+			return `C:\Windows\System32`
+		}
+		// Unknown env -> placeholder that can't accidentally collide with a real path.
+		return `\_env_` + name + `_\`
+	})
+}
+
+var posixEnvRe = regexp.MustCompile(`\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?`)
+
+func expandPosixEnv(s string) string {
+	return posixEnvRe.ReplaceAllStringFunc(s, func(m string) string {
+		name := strings.ToLower(strings.TrimFunc(m, func(r rune) bool {
+			return r == '$' || r == '{' || r == '}'
+		}))
+		switch name {
+		case "home":
+			return "/home/_user_"
+		}
+		return "/_env_" + name + "_"
+	})
+}
+
+// matchSensitivePath returns (subReason, true) on a hit. The matrix is
+// expressed as: (prefix, writeOnly bool, subReason). writeOnly entries fire
+// only when the verb is a write/mutate. Forward-slash, lowercase canonical
+// form is assumed.
+var sensitivePaths = []struct {
+	prefix    string
+	writeOnly bool
+	subReason string
+}{
+	// Always deny (read + write).
+	{"/etc/shadow", false, "sensitive_path:etc_shadow"},
+	{"/etc/sudoers", false, "sensitive_path:etc_sudoers"},
+	{"/etc/master.passwd", false, "sensitive_path:bsd_master_passwd"},
+	{"/etc/security/", false, "sensitive_path:etc_security"},
+	{"/var/lib/secrets/", false, "sensitive_path:var_lib_secrets"},
+	{"/proc/self/environ", false, "sensitive_path:proc_environ"},
+	{"/proc/self/cgroup", false, "sensitive_path:proc_cgroup"},
+	{"/root/.ssh/", false, "sensitive_path:ssh"},
+	{"/root/.aws/", false, "sensitive_path:aws_creds"},
+	{"/root/.docker/", false, "sensitive_path:docker_config"},
+	{"/root/.kube/", false, "sensitive_path:kube_config"},
+	// Windows registry hives + SAM (always).
+	{"c:/windows/system32/config/sam", false, "sensitive_path:windows_sam"},
+	{"c:/windows/system32/config/security", false, "sensitive_path:windows_security_hive"},
+	{"c:/windows/system32/config/system", false, "sensitive_path:windows_system_hive"},
+	{"c:/windows/system32/config/software", false, "sensitive_path:windows_software_hive"},
+	// Write-only (e.g. /etc/passwd is world-readable on Unix).
+	{"/etc/passwd", true, "sensitive_path:etc_passwd_write"},
+	{"/etc/group", true, "sensitive_path:etc_group_write"},
+	{"/etc/hosts", true, "sensitive_path:etc_hosts_write"},
+	{"/boot/", true, "sensitive_path:boot_write"},
+	{"/sbin/", true, "sensitive_path:sbin_write"},
+}
+
+func matchSensitivePath(canon string, write bool) (string, bool) {
+	for _, rule := range sensitivePaths {
+		if rule.writeOnly && !write {
+			continue
+		}
+		if rule.prefix == canon || strings.HasPrefix(canon, rule.prefix) && (len(rule.prefix) == 0 || rule.prefix[len(rule.prefix)-1] == '/' || len(canon) == len(rule.prefix) || canon[len(rule.prefix)] == '/') {
+			return rule.subReason, true
+		}
+	}
+	// Wildcard /home/<any>/.aws/credentials, /home/<any>/.ssh/...
+	if reason, ok := matchHomeUserCredentialDir(canon); ok {
+		return reason, true
+	}
+	return "", false
+}
+
+// matchHomeUserCredentialDir handles /home/<user>/.aws/, /home/<user>/.ssh/,
+// /users/<user>/.aws/ (mac-style after canonicalization keeps mixed-case ->
+// lowercase), and C:/Users/<user>/.aws/ etc. We tolerate any single segment
+// for the user.
+func matchHomeUserCredentialDir(canon string) (string, bool) {
+	suspects := []struct {
+		root      string
+		sub       string
+		subReason string
+	}{
+		{"/home/", "/.ssh/", "sensitive_path:user_ssh"},
+		{"/home/", "/.aws/", "sensitive_path:user_aws_creds"},
+		{"/home/", "/.docker/", "sensitive_path:user_docker_config"},
+		{"/home/", "/.kube/", "sensitive_path:user_kube_config"},
+		{"/users/", "/.ssh/", "sensitive_path:user_ssh"},
+		{"/users/", "/.aws/", "sensitive_path:user_aws_creds"},
+		{"/users/", "/.docker/", "sensitive_path:user_docker_config"},
+		{"/users/", "/.kube/", "sensitive_path:user_kube_config"},
+		{"c:/users/", "/.ssh/", "sensitive_path:user_ssh"},
+		{"c:/users/", "/.aws/", "sensitive_path:user_aws_creds"},
+		{"c:/users/", "/.docker/", "sensitive_path:user_docker_config"},
+		{"c:/users/", "/.kube/", "sensitive_path:user_kube_config"},
+	}
+	for _, s := range suspects {
+		if !strings.HasPrefix(canon, s.root) {
+			continue
+		}
+		rest := canon[len(s.root):]
+		slash := strings.Index(rest, "/")
+		if slash < 0 {
+			continue
+		}
+		tail := rest[slash:]
+		if strings.HasPrefix(tail, s.sub) {
+			return s.subReason, true
+		}
+	}
+	return "", false
+}
+
+// Basename credential patterns. These DENY regardless of directory.
+//
+// Two forms: exact basenames (e.g. id_rsa) and suffix patterns (e.g. *.pem).
+// Pattern matching is intentionally narrow — overly broad globs would over-refuse.
+var credentialExact = map[string]string{
+	"id_rsa":           "credential:ssh_rsa",
+	"id_rsa.pub":       "credential:ssh_rsa_pub",
+	"id_ed25519":       "credential:ssh_ed25519",
+	"id_ed25519.pub":   "credential:ssh_ed25519_pub",
+	"id_dsa":           "credential:ssh_dsa",
+	"id_ecdsa":         "credential:ssh_ecdsa",
+	".npmrc":           "credential:npmrc",
+	".netrc":           "credential:netrc",
+	".env":             "credential:dotenv",
+	".pgpass":          "credential:pgpass",
+	".dockerconfigjson": "credential:docker_pull_secret",
+	"credentials.json": "credential:gcp_or_generic_creds",
+	"keystore.jks":     "credential:jks",
+	"truststore.jks":   "credential:jks",
+}
+
+var credentialSuffix = []struct {
+	suffix    string
+	subReason string
+}{
+	{".pem", "credential:pem"},
+	{".key", "credential:key"},
+	{".kdbx", "credential:kdbx"},
+	{".pgp", "credential:pgp"},
+	{".gpg", "credential:gpg"},
+	{".asc", "credential:pgp_asc"},
+	{".p12", "credential:pkcs12"},
+	{".pfx", "credential:pkcs12"},
+}
+
+var credentialPrefix = []struct {
+	prefix    string
+	suffix    string
+	subReason string
+}{
+	{"service_account", ".json", "credential:gcp_service_account"},
+	{"service-account", ".json", "credential:gcp_service_account"},
+}
+
+func matchCredentialBasename(canon string) (string, bool) {
+	base := canon
+	if idx := strings.LastIndex(canon, "/"); idx >= 0 {
+		base = canon[idx+1:]
+	}
+	if base == "" {
+		return "", false
+	}
+	if reason, ok := credentialExact[base]; ok {
+		return reason, true
+	}
+	for _, suf := range credentialSuffix {
+		if strings.HasSuffix(base, suf.suffix) {
+			return suf.subReason, true
+		}
+	}
+	for _, p := range credentialPrefix {
+		if strings.HasPrefix(base, p.prefix) && strings.HasSuffix(base, p.suffix) {
+			return p.subReason, true
+		}
+	}
+	return "", false
+}
+
+func isWriteVerb(v config.ActionVerb) bool {
+	switch v {
+	case config.ActionVerbWrite, config.ActionVerbDelete, config.ActionVerbDrop, config.ActionVerbTruncate,
+		config.ActionVerbExport, config.ActionVerbAdminGrant, config.ActionVerbAdminRevoke,
+		config.ActionVerbRoleAssign, config.ActionVerbRoleRemove, config.ActionVerbLicenseCreate,
+		config.ActionVerbLicenseRevoke, config.ActionVerbLicenseChange, config.ActionVerbKeyRotate,
+		config.ActionVerbKeyDelete, config.ActionVerbSecretsWrite, config.ActionVerbSecretsDelete,
+		config.ActionVerbConfigWrite, config.ActionVerbConfigDelete, config.ActionVerbBackupRestore,
+		config.ActionVerbTenantCreate, config.ActionVerbTenantDelete, config.ActionVerbPayment:
+		return true
+	}
+	return false
+}
+
+// itoa is a tiny int-to-string used for SIEM breadcrumbs; avoids strconv import
+// inflation in a tight package.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/core/policy/actiongates/file_gate_test.go
+++ b/core/policy/actiongates/file_gate_test.go
@@ -1,0 +1,179 @@
+package actiongates
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// fileGateCase drives a single FileGate.Evaluate invocation. The test runner
+// builds a PolicyInput from {path, verb, args}, runs FileGate, and asserts
+// against expected decision + sub_reason.
+type fileGateCase struct {
+	name         string
+	path         string
+	verb         config.ActionVerb
+	wantDecision pb.DecisionType
+	wantCode     string
+	subReasonHas string // substring match on SubReason; "" skips
+	args         map[string]any
+}
+
+func runFileGate(t *testing.T, tc fileGateCase) {
+	t.Helper()
+	gate := NewFileGate()
+	in := &config.PolicyInput{
+		Tenant: "tnt_a",
+		Action: &config.ActionDescriptor{
+			Kind:       config.ActionKindFile,
+			Verb:       tc.verb,
+			TargetPath: tc.path,
+			Args:       tc.args,
+		},
+	}
+	dec := gate.Evaluate(context.Background(), in)
+	if dec.Decision != tc.wantDecision {
+		t.Fatalf("decision = %v, want %v (path=%q verb=%q reason=%q subReason=%q)", dec.Decision, tc.wantDecision, tc.path, tc.verb, dec.Reason, dec.SubReason)
+	}
+	if tc.wantCode != "" && dec.Code != tc.wantCode {
+		t.Fatalf("code = %q, want %q", dec.Code, tc.wantCode)
+	}
+	if tc.subReasonHas != "" && !strings.Contains(dec.SubReason, tc.subReasonHas) {
+		t.Fatalf("subReason = %q, want substring %q", dec.SubReason, tc.subReasonHas)
+	}
+}
+
+func TestFileGate_SkipsNonFileKind(t *testing.T) {
+	t.Parallel()
+	gate := NewFileGate()
+
+	// nil action -> ALLOW (skip)
+	dec := gate.Evaluate(context.Background(), &config.PolicyInput{})
+	if dec.Fired() {
+		t.Fatalf("nil action: gate fired, want zero decision (Decision=%v Reason=%q)", dec.Decision, dec.Reason)
+	}
+
+	// non-file kind -> ALLOW (skip)
+	dec = gate.Evaluate(context.Background(), &config.PolicyInput{
+		Action: &config.ActionDescriptor{Kind: config.ActionKindURL, TargetURL: "https://example.com"},
+	})
+	if dec.Fired() {
+		t.Fatalf("url kind: gate fired, want zero decision")
+	}
+}
+
+func TestFileGate_DenySensitiveUnixRead(t *testing.T) {
+	t.Parallel()
+	cases := []fileGateCase{
+		{name: "shadow_write", path: "/etc/shadow", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "sensitive_path"},
+		{name: "shadow_read", path: "/etc/shadow", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "sensitive_path"},
+		{name: "ssh_id_rsa_read", path: "/root/.ssh/id_rsa", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "ssh_id_ed25519", path: "/root/.ssh/id_ed25519", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "root_aws_creds", path: "/root/.aws/credentials", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "home_user_aws_creds", path: "/home/alice/.aws/credentials", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "var_lib_secrets", path: "/var/lib/secrets/foo.key", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "proc_self_environ", path: "/proc/self/environ", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "etc_passwd_write", path: "/etc/passwd", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "sensitive_path"},
+		{name: "etc_passwd_read_allowed", path: "/etc/passwd", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runFileGate(t, tc) })
+	}
+}
+
+func TestFileGate_DenyWindowsSensitivePaths(t *testing.T) {
+	t.Parallel()
+	cases := []fileGateCase{
+		{name: "system32_sam", path: `C:\Windows\System32\config\SAM`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "system32_sam_lower", path: `c:\windows\system32\config\sam`, verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "userprofile_aws_creds_lit", path: `C:\Users\bob\.aws\credentials`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "userprofile_env_aws_creds", path: `%USERPROFILE%\.aws\credentials`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "userprofile_env_ssh", path: `%USERPROFILE%\.ssh\id_rsa`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "ssh_id_rsa_backslash", path: `D:\projects\.ssh\id_rsa`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "unc_long_prefix", path: `\\?\C:\Windows\System32\config\SAM`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "unc_dos_namespace", path: `\\.\PhysicalDrive0`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "device"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runFileGate(t, tc) })
+	}
+}
+
+func TestFileGate_DenyTraversal(t *testing.T) {
+	t.Parallel()
+	cases := []fileGateCase{
+		{name: "double_dot_unix", path: "../../etc/passwd", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "traversal"},
+		{name: "double_dot_windows", path: `..\..\Windows\System32\config\SAM`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "traversal"},
+		{name: "url_encoded_slash", path: "..%2f..%2fetc%2fshadow", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "traversal"},
+		{name: "url_encoded_backslash", path: "..%5c..%5cWindows%5cSystem32", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "traversal"},
+		{name: "double_encoded_slash", path: "..%252f..%252fetc%252fshadow", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "traversal"},
+		{name: "mixed_encoding", path: "..%2f..\\etc/shadow", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "traversal"},
+		{name: "null_byte_truncation", path: "/etc/passwd%00.txt", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "null_byte"},
+		{name: "leading_traversal_hidden", path: "/workspace/../../../etc/shadow", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+		{name: "home_tilde_escape", path: "~/../../etc/shadow", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runFileGate(t, tc) })
+	}
+}
+
+func TestFileGate_DenyCredentialPatterns(t *testing.T) {
+	t.Parallel()
+	cases := []fileGateCase{
+		{name: "pem_anywhere", path: "/workspace/secret.pem", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "key_anywhere", path: "/tmp/myapp.key", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "id_rsa_bare", path: "/workspace/id_rsa", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "id_ed25519_bare", path: "/workspace/id_ed25519", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "npmrc", path: "/build/.npmrc", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "netrc", path: "/home/alice/.netrc", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "dotenv", path: "/workspace/.env", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "credentials_json", path: "/workspace/credentials.json", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "service_account_json", path: "/workspace/service_account-foo.json", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "kdbx", path: "/var/data/store.kdbx", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "pgp", path: "/tmp/foo.pgp", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "gpg", path: "/tmp/foo.gpg", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+		{name: "keystore_jks", path: "/srv/keystore.jks", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "credential"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runFileGate(t, tc) })
+	}
+}
+
+// TestFileGate_AllowLegitimateCodingPaths covers ≥5 over-refusal `coding`
+// cases (per epic rail #5 and DoD #1). These paths must NEVER deny.
+func TestFileGate_AllowLegitimateCodingPaths(t *testing.T) {
+	t.Parallel()
+	cases := []fileGateCase{
+		{name: "tmp_build_output", path: "/tmp/build-output.txt", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "workspace_src_go", path: "/workspace/src/foo.go", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "workspace_src_go_write", path: "/workspace/src/foo.go", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "windows_user_projects", path: `C:\Users\u\Projects\foo.txt`, verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "windows_user_projects_read", path: `C:\Users\u\Projects\subdir\bar.md`, verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "macos_repo", path: "/Users/dev/repo/src/main.py", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "monorepo_package_json", path: "/workspace/repo/package.json", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "go_module_file", path: "/workspace/repo/go.mod", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "readme", path: "/workspace/README.md", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "test_fixture", path: "/workspace/test/fixtures/payload.json", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runFileGate(t, tc) })
+	}
+}
+
+func TestFileGate_EmptyPathSkips(t *testing.T) {
+	t.Parallel()
+	gate := NewFileGate()
+	dec := gate.Evaluate(context.Background(), &config.PolicyInput{
+		Action: &config.ActionDescriptor{Kind: config.ActionKindFile, Verb: config.ActionVerbWrite, TargetPath: ""},
+	})
+	if dec.Fired() {
+		t.Fatalf("empty path: gate fired, want skip (Decision=%v)", dec.Decision)
+	}
+}

--- a/core/policy/actiongates/mcp_gate.go
+++ b/core/policy/actiongates/mcp_gate.go
@@ -1,0 +1,241 @@
+package actiongates
+
+import (
+	"context"
+	"path"
+	"reflect"
+	"strings"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/mcp"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// MCPIdentityResolver maps (tenant, agent_id) to the scope-filter view of
+// the calling identity. Implementations MUST be safe for concurrent use and
+// MUST respect ctx cancellation. A miss (no error, identity absent) is
+// signaled by (nil, nil); errors fail closed at the gate.
+type MCPIdentityResolver interface {
+	ResolveMCPIdentity(ctx context.Context, tenant, agentID string) (*mcp.AgentIdentity, error)
+}
+
+// DangerousParamRule names an action argument whose presence at a specific
+// value is automatically denied. Rules are scoped to a tool-name glob (see
+// MCPGateOptions.DangerousParamRules). Comparison is deep-equality on Value.
+type DangerousParamRule struct {
+	Name  string
+	Value any
+}
+
+// MCPGateOptions configures the MCP/tool-call gate. Identities is required;
+// the gate fails closed without it. Reachability is optional; a nil probe
+// skips the unavailability check. DangerousParamRules is keyed by a tool-
+// name glob ("*" applies to all tools); rules from every matching key are
+// evaluated.
+type MCPGateOptions struct {
+	Identities          MCPIdentityResolver
+	Reachability        ReachabilityProbe
+	DangerousParamRules map[string][]DangerousParamRule
+}
+
+// MCPGate enforces MCP/tool-call admission. It converges on the same
+// allow/deny semantics as core/mcp.FilterForIdentity for the AllowedTools
+// field but additionally validates: AllowedServers, AllowedResources,
+// RequiredEntitlement, DangerousParamRules and Reachability.
+type MCPGate struct {
+	identities   MCPIdentityResolver
+	reachability ReachabilityProbe
+	dangerous    map[string][]DangerousParamRule
+}
+
+// NewMCPGate returns a gate bound to the resolver/probe in opts.
+func NewMCPGate(opts MCPGateOptions) *MCPGate {
+	return &MCPGate{
+		identities:   opts.Identities,
+		reachability: opts.Reachability,
+		dangerous:    opts.DangerousParamRules,
+	}
+}
+
+func (g *MCPGate) ID() string { return GateIDMCP }
+
+func (g *MCPGate) Evaluate(ctx context.Context, in *config.PolicyInput) ActionGateDecision {
+	if in == nil || in.Action == nil {
+		return ActionGateDecision{}
+	}
+	act := in.Action
+	if act.Kind != config.ActionKindMCPCall {
+		return ActionGateDecision{}
+	}
+
+	actx := auth.FromContext(ctx)
+	if actx == nil || strings.TrimSpace(actx.Tenant) == "" {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeUnauthorized,
+			"authentication required", "missing_auth")
+	}
+
+	agentID := strings.TrimSpace(in.Meta.AgentID)
+	if agentID == "" {
+		agentID = strings.TrimSpace(in.Labels["agent_id"])
+	}
+	if agentID == "" {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeUnauthorized,
+			"agent identity required for mcp_call", "missing_agent_id")
+	}
+
+	if g.identities == nil {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"identity resolver unavailable", "identity_resolver_unavailable")
+	}
+	id, err := g.identities.ResolveMCPIdentity(ctx, actx.Tenant, agentID)
+	if err != nil {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"identity resolution failed", "identity_lookup_failed:"+sanitizeErr(err))
+	}
+	if id == nil {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeUnauthorized,
+			"agent identity not found", "no_identity")
+	}
+
+	if !globAdmits(id.AllowedServers, act.Server) {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			"MCP server is not allow-listed for this identity", "server_not_allowlisted")
+	}
+	if !globAdmits(id.AllowedTools, act.Tool) {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			"MCP tool is not allow-listed for this identity", "tool_not_allowlisted")
+	}
+	if act.TargetURL != "" {
+		if !globAdmits(id.AllowedResources, act.TargetURL) {
+			return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+				"MCP resource is not allow-listed for this identity", "resource_not_allowlisted")
+		}
+	}
+
+	if strings.TrimSpace(act.RequiredEntitlement) != "" && !hasEntitlement(id.Entitlements, act.RequiredEntitlement) {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			"identity lacks required entitlement", "unlicensed")
+	}
+
+	if sub, hit := matchDangerousParams(g.dangerous, act.Tool, act.Args); hit {
+		return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			"action carries a dangerous parameter", sub)
+	}
+
+	if g.reachability != nil && strings.TrimSpace(act.Server) != "" {
+		reachable, perr := g.reachability.MCPServerReachable(ctx, act.Server)
+		if perr != nil {
+			return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeServiceUnavailable,
+				"MCP server reachability probe failed", "reachability_probe_failed:"+sanitizeErr(perr))
+		}
+		if !reachable {
+			return mcpDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeServiceUnavailable,
+				"MCP server is currently unreachable", "server_unreachable")
+		}
+	}
+
+	return ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_ALLOW,
+		GateID:    GateIDMCP,
+		Reason:    "mcp call authorized",
+		SubReason: "allowed",
+		Extra:     mcpExtra(act, "allowed"),
+	}
+}
+
+func mcpDecision(decision pb.DecisionType, act *config.ActionDescriptor, code, reason, sub string) ActionGateDecision {
+	return ActionGateDecision{
+		Decision:  decision,
+		GateID:    GateIDMCP,
+		Code:      code,
+		Reason:    reason,
+		SubReason: sub,
+		Extra:     mcpExtra(act, sub),
+	}
+}
+
+func mcpExtra(act *config.ActionDescriptor, sub string) map[string]string {
+	out := map[string]string{
+		"gate":       GateIDMCP,
+		"sub_reason": sub,
+	}
+	if act.Server != "" {
+		out["server"] = act.Server
+	}
+	if act.Tool != "" {
+		out["tool"] = act.Tool
+	}
+	return out
+}
+
+// globAdmits returns true when value matches any glob in patterns. Empty
+// patterns or empty value returns false (fail-closed). Patterns use the
+// stdlib path.Match grammar — same as the existing core/mcp filter and the
+// matchTopic helper in core/infra/config.
+func globAdmits(patterns []string, value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for _, p := range patterns {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		ok, err := path.Match(p, value)
+		if err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEntitlement(have []string, required string) bool {
+	want := strings.TrimSpace(required)
+	if want == "" {
+		return true
+	}
+	for _, e := range have {
+		if strings.EqualFold(strings.TrimSpace(e), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchDangerousParams walks the configured rule sets, picking up entries
+// whose tool-name glob matches the action's tool. For each entry it
+// compares Args[Name] to Value with reflect.DeepEqual so map/slice payloads
+// are handled consistently. The first match wins; sub_reason carries the
+// param name so SIEM can pivot.
+func matchDangerousParams(rules map[string][]DangerousParamRule, tool string, args map[string]any) (string, bool) {
+	if len(rules) == 0 || len(args) == 0 {
+		return "", false
+	}
+	tool = strings.TrimSpace(tool)
+	for pattern, set := range rules {
+		p := strings.TrimSpace(pattern)
+		if p == "" {
+			continue
+		}
+		ok, err := path.Match(p, tool)
+		if err != nil || !ok {
+			continue
+		}
+		for _, rule := range set {
+			name := strings.TrimSpace(rule.Name)
+			if name == "" {
+				continue
+			}
+			actual, present := args[name]
+			if !present {
+				continue
+			}
+			if reflect.DeepEqual(actual, rule.Value) {
+				return "dangerous_param:" + name, true
+			}
+		}
+	}
+	return "", false
+}

--- a/core/policy/actiongates/mcp_gate_test.go
+++ b/core/policy/actiongates/mcp_gate_test.go
@@ -1,0 +1,361 @@
+package actiongates
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/mcp"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// fakeMCPIdentityResolver returns identities by tenant+agent id; unknown
+// ids resolve to nil (no identity) so the gate's fail-closed path is
+// exercisable.
+type fakeMCPIdentityResolver struct {
+	by  map[string]*mcp.AgentIdentity // key = tenant + "/" + agentID
+	err error
+}
+
+func (f *fakeMCPIdentityResolver) ResolveMCPIdentity(_ context.Context, tenant, agentID string) (*mcp.AgentIdentity, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if id, ok := f.by[tenant+"/"+agentID]; ok {
+		return id, nil
+	}
+	return nil, nil
+}
+
+// fakeReachability lets tests script per-server reachability + errors.
+type fakeReachability struct {
+	reachable map[string]bool
+	err       error
+}
+
+func (f *fakeReachability) MCPServerReachable(_ context.Context, server string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	if r, ok := f.reachable[server]; ok {
+		return r, nil
+	}
+	return true, nil
+}
+
+const (
+	mcpTenantA = "tnt_a"
+	mcpAgentA  = "agent_a"
+)
+
+func mcpAuthCtx() context.Context {
+	return ctxWithAuth(&auth.AuthContext{
+		Tenant: mcpTenantA, PrincipalID: "p1", Role: "user",
+	})
+}
+
+func mcpFullIdentity() *mcp.AgentIdentity {
+	return &mcp.AgentIdentity{
+		ID:                  mcpAgentA,
+		AllowedServers:      []string{"vault", "calendar*"},
+		AllowedTools:        []string{"read_*", "list_*"},
+		AllowedResources:    []string{"cordum://docs/*", "cordum://calendar/*"},
+		Entitlements:        []string{"vault.read", "calendar.read"},
+		RiskTier:            "high",
+		DataClassifications: []string{"public", "internal"},
+	}
+}
+
+func mcpInputAction(server, tool string) *config.PolicyInput {
+	return &config.PolicyInput{Action: &config.ActionDescriptor{
+		Kind:   config.ActionKindMCPCall,
+		Verb:   config.ActionVerbRead,
+		Server: server,
+		Tool:   tool,
+	}}
+}
+
+func newMCPGateWithIdentity(id *mcp.AgentIdentity, opts ...func(*MCPGateOptions)) *MCPGate {
+	resolver := &fakeMCPIdentityResolver{by: map[string]*mcp.AgentIdentity{}}
+	if id != nil {
+		resolver.by[mcpTenantA+"/"+id.ID] = id
+	}
+	gopts := MCPGateOptions{Identities: resolver, Reachability: &fakeReachability{}}
+	for _, o := range opts {
+		o(&gopts)
+	}
+	return NewMCPGate(gopts)
+}
+
+func withAgentIDLabel(in *config.PolicyInput, agentID string) *config.PolicyInput {
+	if in.Labels == nil {
+		in.Labels = map[string]string{}
+	}
+	in.Labels["agent_id"] = agentID
+	return in
+}
+
+func TestMCPGate_SkipsWhenNoAction(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	dec := gate.Evaluate(mcpAuthCtx(), &config.PolicyInput{})
+	if dec.Fired() {
+		t.Fatalf("no action: gate fired (decision=%v)", dec.Decision)
+	}
+}
+
+func TestMCPGate_OtherKindsSkip(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	dec := gate.Evaluate(mcpAuthCtx(), &config.PolicyInput{Action: &config.ActionDescriptor{
+		Kind: config.ActionKindFile, TargetPath: "/tmp/x",
+	}})
+	if dec.Fired() {
+		t.Fatalf("file kind: gate fired")
+	}
+}
+
+func TestMCPGate_UnauthDenies(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	dec := gate.Evaluate(ctxWithAuth(nil), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeUnauthorized {
+		t.Fatalf("got %v / %q, want DENY / unauthorized", dec.Decision, dec.Code)
+	}
+}
+
+func TestMCPGate_NoIdentityResolvedDenies(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(nil) // resolver returns (nil, nil)
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), "unknown_agent")
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeUnauthorized {
+		t.Fatalf("got %v / %q, want DENY / unauthorized (no identity)", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "no_identity") {
+		t.Fatalf("subReason = %q, want no_identity", dec.SubReason)
+	}
+}
+
+func TestMCPGate_IdentityResolverErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+	gate := NewMCPGate(MCPGateOptions{
+		Identities:   &fakeMCPIdentityResolver{err: errors.New("redis unreachable")},
+		Reachability: &fakeReachability{},
+	})
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeInternalError {
+		t.Fatalf("got %v / %q, want DENY / internal_error (fail-closed)", dec.Decision, dec.Code)
+	}
+}
+
+func TestMCPGate_ServerNotAllowlistedDenied(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	in := withAgentIDLabel(mcpInputAction("billing", "charge"), mcpAgentA) // billing not in AllowedServers
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+		t.Fatalf("got %v / %q, want DENY / access_denied", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "server_not_allowlisted") {
+		t.Fatalf("subReason = %q, want server_not_allowlisted", dec.SubReason)
+	}
+}
+
+func TestMCPGate_EmptyAllowedServersDeniesAll(t *testing.T) {
+	t.Parallel()
+	id := mcpFullIdentity()
+	id.AllowedServers = nil // fail-closed
+	gate := newMCPGateWithIdentity(id)
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+		t.Fatalf("got %v / %q, want DENY / access_denied for empty AllowedServers", dec.Decision, dec.Code)
+	}
+}
+
+func TestMCPGate_ToolNotAllowlistedDenied(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	in := withAgentIDLabel(mcpInputAction("vault", "delete_secret"), mcpAgentA) // not in read_*/list_*
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+		t.Fatalf("got %v / %q, want DENY / access_denied", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "tool_not_allowlisted") {
+		t.Fatalf("subReason = %q, want tool_not_allowlisted", dec.SubReason)
+	}
+}
+
+// TestMCPGate_ConvergesWithFilterForIdentity asserts that the actiongates
+// path and the existing core/mcp.EvaluateForIdentity path agree on tool-
+// allowlist denials: both reject the same identity+tool pair.
+func TestMCPGate_ConvergesWithFilterForIdentity(t *testing.T) {
+	t.Parallel()
+	id := mcpFullIdentity()
+	tool := mcp.Tool{Name: "delete_secret", RiskTier: "high"}
+	reason := mcp.EvaluateForIdentity(tool, id)
+	if reason != mcp.DenyReasonNotInAllowedList {
+		t.Fatalf("FilterForIdentity reason = %q, want %q", reason, mcp.DenyReasonNotInAllowedList)
+	}
+
+	gate := newMCPGateWithIdentity(id)
+	in := withAgentIDLabel(mcpInputAction("vault", tool.Name), mcpAgentA)
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || !strings.Contains(dec.SubReason, "tool_not_allowlisted") {
+		t.Fatalf("MCPGate disagreed with FilterForIdentity: dec=%v sub=%q", dec.Decision, dec.SubReason)
+	}
+}
+
+func TestMCPGate_ResourceNotAllowlistedDenied(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	in.Action.TargetURL = "cordum://secrets/db_password" // not in AllowedResources
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+		t.Fatalf("got %v / %q, want DENY / access_denied", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "resource_not_allowlisted") {
+		t.Fatalf("subReason = %q, want resource_not_allowlisted", dec.SubReason)
+	}
+}
+
+func TestMCPGate_AllowedResourceMatches(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	in.Action.TargetURL = "cordum://docs/runbook.md"
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_ALLOW {
+		t.Fatalf("got %v, want ALLOW for allow-listed resource", dec.Decision)
+	}
+}
+
+func TestMCPGate_DangerousParamsDenied(t *testing.T) {
+	t.Parallel()
+	customRules := map[string][]DangerousParamRule{
+		"*":        {{Name: "force", Value: true}, {Name: "no_confirm", Value: true}},
+		"delete_*": {{Name: "recursive", Value: true}},
+		"*exec*":   {{Name: "shell", Value: true}},
+	}
+	cases := []struct {
+		name   string
+		server string
+		tool   string
+		args   map[string]any
+	}{
+		{"force_true", "vault", "read_secret", map[string]any{"force": true}},
+		{"no_confirm_true", "vault", "read_secret", map[string]any{"no_confirm": true}},
+		{"recursive_on_delete", "vault", "delete_secret_v2", map[string]any{"recursive": true}},
+		{"shell_on_exec", "calendar", "shellexec", map[string]any{"shell": true}},
+	}
+	id := mcpFullIdentity()
+	id.AllowedTools = append(id.AllowedTools, "delete_*", "*exec*") // permit so the dangerous-param check is reached
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gate := newMCPGateWithIdentity(id, func(o *MCPGateOptions) { o.DangerousParamRules = customRules })
+			in := withAgentIDLabel(mcpInputAction(tc.server, tc.tool), mcpAgentA)
+			in.Action.Args = tc.args
+			dec := gate.Evaluate(mcpAuthCtx(), in)
+			if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+				t.Fatalf("got %v / %q, want DENY / access_denied", dec.Decision, dec.Code)
+			}
+			if !strings.Contains(dec.SubReason, "dangerous_param") {
+				t.Fatalf("subReason = %q, want dangerous_param", dec.SubReason)
+			}
+		})
+	}
+}
+
+func TestMCPGate_UnlicensedDenied(t *testing.T) {
+	t.Parallel()
+	id := mcpFullIdentity()
+	id.Entitlements = []string{"calendar.read"} // missing vault.read
+	gate := newMCPGateWithIdentity(id)
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	in.Action.RequiredEntitlement = "vault.read"
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+		t.Fatalf("got %v / %q, want DENY / access_denied", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "unlicensed") {
+		t.Fatalf("subReason = %q, want unlicensed", dec.SubReason)
+	}
+}
+
+func TestMCPGate_ServerUnavailable(t *testing.T) {
+	t.Parallel()
+	id := mcpFullIdentity()
+	reach := &fakeReachability{reachable: map[string]bool{"vault": false}}
+	gate := NewMCPGate(MCPGateOptions{
+		Identities:   &fakeMCPIdentityResolver{by: map[string]*mcp.AgentIdentity{mcpTenantA + "/" + mcpAgentA: id}},
+		Reachability: reach,
+	})
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeServiceUnavailable {
+		t.Fatalf("got %v / %q, want DENY / service_unavailable", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "server_unreachable") {
+		t.Fatalf("subReason = %q, want server_unreachable", dec.SubReason)
+	}
+}
+
+func TestMCPGate_ProbeErrFailsClosed(t *testing.T) {
+	t.Parallel()
+	id := mcpFullIdentity()
+	reach := &fakeReachability{err: errors.New("probe timed out")}
+	gate := NewMCPGate(MCPGateOptions{
+		Identities:   &fakeMCPIdentityResolver{by: map[string]*mcp.AgentIdentity{mcpTenantA + "/" + mcpAgentA: id}},
+		Reachability: reach,
+	})
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeServiceUnavailable {
+		t.Fatalf("got %v / %q, want DENY / service_unavailable on probe err", dec.Decision, dec.Code)
+	}
+}
+
+func TestMCPGate_AllowValid(t *testing.T) {
+	t.Parallel()
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	in.Action.RequiredEntitlement = "vault.read"
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_ALLOW {
+		t.Fatalf("got %v, want ALLOW for allow-listed valid call", dec.Decision)
+	}
+}
+
+func TestMCPGate_NoReachabilityProbeAllows(t *testing.T) {
+	t.Parallel()
+	// nil probe means "skip reachability gate"; the test ensures the gate
+	// does not crash on a nil probe.
+	gate := NewMCPGate(MCPGateOptions{
+		Identities:   &fakeMCPIdentityResolver{by: map[string]*mcp.AgentIdentity{mcpTenantA + "/" + mcpAgentA: mcpFullIdentity()}},
+		Reachability: nil,
+	})
+	in := withAgentIDLabel(mcpInputAction("vault", "read_secret"), mcpAgentA)
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_ALLOW {
+		t.Fatalf("got %v, want ALLOW with nil probe", dec.Decision)
+	}
+}
+
+func TestMCPGate_MissingAgentLabelDenies(t *testing.T) {
+	t.Parallel()
+	// No agent_id label -> cannot resolve identity -> fail-closed.
+	gate := newMCPGateWithIdentity(mcpFullIdentity())
+	in := mcpInputAction("vault", "read_secret") // no agent_id label
+	dec := gate.Evaluate(mcpAuthCtx(), in)
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeUnauthorized {
+		t.Fatalf("got %v / %q, want DENY / unauthorized (missing agent_id)", dec.Decision, dec.Code)
+	}
+}

--- a/core/policy/actiongates/mutation_gate.go
+++ b/core/policy/actiongates/mutation_gate.go
@@ -1,0 +1,281 @@
+package actiongates
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// MutationGate enforces approval + provenance discipline for destructive
+// verbs. Non-destructive verbs (read/write) and non-mutation kinds short-
+// circuit to the zero decision so the pipeline continues.
+//
+// The gate trusts neither ApprovalClaim.ClaimText ("approved by CFO") nor
+// any tenant claim on the action body. Authorization is granted only when
+// the backend resolves ApprovalClaim.ApprovalRef to an EdgeApproval that
+// (a) belongs to the auth tenant, (b) is not self-approved, (c) is in
+// status "approved" with decision "approve", (d) has not been consumed,
+// (e) has not expired, and (f) carries an ActionHash matching the
+// canonical hash of the current descriptor.
+type MutationGate struct {
+	approvals ApprovalLookup
+	resources ResourceLookup
+}
+
+// MutationGateOptions configures the gate. Approvals SHOULD be wired to a
+// Cordum approval store in production; Resources is optional and skipped
+// when nil (callers that cannot afford a synchronous existence check
+// accept the downstream error path).
+type MutationGateOptions struct {
+	Approvals ApprovalLookup
+	Resources ResourceLookup
+}
+
+// NewMutationGate returns a mutation gate bound to the provided lookups.
+// A nil Approvals lookup causes every destructive action to fail closed
+// with internal_error; this matches the "no silent allow" rule even when
+// integration is mis-wired in test/dev.
+func NewMutationGate(opts MutationGateOptions) *MutationGate {
+	return &MutationGate{approvals: opts.Approvals, resources: opts.Resources}
+}
+
+func (g *MutationGate) ID() string { return GateIDMutation }
+
+// destructiveVerbs is the set of action verbs the gate fires on. Adding a
+// new destructive verb requires updating both this set and the matching
+// public ActionVerb const in core/infra/config/safety_policy.go.
+var destructiveVerbs = map[config.ActionVerb]struct{}{
+	config.ActionVerbDelete:        {},
+	config.ActionVerbDrop:          {},
+	config.ActionVerbTruncate:      {},
+	config.ActionVerbExport:        {},
+	config.ActionVerbPayment:       {},
+	config.ActionVerbAdminGrant:    {},
+	config.ActionVerbAdminRevoke:   {},
+	config.ActionVerbRoleAssign:    {},
+	config.ActionVerbRoleRemove:    {},
+	config.ActionVerbLicenseCreate: {},
+	config.ActionVerbLicenseRevoke: {},
+	config.ActionVerbLicenseChange: {},
+	config.ActionVerbKeyRotate:     {},
+	config.ActionVerbKeyDelete:     {},
+	config.ActionVerbSecretsWrite:  {},
+	config.ActionVerbSecretsDelete: {},
+	config.ActionVerbConfigWrite:   {},
+	config.ActionVerbConfigDelete:  {},
+	config.ActionVerbBackupRestore: {},
+	config.ActionVerbTenantCreate:  {},
+	config.ActionVerbTenantDelete:  {},
+}
+
+// IsDestructiveVerb reports whether v is in the set of destructive verbs.
+// Exported for use by sibling gates (provenance) that share the policy.
+func IsDestructiveVerb(v config.ActionVerb) bool {
+	_, ok := destructiveVerbs[v]
+	return ok
+}
+
+func (g *MutationGate) Evaluate(ctx context.Context, in *config.PolicyInput) ActionGateDecision {
+	if in == nil || in.Action == nil {
+		return ActionGateDecision{}
+	}
+	act := in.Action
+	if act.Kind != config.ActionKindMutation || !IsDestructiveVerb(act.Verb) {
+		return ActionGateDecision{}
+	}
+
+	actx := auth.FromContext(ctx)
+	if actx == nil || strings.TrimSpace(actx.Tenant) == "" {
+		return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeUnauthorized,
+			"authentication required", "missing_auth")
+	}
+
+	if act.ApprovalClaim == nil || strings.TrimSpace(act.ApprovalClaim.ApprovalRef) == "" {
+		return mutDecision(pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN, act, CodeRequireHuman,
+			"destructive action requires human approval", "missing_approval")
+	}
+
+	hash := CanonicalActionHash(act)
+	if g.approvals == nil {
+		return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"approval lookup unavailable", "approval_lookup_failed:nil_lookup")
+	}
+	approval, ok, err := g.approvals.LookupByActionHash(ctx, actx.Tenant, hash)
+	if err != nil {
+		return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"approval lookup failed", "approval_lookup_failed:"+sanitizeErr(err))
+	}
+	if !ok || approval == nil {
+		return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeNotFound,
+			"no approval record for this action", "approval_not_found")
+	}
+
+	if approval.TenantID != actx.Tenant {
+		return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			"approval is for a different tenant", "approval_tenant_mismatch")
+	}
+	if approval.ResolverID != "" && approval.ResolverID == actx.PrincipalID {
+		return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			"self-approval is not allowed", "self_approval")
+	}
+	if approval.Status != edge.ApprovalStatusApproved {
+		return mutConflict(act, "approval_status_"+string(approval.Status))
+	}
+	if approval.Decision != edge.ApprovalDecisionApprove {
+		return mutConflict(act, "approval_decision_"+string(approval.Decision))
+	}
+	if approval.ConsumedAt != nil {
+		return mutConflict(act, "approval_consumed")
+	}
+	if approval.ExpiresAt != nil && time.Now().UTC().After(*approval.ExpiresAt) {
+		return mutConflict(act, "approval_expired")
+	}
+	if approval.ActionHash != hash {
+		return mutConflict(act, "approval_mismatch")
+	}
+
+	if g.resources != nil && act.TargetResource != nil && strings.TrimSpace(act.TargetResource.ID) != "" {
+		exists, rerr := g.resources.ResourceExists(ctx, actx.Tenant, *act.TargetResource)
+		if rerr != nil {
+			return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeServiceUnavailable,
+				"target lookup unavailable", "resource_lookup_failed:"+sanitizeErr(rerr))
+		}
+		if !exists {
+			return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeNotFound,
+				"target resource not found", "resource_not_found")
+		}
+	}
+
+	extra := mutExtra(act, "approved")
+	extra["approval_ref"] = approval.ApprovalRef
+	extra["single_use"] = "true"
+	return ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS,
+		GateID:    GateIDMutation,
+		Reason:    "destructive action authorized by backend approval",
+		SubReason: "approved",
+		Extra:     extra,
+	}
+}
+
+func mutDecision(decision pb.DecisionType, act *config.ActionDescriptor, code, reason, sub string) ActionGateDecision {
+	return ActionGateDecision{
+		Decision:  decision,
+		GateID:    GateIDMutation,
+		Code:      code,
+		Reason:    reason,
+		SubReason: sub,
+		Extra:     mutExtra(act, sub),
+	}
+}
+
+func mutConflict(act *config.ActionDescriptor, sub string) ActionGateDecision {
+	return mutDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeConflict,
+		"approval cannot be used for this action", sub)
+}
+
+func mutExtra(act *config.ActionDescriptor, sub string) map[string]string {
+	out := map[string]string{
+		"gate":       GateIDMutation,
+		"sub_reason": sub,
+		"verb":       string(act.Verb),
+	}
+	if act.TargetResource != nil && act.TargetResource.Type != "" {
+		out["target_type"] = act.TargetResource.Type
+	}
+	return out
+}
+
+// sanitizeErr strips newlines from an error message so the sub_reason
+// stays single-line for SIEM grep'ability.
+func sanitizeErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := err.Error()
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}
+
+// CanonicalActionHash returns a stable hex-encoded SHA-256 of the action's
+// authorization-relevant fields. Map ordering is normalized so equivalent
+// payloads hash identically regardless of insertion order. nil returns "".
+//
+// The hash binds an approval to a specific action shape: when the resolved
+// approval.ActionHash differs from this value, the gate raises an
+// approval_mismatch conflict — the approval was granted for a different
+// payload.
+func CanonicalActionHash(act *config.ActionDescriptor) string {
+	if act == nil {
+		return ""
+	}
+	payload := canonicalPayload(act)
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		// All entries in payload are primitives/strings/maps/slices that
+		// json.Marshal can encode; this branch is defensive.
+		return ""
+	}
+	sum := sha256.Sum256(buf)
+	return hex.EncodeToString(sum[:])
+}
+
+// canonicalPayload builds a deterministic representation of the action
+// suitable for hashing. encoding/json sorts map keys, so map[string]X
+// values produce stable bytes. Slices that are conceptually sets
+// (Wildcards, RiskTags) are sorted before being embedded.
+func canonicalPayload(act *config.ActionDescriptor) map[string]any {
+	payload := map[string]any{
+		"kind": string(act.Kind),
+		"verb": string(act.Verb),
+	}
+	if act.Server != "" {
+		payload["server"] = act.Server
+	}
+	if act.Tool != "" {
+		payload["tool"] = act.Tool
+	}
+	if act.TargetPath != "" {
+		payload["target_path"] = act.TargetPath
+	}
+	if act.TargetURL != "" {
+		payload["target_url"] = act.TargetURL
+	}
+	if act.TargetResource != nil {
+		payload["target_resource"] = map[string]any{
+			"type":         act.TargetResource.Type,
+			"id":           act.TargetResource.ID,
+			"owner_tenant": act.TargetResource.OwnerTenant,
+		}
+	}
+	if len(act.Filters) > 0 {
+		payload["filters"] = act.Filters
+	}
+	if len(act.Wildcards) > 0 {
+		payload["wildcards"] = sortedCopy(act.Wildcards)
+	}
+	if len(act.Args) > 0 {
+		payload["args"] = act.Args
+	}
+	if len(act.RiskTags) > 0 {
+		payload["risk_tags"] = sortedCopy(act.RiskTags)
+	}
+	return payload
+}
+
+func sortedCopy(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	sort.Strings(out)
+	return out
+}

--- a/core/policy/actiongates/mutation_gate_test.go
+++ b/core/policy/actiongates/mutation_gate_test.go
@@ -1,0 +1,377 @@
+package actiongates
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// fakeApprovalLookup is a minimal ApprovalLookup implementation for tests.
+type fakeApprovalLookup struct {
+	records map[string]*edge.EdgeApproval // key: tenant + ":" + hash
+	err     error
+}
+
+func (f *fakeApprovalLookup) LookupByActionHash(_ context.Context, tenant, hash string) (*edge.EdgeApproval, bool, error) {
+	if f.err != nil {
+		return nil, false, f.err
+	}
+	if a, ok := f.records[tenant+":"+hash]; ok {
+		return a, true, nil
+	}
+	return nil, false, nil
+}
+
+// fakeResourceLookup says any resource exists unless its ID is in missing.
+type fakeResourceLookup struct {
+	missing map[string]bool
+	err     error
+}
+
+func (f *fakeResourceLookup) ResourceExists(_ context.Context, _ string, res config.ActionTargetResource) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	if f.missing[res.ID] {
+		return false, nil
+	}
+	return true, nil
+}
+
+func mutDeleteAction() *config.ActionDescriptor {
+	return &config.ActionDescriptor{
+		Kind: config.ActionKindMutation,
+		Verb: config.ActionVerbDelete,
+		TargetResource: &config.ActionTargetResource{
+			Type: "user", ID: "user_42", OwnerTenant: "tnt_a",
+		},
+	}
+}
+
+func mutCtx() context.Context {
+	return ctxWithAuth(&auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"})
+}
+
+func TestMutationGate_NonDestructiveSkips(t *testing.T) {
+	t.Parallel()
+	gate := NewMutationGate(MutationGateOptions{Approvals: &fakeApprovalLookup{}, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{
+		Action: &config.ActionDescriptor{Kind: config.ActionKindMutation, Verb: config.ActionVerbRead},
+	})
+	if dec.Fired() {
+		t.Fatalf("read verb: gate fired (Decision=%v)", dec.Decision)
+	}
+}
+
+func TestMutationGate_OtherKindsSkip(t *testing.T) {
+	t.Parallel()
+	gate := NewMutationGate(MutationGateOptions{Approvals: &fakeApprovalLookup{}, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{
+		Action: &config.ActionDescriptor{Kind: config.ActionKindFile, TargetPath: "/tmp/x"},
+	})
+	if dec.Fired() {
+		t.Fatal("file kind: gate fired")
+	}
+}
+
+func TestMutationGate_UnauthDenies(t *testing.T) {
+	t.Parallel()
+	gate := NewMutationGate(MutationGateOptions{Approvals: &fakeApprovalLookup{}, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(ctxWithAuth(nil), &config.PolicyInput{Action: mutDeleteAction()})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeUnauthorized {
+		t.Fatalf("got %v / %q, want DENY / unauthorized", dec.Decision, dec.Code)
+	}
+}
+
+func TestMutationGate_NoApprovalRequiresHuman(t *testing.T) {
+	t.Parallel()
+	gate := NewMutationGate(MutationGateOptions{Approvals: &fakeApprovalLookup{}, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: mutDeleteAction()})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN || dec.Code != CodeRequireHuman {
+		t.Fatalf("got %v / %q, want REQUIRE_HUMAN", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "missing_approval") {
+		t.Fatalf("subReason = %q, want substring missing_approval", dec.SubReason)
+	}
+}
+
+func TestMutationGate_ClaimTextOnlyStillRequiresHuman(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ClaimText: "approved by CFO", ApprovalRef: ""}
+	gate := NewMutationGate(MutationGateOptions{Approvals: &fakeApprovalLookup{}, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+		t.Fatalf("got %v, want REQUIRE_HUMAN (claim text without backend ref must not pass)", dec.Decision)
+	}
+	if !strings.Contains(dec.SubReason, "missing_approval") {
+		t.Fatalf("subReason = %q, want missing_approval", dec.SubReason)
+	}
+}
+
+func TestMutationGate_SelfApprovalDenied(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	hash := CanonicalActionHash(action)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p1", // same as PrincipalID -> self approval
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+	}
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{"tnt_a:" + hash: approval}}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+		t.Fatalf("got %v / %q, want DENY / access_denied", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "self_approval") {
+		t.Fatalf("subReason = %q, want self_approval", dec.SubReason)
+	}
+}
+
+func TestMutationGate_ConsumedConflict(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	hash := CanonicalActionHash(action)
+	now := time.Now().UTC().Add(-1 * time.Hour)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+		ConsumedAt:  &now, // already used
+	}
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{"tnt_a:" + hash: approval}}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeConflict {
+		t.Fatalf("got %v / %q, want DENY / conflict", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "consumed") {
+		t.Fatalf("subReason = %q, want substring consumed", dec.SubReason)
+	}
+}
+
+func TestMutationGate_ExpiredConflict(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	hash := CanonicalActionHash(action)
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+		ExpiresAt:   &past,
+	}
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{"tnt_a:" + hash: approval}}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeConflict {
+		t.Fatalf("got %v / %q, want conflict", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "expired") {
+		t.Fatalf("subReason = %q, want expired", dec.SubReason)
+	}
+}
+
+func TestMutationGate_HashMismatchConflict(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	hash := CanonicalActionHash(action)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  "DIFFERENT_HASH",
+	}
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{"tnt_a:" + hash: approval}}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeConflict {
+		t.Fatalf("got %v / %q, want conflict", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "mismatch") {
+		t.Fatalf("subReason = %q, want mismatch", dec.SubReason)
+	}
+}
+
+func TestMutationGate_BackendDownFailsClosed(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	lookup := &fakeApprovalLookup{err: errors.New("redis down")}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeInternalError {
+		t.Fatalf("got %v / %q, want DENY / internal_error (fail closed)", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "approval_lookup_failed") {
+		t.Fatalf("subReason = %q, want approval_lookup_failed", dec.SubReason)
+	}
+}
+
+func TestMutationGate_TargetMissingNotFound(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	hash := CanonicalActionHash(action)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+	}
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{"tnt_a:" + hash: approval}}
+	resources := &fakeResourceLookup{missing: map[string]bool{"user_42": true}}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: resources})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeNotFound {
+		t.Fatalf("got %v / %q, want DENY / not_found", dec.Decision, dec.Code)
+	}
+}
+
+func TestMutationGate_ResourceLookupErrorServiceUnavailable(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	hash := CanonicalActionHash(action)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+	}
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{"tnt_a:" + hash: approval}}
+	resources := &fakeResourceLookup{err: errors.New("db unreachable")}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: resources})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeServiceUnavailable {
+		t.Fatalf("got %v / %q, want DENY / service_unavailable", dec.Decision, dec.Code)
+	}
+}
+
+func TestMutationGate_ValidApprovalAllows(t *testing.T) {
+	t.Parallel()
+	action := mutDeleteAction()
+	action.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	hash := CanonicalActionHash(action)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+	}
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{"tnt_a:" + hash: approval}}
+	gate := NewMutationGate(MutationGateOptions{Approvals: lookup, Resources: &fakeResourceLookup{}})
+	dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: action})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS {
+		t.Fatalf("got %v, want ALLOW_WITH_CONSTRAINTS", dec.Decision)
+	}
+	if dec.Extra["approval_ref"] != "appr_1" {
+		t.Fatalf("extra.approval_ref = %q, want appr_1", dec.Extra["approval_ref"])
+	}
+	if dec.Extra["single_use"] != "true" {
+		t.Fatalf("extra.single_use = %q, want true", dec.Extra["single_use"])
+	}
+}
+
+func TestMutationGate_DestructiveVerbCoverage(t *testing.T) {
+	t.Parallel()
+	verbs := []config.ActionVerb{
+		config.ActionVerbDelete, config.ActionVerbDrop, config.ActionVerbTruncate,
+		config.ActionVerbExport, config.ActionVerbPayment,
+		config.ActionVerbAdminGrant, config.ActionVerbAdminRevoke,
+		config.ActionVerbRoleAssign, config.ActionVerbRoleRemove,
+		config.ActionVerbLicenseCreate, config.ActionVerbLicenseRevoke, config.ActionVerbLicenseChange,
+		config.ActionVerbKeyRotate, config.ActionVerbKeyDelete,
+		config.ActionVerbSecretsWrite, config.ActionVerbSecretsDelete,
+		config.ActionVerbConfigWrite, config.ActionVerbConfigDelete,
+		config.ActionVerbBackupRestore,
+		config.ActionVerbTenantCreate, config.ActionVerbTenantDelete,
+	}
+	gate := NewMutationGate(MutationGateOptions{Approvals: &fakeApprovalLookup{}, Resources: &fakeResourceLookup{}})
+	for _, v := range verbs {
+		t.Run(string(v), func(t *testing.T) {
+			t.Parallel()
+			act := mutDeleteAction()
+			act.Verb = v
+			dec := gate.Evaluate(mutCtx(), &config.PolicyInput{Action: act})
+			if dec.Decision != pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+				t.Fatalf("verb %q: got %v, want REQUIRE_HUMAN", v, dec.Decision)
+			}
+		})
+	}
+}
+
+func TestCanonicalActionHash_StableUnderKeyReordering(t *testing.T) {
+	t.Parallel()
+	a := &config.ActionDescriptor{
+		Kind: config.ActionKindMutation, Verb: config.ActionVerbDelete,
+		TargetResource: &config.ActionTargetResource{Type: "user", ID: "u1", OwnerTenant: "tnt_a"},
+		Filters:        map[string]string{"b": "1", "a": "2"},
+		Args:           map[string]any{"y": 2, "x": 1, "nested": map[string]any{"q": "Q", "p": "P"}},
+	}
+	b := &config.ActionDescriptor{
+		Kind: config.ActionKindMutation, Verb: config.ActionVerbDelete,
+		TargetResource: &config.ActionTargetResource{Type: "user", ID: "u1", OwnerTenant: "tnt_a"},
+		Filters:        map[string]string{"a": "2", "b": "1"},
+		Args:           map[string]any{"x": 1, "y": 2, "nested": map[string]any{"p": "P", "q": "Q"}},
+	}
+	h1 := CanonicalActionHash(a)
+	h2 := CanonicalActionHash(b)
+	if h1 == "" || h1 != h2 {
+		t.Fatalf("hash mismatch under reorder: %q vs %q", h1, h2)
+	}
+	// Different verb => different hash.
+	c := *a
+	c.Verb = config.ActionVerbTruncate
+	if CanonicalActionHash(&c) == h1 {
+		t.Fatalf("hash collided across verbs")
+	}
+	// Different target id => different hash.
+	d := *a
+	tr := *a.TargetResource
+	tr.ID = "u2"
+	d.TargetResource = &tr
+	if CanonicalActionHash(&d) == h1 {
+		t.Fatalf("hash collided across resource ids")
+	}
+	// Nil descriptor returns "".
+	if CanonicalActionHash(nil) != "" {
+		t.Fatalf("nil descriptor must hash to empty")
+	}
+}

--- a/core/policy/actiongates/pipeline.go
+++ b/core/policy/actiongates/pipeline.go
@@ -1,0 +1,104 @@
+package actiongates
+
+import (
+	"context"
+
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// Pipeline runs the action-layer gates in fixed evaluation order:
+// tenant → file → url → mcp → mutation → provenance. The ordering is
+// deliberate:
+//
+//   - tenant first: cross-tenant denials short-circuit everything; we don't
+//     want a target_path check leaking that resource exists in another tenant.
+//   - file / url: enforce egress + filesystem invariants before tool-/MCP-
+//     specific logic that might rely on them.
+//   - mcp: validate tool/server/resource scope before evaluating mutations
+//     so a non-allowlisted MCP server is rejected without revealing approval
+//     state for its tools.
+//   - mutation: approval+self-approval+expiry+consumption checks.
+//   - provenance: chain-evidence verification — last because it depends on
+//     the approval record the mutation gate already validated.
+//
+// A gate may return a zero decision (Decision == UNSPECIFIED) to signal
+// "does not apply to this input"; the pipeline simply continues. An
+// ALLOW or ALLOW_WITH_CONSTRAINTS lets subsequent gates run because
+// each gate enforces a different invariant. Any other decision
+// (DENY / REQUIRE_HUMAN / THROTTLE) short-circuits.
+type Pipeline struct {
+	gates []ActionGate
+}
+
+// NewPipeline returns a pipeline with the supplied gates in evaluation
+// order. nil gates are filtered out so deployments can omit a gate
+// (e.g. provenance gate when an approval store is not yet wired) by
+// passing nil rather than wrapping the option struct in conditional
+// build logic.
+func NewPipeline(gates ...ActionGate) *Pipeline {
+	if len(gates) == 0 {
+		return &Pipeline{}
+	}
+	out := make([]ActionGate, 0, len(gates))
+	for _, g := range gates {
+		if g == nil {
+			continue
+		}
+		out = append(out, g)
+	}
+	return &Pipeline{gates: out}
+}
+
+// Gates returns a shallow copy of the registered gates in evaluation
+// order. Exposed for observability (admin endpoints, tests) — never
+// mutate the returned slice.
+func (p *Pipeline) Gates() []ActionGate {
+	if p == nil || len(p.gates) == 0 {
+		return nil
+	}
+	out := make([]ActionGate, len(p.gates))
+	copy(out, p.gates)
+	return out
+}
+
+// Run evaluates each gate in order. It returns (decision, true) on the
+// first non-allow decision and short-circuits the remaining gates.
+// A nil pipeline / nil input / Action-less input returns the zero
+// decision with fired=false so callers can fall through to legacy
+// rule evaluation without an action-layer ambiguity.
+func (p *Pipeline) Run(ctx context.Context, in *config.PolicyInput) (ActionGateDecision, bool) {
+	if p == nil || len(p.gates) == 0 {
+		return ActionGateDecision{}, false
+	}
+	if in == nil || in.Action == nil {
+		return ActionGateDecision{}, false
+	}
+	for _, g := range p.gates {
+		select {
+		case <-ctx.Done():
+			return ActionGateDecision{
+				Decision:  pb.DecisionType_DECISION_TYPE_DENY,
+				GateID:    g.ID(),
+				Code:      CodeInternalError,
+				Reason:    "context canceled before pipeline completed",
+				SubReason: "context_canceled",
+				Extra:     map[string]string{"gate": g.ID(), "sub_reason": "context_canceled"},
+			}, true
+		default:
+		}
+		dec := g.Evaluate(ctx, in)
+		if !dec.Fired() {
+			continue
+		}
+		if dec.Allowed() {
+			// ALLOW / ALLOW_WITH_CONSTRAINTS lets subsequent gates run.
+			// Each gate enforces a different invariant and a downstream
+			// gate may still produce a non-allow decision for the same
+			// input.
+			continue
+		}
+		return dec, true
+	}
+	return ActionGateDecision{}, false
+}

--- a/core/policy/actiongates/pipeline.go
+++ b/core/policy/actiongates/pipeline.go
@@ -2,6 +2,7 @@ package actiongates
 
 import (
 	"context"
+	"maps"
 
 	"github.com/cordum/cordum/core/infra/config"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
@@ -67,6 +68,16 @@ func (p *Pipeline) Gates() []ActionGate {
 // A nil pipeline / nil input / Action-less input returns the zero
 // decision with fired=false so callers can fall through to legacy
 // rule evaluation without an action-layer ambiguity.
+//
+// When every fired gate ALLOWs (DECISION_TYPE_ALLOW or
+// DECISION_TYPE_ALLOW_WITH_CONSTRAINTS) the pipeline returns
+// (mergedExtra, false): fired stays false so the existing "no blocking
+// decision" caller contract is preserved, and the returned decision
+// keeps Decision == UNSPECIFIED (Fired() reports false). The Extra map
+// carries the merged breadcrumbs from every firing gate (mutation
+// gate's `single_use=true`, provenance gate's `provenance_verified=true`,
+// etc.) so audit/observability paths can read constraint signals
+// without losing data when a later gate overwrites an earlier one.
 func (p *Pipeline) Run(ctx context.Context, in *config.PolicyInput) (ActionGateDecision, bool) {
 	if p == nil || len(p.gates) == 0 {
 		return ActionGateDecision{}, false
@@ -74,6 +85,7 @@ func (p *Pipeline) Run(ctx context.Context, in *config.PolicyInput) (ActionGateD
 	if in == nil || in.Action == nil {
 		return ActionGateDecision{}, false
 	}
+	var mergedExtra map[string]string
 	for _, g := range p.gates {
 		select {
 		case <-ctx.Done():
@@ -92,13 +104,15 @@ func (p *Pipeline) Run(ctx context.Context, in *config.PolicyInput) (ActionGateD
 			continue
 		}
 		if dec.Allowed() {
-			// ALLOW / ALLOW_WITH_CONSTRAINTS lets subsequent gates run.
-			// Each gate enforces a different invariant and a downstream
-			// gate may still produce a non-allow decision for the same
-			// input.
+			if len(dec.Extra) > 0 {
+				if mergedExtra == nil {
+					mergedExtra = make(map[string]string, len(dec.Extra))
+				}
+				maps.Copy(mergedExtra, dec.Extra)
+			}
 			continue
 		}
 		return dec, true
 	}
-	return ActionGateDecision{}, false
+	return ActionGateDecision{Extra: mergedExtra}, false
 }

--- a/core/policy/actiongates/pipeline_test.go
+++ b/core/policy/actiongates/pipeline_test.go
@@ -1,0 +1,263 @@
+package actiongates
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/mcp"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+func approvalTimeAgo() *time.Time {
+	t := time.Now().UTC().Add(-1 * time.Hour)
+	return &t
+}
+
+// pipelineFixture returns the full production gate ordering wired against
+// in-memory fakes. The mutation + provenance gates share the same approval
+// store so behavior matches the real wiring.
+type pipelineFixture struct {
+	pipeline  *Pipeline
+	approvals *fakeApprovalLookup
+	resources *fakeResourceLookup
+	identity  *fakeMCPIdentityResolver
+	reach     *fakeReachability
+	chain     *fakeChainVerifier
+}
+
+func newPipelineFixture(opts ...func(*pipelineFixture)) *pipelineFixture {
+	f := &pipelineFixture{
+		approvals: &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{}},
+		resources: &fakeResourceLookup{},
+		identity:  &fakeMCPIdentityResolver{by: map[string]*mcp.AgentIdentity{}},
+		reach:     &fakeReachability{},
+		chain:     &fakeChainVerifier{outcome: ChainVerifyOutcome{Status: ChainStatusOK}},
+	}
+	for _, o := range opts {
+		o(f)
+	}
+	f.pipeline = NewPipeline(
+		NewTenantGate(),
+		NewFileGate(),
+		NewURLGate(URLGateOptions{}),
+		NewMCPGate(MCPGateOptions{Identities: f.identity, Reachability: f.reach}),
+		NewMutationGate(MutationGateOptions{Approvals: f.approvals, Resources: f.resources}),
+		NewProvenanceGate(ProvenanceGateOptions{Approvals: f.approvals, ChainVerifier: f.chain}),
+	)
+	return f
+}
+
+func pipelineAuthCtx() context.Context {
+	return ctxWithAuth(&auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"})
+}
+
+func pipelineDeleteAction() *config.ActionDescriptor {
+	return &config.ActionDescriptor{
+		Kind:           config.ActionKindMutation,
+		Verb:           config.ActionVerbDelete,
+		TargetResource: &config.ActionTargetResource{Type: "user", ID: "user_42", OwnerTenant: "tnt_a"},
+	}
+}
+
+// DoD-7 shape #1: allowed — valid backed approval, all gates clear, no fire.
+func TestPipeline_AllowedShape(t *testing.T) {
+	t.Parallel()
+	act := pipelineDeleteAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_ok"}
+	hash := CanonicalActionHash(act)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_ok",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+	}
+	f := newPipelineFixture(func(f *pipelineFixture) {
+		f.approvals.records["tnt_a:"+hash] = approval
+	})
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	// Mutation gate may emit ALLOW_WITH_CONSTRAINTS but pipeline considers
+	// that an "allow" — fired must be false (no blocking decision).
+	if fired || dec.Fired() {
+		t.Fatalf("expected pipeline to clear; got fired=%v dec=%v sub=%q", fired, dec.Decision, dec.SubReason)
+	}
+}
+
+// DoD-7 shape #2: denied — cross-tenant DENY short-circuits the entire pipeline.
+func TestPipeline_DeniedShape(t *testing.T) {
+	t.Parallel()
+	act := &config.ActionDescriptor{
+		Kind:           config.ActionKindMutation,
+		Verb:           config.ActionVerbDelete,
+		TargetResource: &config.ActionTargetResource{Type: "user", ID: "user_42", OwnerTenant: "tnt_b"},
+	}
+	f := newPipelineFixture()
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if !fired || dec.Decision != pb.DecisionType_DECISION_TYPE_DENY {
+		t.Fatalf("expected DENY, got fired=%v dec=%v", fired, dec.Decision)
+	}
+	if dec.GateID != GateIDTenant || !strings.Contains(dec.SubReason, "cross_tenant") {
+		t.Fatalf("expected tenant cross_tenant denial, got gate=%q sub=%q", dec.GateID, dec.SubReason)
+	}
+}
+
+// DoD-7 shape #3: require-human — destructive verb with no claim, mutation
+// gate raises REQUIRE_HUMAN (provenance gate would too but mutation fires first).
+func TestPipeline_RequireHumanShape(t *testing.T) {
+	t.Parallel()
+	act := pipelineDeleteAction()
+	f := newPipelineFixture()
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if !fired || dec.Decision != pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+		t.Fatalf("expected REQUIRE_HUMAN, got fired=%v dec=%v", fired, dec.Decision)
+	}
+}
+
+// DoD-7 shape #4: tenant isolation — prefixed-ID encodes a different tenant.
+func TestPipeline_TenantIsolationShape(t *testing.T) {
+	t.Parallel()
+	act := &config.ActionDescriptor{
+		Kind:           config.ActionKindMutation,
+		Verb:           config.ActionVerbWrite,
+		TargetResource: &config.ActionTargetResource{Type: "doc", ID: "tnt_b_doc_99"},
+	}
+	f := newPipelineFixture()
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if !fired || dec.GateID != GateIDTenant {
+		t.Fatalf("expected tenant gate denial, got fired=%v gate=%q", fired, dec.GateID)
+	}
+	if !strings.Contains(dec.SubReason, "prefixed_id_mismatch") {
+		t.Fatalf("expected prefixed_id_mismatch sub_reason, got %q", dec.SubReason)
+	}
+}
+
+// DoD-7 shape #5: stale/conflict — approval already consumed.
+func TestPipeline_StaleConflictShape(t *testing.T) {
+	t.Parallel()
+	act := pipelineDeleteAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_old"}
+	hash := CanonicalActionHash(act)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_old",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+		ConsumedAt:  approvalTimeAgo(),
+	}
+	f := newPipelineFixture(func(f *pipelineFixture) {
+		f.approvals.records["tnt_a:"+hash] = approval
+	})
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if !fired || dec.Code != CodeConflict {
+		t.Fatalf("expected conflict, got fired=%v code=%q", fired, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "consumed") {
+		t.Fatalf("expected consumed sub_reason, got %q", dec.SubReason)
+	}
+}
+
+// DoD-7 shape #6: unavailable backend — approval store returns an error.
+func TestPipeline_UnavailableBackendShape(t *testing.T) {
+	t.Parallel()
+	act := pipelineDeleteAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_x"}
+	f := newPipelineFixture(func(f *pipelineFixture) {
+		f.approvals.err = errors.New("redis down")
+	})
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if !fired || dec.Code != CodeInternalError {
+		t.Fatalf("expected internal_error fail-closed, got fired=%v code=%q", fired, dec.Code)
+	}
+}
+
+// DoD-7 shape #7: audit evidence — provenance gate fires after mutation
+// allows, when the chain verifier reports an evidence gap.
+func TestPipeline_AuditEvidenceShape(t *testing.T) {
+	t.Parallel()
+	act := pipelineDeleteAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_gap"}
+	hash := CanonicalActionHash(act)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_gap",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+	}
+	f := newPipelineFixture(func(f *pipelineFixture) {
+		f.approvals.records["tnt_a:"+hash] = approval
+		f.chain.outcome = ChainVerifyOutcome{Status: ChainStatusOK, HasEvidenceGap: true}
+	})
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if !fired || dec.GateID != GateIDProvenance {
+		t.Fatalf("expected provenance gate fire, got fired=%v gate=%q", fired, dec.GateID)
+	}
+	if !strings.Contains(dec.SubReason, "audit_evidence_missing") {
+		t.Fatalf("expected audit_evidence_missing, got %q", dec.SubReason)
+	}
+}
+
+func TestPipeline_NilPipelineReturnsZero(t *testing.T) {
+	t.Parallel()
+	var p *Pipeline
+	dec, fired := p.Run(pipelineAuthCtx(), &config.PolicyInput{Action: pipelineDeleteAction()})
+	if fired || dec.Fired() {
+		t.Fatalf("nil pipeline: expected zero/false, got fired=%v dec=%v", fired, dec.Decision)
+	}
+}
+
+func TestPipeline_NilActionShortCircuits(t *testing.T) {
+	t.Parallel()
+	f := newPipelineFixture()
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a"})
+	if fired || dec.Fired() {
+		t.Fatalf("nil action: expected zero/false, got fired=%v dec=%v", fired, dec.Decision)
+	}
+}
+
+func TestPipeline_CanceledContextFailsClosed(t *testing.T) {
+	t.Parallel()
+	f := newPipelineFixture()
+	ctx, cancel := context.WithCancel(pipelineAuthCtx())
+	cancel()
+	dec, fired := f.pipeline.Run(ctx, &config.PolicyInput{Tenant: "tnt_a", Action: pipelineDeleteAction()})
+	if !fired || dec.Code != CodeInternalError {
+		t.Fatalf("canceled ctx: expected internal_error fail-closed, got fired=%v code=%q", fired, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "context_canceled") {
+		t.Fatalf("expected context_canceled sub_reason, got %q", dec.SubReason)
+	}
+}
+
+func TestPipeline_GatesReturnsOrderedCopy(t *testing.T) {
+	t.Parallel()
+	f := newPipelineFixture()
+	gates := f.pipeline.Gates()
+	wantOrder := []string{GateIDTenant, GateIDFile, GateIDURL, GateIDMCP, GateIDMutation, GateIDProvenance}
+	if len(gates) != len(wantOrder) {
+		t.Fatalf("len = %d, want %d", len(gates), len(wantOrder))
+	}
+	for i, g := range gates {
+		if g.ID() != wantOrder[i] {
+			t.Fatalf("Gates()[%d] = %q, want %q", i, g.ID(), wantOrder[i])
+		}
+	}
+	// Mutating the returned slice must not affect the pipeline.
+	gates[0] = nil
+	if f.pipeline.Gates()[0].ID() != GateIDTenant {
+		t.Fatal("Gates() returned a shared slice; internal state was mutated")
+	}
+}

--- a/core/policy/actiongates/pipeline_test.go
+++ b/core/policy/actiongates/pipeline_test.go
@@ -242,6 +242,68 @@ func TestPipeline_CanceledContextFailsClosed(t *testing.T) {
 	}
 }
 
+// TestPipeline_AllowedExtraSurvivesPastLaterAllow asserts the QA-flagged
+// invariant: when an early gate emits ALLOW_WITH_CONSTRAINTS with breadcrumb
+// Extras (mutation gate's `single_use=true`) and a later gate also passes,
+// the merged Extra MUST survive on the returned decision even though
+// fired=false. Before the merge fix, the later gate's Allow simply
+// overwrote prior breadcrumbs by returning the zero decision.
+func TestPipeline_AllowedExtraSurvivesPastLaterAllow(t *testing.T) {
+	t.Parallel()
+	act := pipelineDeleteAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_ok"}
+	hash := CanonicalActionHash(act)
+	approval := &edge.EdgeApproval{
+		ApprovalRef: "appr_ok",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  hash,
+	}
+	f := newPipelineFixture(func(f *pipelineFixture) {
+		f.approvals.records["tnt_a:"+hash] = approval
+	})
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if fired {
+		t.Fatalf("expected no terminal decision, got fired=%v", fired)
+	}
+	if dec.Fired() {
+		t.Fatalf("merged decision should report Fired()==false, got Decision=%v", dec.Decision)
+	}
+	if got := dec.Extra["single_use"]; got != "true" {
+		t.Fatalf("merged Extra lost mutation gate's single_use breadcrumb; got %q want %q", got, "true")
+	}
+}
+
+// TestPipeline_AllowedExtraEmptyOnPlainAllow verifies that when no gate
+// emits non-empty Extra on the allowed path, the returned Extra map is
+// nil — the merge accumulator is allocated lazily so plain ALLOWs do not
+// leak an empty map into the audit surface.
+func TestPipeline_AllowedExtraEmptyOnPlainAllow(t *testing.T) {
+	t.Parallel()
+	// Use a read action: no destructive verb, no approval lookup required;
+	// only tenant gate runs (and clears) without setting Extras.
+	act := &config.ActionDescriptor{
+		Kind: config.ActionKindMutation,
+		Verb: config.ActionVerbRead,
+		TargetResource: &config.ActionTargetResource{
+			Type:        "doc",
+			ID:          "doc_42",
+			OwnerTenant: "tnt_a",
+		},
+	}
+	f := newPipelineFixture()
+	dec, fired := f.pipeline.Run(pipelineAuthCtx(), &config.PolicyInput{Tenant: "tnt_a", Action: act})
+	if fired || dec.Fired() {
+		t.Fatalf("read action should pass cleanly, got fired=%v dec=%v", fired, dec.Decision)
+	}
+	if len(dec.Extra) != 0 {
+		t.Fatalf("plain allow should not leak Extra entries, got %v", dec.Extra)
+	}
+}
+
 func TestPipeline_GatesReturnsOrderedCopy(t *testing.T) {
 	t.Parallel()
 	f := newPipelineFixture()

--- a/core/policy/actiongates/provenance_gate.go
+++ b/core/policy/actiongates/provenance_gate.go
@@ -1,0 +1,244 @@
+package actiongates
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// RiskTagRequiresProvenance is the canonical risk-tag string that marks a
+// non-mutation action as requiring backend-verified provenance. Adding it
+// to ActionDescriptor.RiskTags from upstream classifiers brings an action
+// into the provenance gate's scope without it being a destructive verb.
+const RiskTagRequiresProvenance = "requires_provenance"
+
+// UnverifiedClaimReason is the exact Reason emitted when the gate rejects
+// an action carrying only ClaimText with no ApprovalRef. The wording is a
+// product / docs contract: it appears in audit logs and HTTP error
+// envelopes so red-team reports and DPO reviews can grep for it.
+const UnverifiedClaimReason = "approval claim text is not a substitute for a backend-verified approval record"
+
+// ChainStatus enumerates the high-level outcomes a chain verifier reports
+// for a single approval's audit slice. The values intentionally mirror
+// the labels used by core/audit.VerifyResult so a production wiring can
+// translate VerifyStatus values directly without an extra lookup table.
+type ChainStatus string
+
+const (
+	// ChainStatusOK means every event in the approval's window verified.
+	ChainStatusOK ChainStatus = "ok"
+	// ChainStatusPartial means the verifier could not attest the full
+	// window because retention trimmed older events. Not tampering.
+	ChainStatusPartial ChainStatus = "partial"
+	// ChainStatusCompromised means at least one event in the window failed
+	// hash, linkage, or HMAC verification. Hard fail-closed signal.
+	ChainStatusCompromised ChainStatus = "compromised"
+)
+
+// ChainVerifyOutcome is the verifier's structured answer about an
+// approval's audit slice. Status is mandatory; HasEvidenceGap means the
+// approval's own seq (or an immediately neighboring seq) is missing from
+// the chain — typically a tamper signal independent of Status.
+type ChainVerifyOutcome struct {
+	Status         ChainStatus
+	HasEvidenceGap bool
+	// Detail is optional free-form context (e.g. "first gap at seq=1234")
+	// surfaced into the gate's SubReason for audit. Never PII.
+	Detail string
+}
+
+// ChainVerifier resolves the audit-chain status that covers a given
+// approval. Production wires this to core/audit.VerifyChain bounded by
+// the approval's CreatedAt..max(ResolvedAt, ConsumedAt, now) window.
+// Implementations MUST be safe for concurrent use.
+type ChainVerifier interface {
+	VerifyForApproval(ctx context.Context, tenant string, approval *edge.EdgeApproval) (ChainVerifyOutcome, error)
+}
+
+// ProvenanceGateOptions configures the gate.
+type ProvenanceGateOptions struct {
+	Approvals     ApprovalLookup
+	ChainVerifier ChainVerifier
+}
+
+// ProvenanceGate is the explicit, deterministic refusal of "approved by
+// CFO"-style claims. It only fires when the action either is a destructive
+// mutation OR carries the requires_provenance risk tag. In scope:
+//
+//  1. ClaimText with empty ApprovalRef → DENY/access_denied/unverified_claim
+//     with the verbatim UnverifiedClaimReason.
+//  2. No claim at all → REQUIRE_HUMAN (system should issue an approval).
+//  3. ApprovalRef resolves to no record → DENY/not_found.
+//  4. Approval belongs to a different tenant → DENY/access_denied/approval_tenant_mismatch.
+//  5. Chain verification reports compromised → DENY/internal_error/audit_chain_compromised.
+//  6. Chain verifier reports an evidence gap → DENY/internal_error/audit_evidence_missing.
+//  7. Verifier error or nil verifier → DENY/internal_error fail-closed.
+//
+// The mutation gate is responsible for the surface validation of an
+// approval record (status/decision/expiry/consumption/hash). The
+// provenance gate concentrates on backend-verified evidence. Both run.
+type ProvenanceGate struct {
+	approvals     ApprovalLookup
+	chainVerifier ChainVerifier
+}
+
+// NewProvenanceGate returns a gate bound to opts.Approvals and
+// opts.ChainVerifier. Either being nil causes destructive actions to
+// fail closed with Code=internal_error — explicit refusal beats a
+// silent allow under mis-configuration.
+func NewProvenanceGate(opts ProvenanceGateOptions) *ProvenanceGate {
+	return &ProvenanceGate{approvals: opts.Approvals, chainVerifier: opts.ChainVerifier}
+}
+
+func (g *ProvenanceGate) ID() string { return GateIDProvenance }
+
+func (g *ProvenanceGate) Evaluate(ctx context.Context, in *config.PolicyInput) ActionGateDecision {
+	if in == nil || in.Action == nil {
+		return ActionGateDecision{}
+	}
+	act := in.Action
+	if !requiresProvenance(act) {
+		return ActionGateDecision{}
+	}
+
+	actx := auth.FromContext(ctx)
+	if actx == nil || strings.TrimSpace(actx.Tenant) == "" {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeUnauthorized,
+			"authentication required", "missing_auth")
+	}
+
+	// Claim text without a backend reference is the explicit "approved
+	// by CFO" rejection — the centerpiece of this gate.
+	hasClaimText := act.ApprovalClaim != nil && strings.TrimSpace(act.ApprovalClaim.ClaimText) != ""
+	hasApprovalRef := act.ApprovalClaim != nil && strings.TrimSpace(act.ApprovalClaim.ApprovalRef) != ""
+
+	if hasClaimText && !hasApprovalRef {
+		dec := provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			UnverifiedClaimReason, "unverified_claim")
+		// Length-bounded claim digest for audit; never echo the raw text
+		// (could be PII / abuse vector).
+		dec.Extra["claim_present"] = "true"
+		dec.Extra["claim_chars"] = sanitizeClaimLen(act.ApprovalClaim.ClaimText)
+		return dec
+	}
+
+	if !hasApprovalRef {
+		return provDecision(pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN, act, CodeRequireHuman,
+			"action requires backend-verified human approval", "missing_approval")
+	}
+
+	if g.approvals == nil {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"approval lookup unavailable", "approval_lookup_failed:nil_lookup")
+	}
+	approval, ok, err := g.approvals.LookupByActionHash(ctx, actx.Tenant, CanonicalActionHash(act))
+	if err != nil {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"approval lookup failed", "approval_lookup_failed:"+sanitizeErr(err))
+	}
+	if !ok || approval == nil {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeNotFound,
+			"no approval record for this action", "approval_not_found")
+	}
+	if approval.TenantID != actx.Tenant {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeAccessDenied,
+			"approval is for a different tenant", "approval_tenant_mismatch")
+	}
+
+	if g.chainVerifier == nil {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"audit chain verifier unavailable", "audit_chain_verifier_unavailable")
+	}
+	outcome, verr := g.chainVerifier.VerifyForApproval(ctx, actx.Tenant, approval)
+	if verr != nil {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"audit chain verification failed", "audit_chain_verify_failed:"+sanitizeErr(verr))
+	}
+	if outcome.Status == ChainStatusCompromised {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"audit chain reports tampering", "audit_chain_compromised:"+chainDetail(outcome))
+	}
+	if outcome.HasEvidenceGap {
+		return provDecision(pb.DecisionType_DECISION_TYPE_DENY, act, CodeInternalError,
+			"audit evidence for this approval is missing", "audit_evidence_missing:"+chainDetail(outcome))
+	}
+
+	// Status OK or Partial. Partial only means retention-trimmed prefix;
+	// for an in-window-only verifier this still counts as authenticated.
+	return ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_ALLOW,
+		GateID:    GateIDProvenance,
+		Reason:    "approval backed by verified audit chain",
+		SubReason: "provenance_ok:" + string(outcome.Status),
+		Extra:     provExtra(act, "provenance_ok"),
+	}
+}
+
+func requiresProvenance(act *config.ActionDescriptor) bool {
+	if act.Kind == config.ActionKindMutation && IsDestructiveVerb(act.Verb) {
+		return true
+	}
+	for _, tag := range act.RiskTags {
+		if strings.EqualFold(strings.TrimSpace(tag), RiskTagRequiresProvenance) {
+			return true
+		}
+	}
+	return false
+}
+
+func provDecision(decision pb.DecisionType, act *config.ActionDescriptor, code, reason, sub string) ActionGateDecision {
+	return ActionGateDecision{
+		Decision:  decision,
+		GateID:    GateIDProvenance,
+		Code:      code,
+		Reason:    reason,
+		SubReason: sub,
+		Extra:     provExtra(act, sub),
+	}
+}
+
+func provExtra(act *config.ActionDescriptor, sub string) map[string]string {
+	out := map[string]string{
+		"gate":       GateIDProvenance,
+		"sub_reason": sub,
+		"kind":       string(act.Kind),
+	}
+	if act.Verb != "" {
+		out["verb"] = string(act.Verb)
+	}
+	if act.TargetResource != nil && act.TargetResource.Type != "" {
+		out["target_type"] = act.TargetResource.Type
+	}
+	return out
+}
+
+func chainDetail(o ChainVerifyOutcome) string {
+	d := strings.TrimSpace(o.Detail)
+	if d == "" {
+		return string(o.Status)
+	}
+	return string(o.Status) + ":" + d
+}
+
+// sanitizeClaimLen returns a coarse length bucket for the raw claim text
+// so the SIEM record can show "the user did present a claim" without
+// echoing the content (PII / phishing vector).
+func sanitizeClaimLen(s string) string {
+	n := len(s)
+	switch {
+	case n == 0:
+		return "0"
+	case n <= 32:
+		return "<=32"
+	case n <= 128:
+		return "<=128"
+	case n <= 512:
+		return "<=512"
+	default:
+		return ">512"
+	}
+}

--- a/core/policy/actiongates/provenance_gate_test.go
+++ b/core/policy/actiongates/provenance_gate_test.go
@@ -1,0 +1,269 @@
+package actiongates
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// fakeChainVerifier scripts the chain-verify outcome for a single approval.
+type fakeChainVerifier struct {
+	outcome ChainVerifyOutcome
+	err     error
+}
+
+func (f *fakeChainVerifier) VerifyForApproval(_ context.Context, _ string, _ *edge.EdgeApproval) (ChainVerifyOutcome, error) {
+	return f.outcome, f.err
+}
+
+// chainOK is a verifier that always reports an intact chain.
+var chainOK = &fakeChainVerifier{outcome: ChainVerifyOutcome{Status: ChainStatusOK}}
+
+func provAuthCtx() context.Context {
+	return ctxWithAuth(&auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"})
+}
+
+func provMutationAction() *config.ActionDescriptor {
+	return &config.ActionDescriptor{
+		Kind:           config.ActionKindMutation,
+		Verb:           config.ActionVerbDelete,
+		TargetResource: &config.ActionTargetResource{Type: "user", ID: "user_42", OwnerTenant: "tnt_a"},
+	}
+}
+
+func provValidApproval(act *config.ActionDescriptor) *edge.EdgeApproval {
+	return &edge.EdgeApproval{
+		ApprovalRef: "appr_1",
+		TenantID:    "tnt_a",
+		PrincipalID: "p1",
+		ResolverID:  "p2",
+		Status:      edge.ApprovalStatusApproved,
+		Decision:    edge.ApprovalDecisionApprove,
+		ActionHash:  CanonicalActionHash(act),
+	}
+}
+
+func newProvenanceGateWith(approval *edge.EdgeApproval, verifier ChainVerifier, lookupErr error) *ProvenanceGate {
+	lookup := &fakeApprovalLookup{records: map[string]*edge.EdgeApproval{}, err: lookupErr}
+	if approval != nil {
+		lookup.records["tnt_a:"+approval.ActionHash] = approval
+	}
+	return NewProvenanceGate(ProvenanceGateOptions{Approvals: lookup, ChainVerifier: verifier})
+}
+
+func TestProvenanceGate_NoActionSkips(t *testing.T) {
+	t.Parallel()
+	gate := newProvenanceGateWith(nil, chainOK, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{})
+	if dec.Fired() {
+		t.Fatalf("no action: gate fired (decision=%v)", dec.Decision)
+	}
+}
+
+func TestProvenanceGate_NonScopeSkips(t *testing.T) {
+	t.Parallel()
+	gate := newProvenanceGateWith(nil, chainOK, nil)
+	// file kind without requires_provenance risk tag is out of scope.
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: &config.ActionDescriptor{
+		Kind: config.ActionKindFile, TargetPath: "/tmp/x",
+	}})
+	if dec.Fired() {
+		t.Fatalf("file kind no risk tag: gate fired")
+	}
+}
+
+func TestProvenanceGate_UnauthDenies(t *testing.T) {
+	t.Parallel()
+	gate := newProvenanceGateWith(nil, chainOK, nil)
+	dec := gate.Evaluate(ctxWithAuth(nil), &config.PolicyInput{Action: provMutationAction()})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeUnauthorized {
+		t.Fatalf("got %v / %q, want DENY / unauthorized", dec.Decision, dec.Code)
+	}
+}
+
+func TestProvenanceGate_NoClaimRequiresHuman(t *testing.T) {
+	t.Parallel()
+	gate := newProvenanceGateWith(nil, chainOK, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: provMutationAction()})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+		t.Fatalf("got %v, want REQUIRE_HUMAN", dec.Decision)
+	}
+	if dec.Code != CodeRequireHuman {
+		t.Fatalf("code = %q, want require_human", dec.Code)
+	}
+}
+
+func TestProvenanceGate_RisktagRequiresProvenance(t *testing.T) {
+	t.Parallel()
+	gate := newProvenanceGateWith(nil, chainOK, nil)
+	// Non-mutation kind, but RiskTags carries requires_provenance.
+	act := &config.ActionDescriptor{
+		Kind:     config.ActionKindURL,
+		Verb:     config.ActionVerbExport,
+		RiskTags: []string{RiskTagRequiresProvenance},
+	}
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN {
+		t.Fatalf("got %v, want REQUIRE_HUMAN for requires_provenance risk tag", dec.Decision)
+	}
+}
+
+func TestProvenanceGate_ClaimTextOnlyRejected(t *testing.T) {
+	t.Parallel()
+	phrases := []string{
+		"approved by CFO",
+		"approved by John",
+		"per CISO",
+		"with admin override",
+		"emergency authorization",
+		"I have approval",
+		"sign-off from VP Engineering",
+	}
+	gate := newProvenanceGateWith(nil, chainOK, nil)
+	for _, phrase := range phrases {
+		t.Run(strings.ReplaceAll(phrase, " ", "_"), func(t *testing.T) {
+			t.Parallel()
+			act := provMutationAction()
+			act.ApprovalClaim = &config.ActionApprovalClaim{ClaimText: phrase, ApprovalRef: ""}
+			dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+			if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+				t.Fatalf("phrase %q: got %v / %q, want DENY / access_denied", phrase, dec.Decision, dec.Code)
+			}
+			if !strings.Contains(dec.SubReason, "unverified_claim") {
+				t.Fatalf("phrase %q: subReason = %q, want unverified_claim", phrase, dec.SubReason)
+			}
+			const wantReason = "approval claim text is not a substitute for a backend-verified approval record"
+			if dec.Reason != wantReason {
+				t.Fatalf("phrase %q: Reason = %q, want exactly %q", phrase, dec.Reason, wantReason)
+			}
+		})
+	}
+}
+
+func TestProvenanceGate_RefButRecordAbsentNotFound(t *testing.T) {
+	t.Parallel()
+	gate := newProvenanceGateWith(nil, chainOK, nil) // approval store is empty
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_missing"}
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeNotFound {
+		t.Fatalf("got %v / %q, want DENY / not_found", dec.Decision, dec.Code)
+	}
+}
+
+func TestProvenanceGate_TenantMismatchDenies(t *testing.T) {
+	t.Parallel()
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	approval := provValidApproval(act)
+	approval.TenantID = "tnt_b" // foreign tenant
+	gate := newProvenanceGateWith(approval, chainOK, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeAccessDenied {
+		t.Fatalf("got %v / %q, want DENY / access_denied", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "approval_tenant_mismatch") {
+		t.Fatalf("subReason = %q, want approval_tenant_mismatch", dec.SubReason)
+	}
+}
+
+func TestProvenanceGate_ChainCompromisedFailsClosed(t *testing.T) {
+	t.Parallel()
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	approval := provValidApproval(act)
+	verifier := &fakeChainVerifier{outcome: ChainVerifyOutcome{Status: ChainStatusCompromised}}
+	gate := newProvenanceGateWith(approval, verifier, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeInternalError {
+		t.Fatalf("got %v / %q, want DENY / internal_error", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "audit_chain_compromised") {
+		t.Fatalf("subReason = %q, want audit_chain_compromised", dec.SubReason)
+	}
+}
+
+func TestProvenanceGate_EvidenceGapFailsClosed(t *testing.T) {
+	t.Parallel()
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	approval := provValidApproval(act)
+	verifier := &fakeChainVerifier{outcome: ChainVerifyOutcome{Status: ChainStatusOK, HasEvidenceGap: true}}
+	gate := newProvenanceGateWith(approval, verifier, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeInternalError {
+		t.Fatalf("got %v / %q, want DENY / internal_error on evidence gap", dec.Decision, dec.Code)
+	}
+	if !strings.Contains(dec.SubReason, "audit_evidence_missing") {
+		t.Fatalf("subReason = %q, want audit_evidence_missing", dec.SubReason)
+	}
+}
+
+func TestProvenanceGate_ChainVerifierErrFailsClosed(t *testing.T) {
+	t.Parallel()
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	approval := provValidApproval(act)
+	verifier := &fakeChainVerifier{err: errors.New("redis unavailable")}
+	gate := newProvenanceGateWith(approval, verifier, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeInternalError {
+		t.Fatalf("got %v / %q, want DENY / internal_error", dec.Decision, dec.Code)
+	}
+}
+
+func TestProvenanceGate_LookupErrFailsClosed(t *testing.T) {
+	t.Parallel()
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	gate := newProvenanceGateWith(nil, chainOK, errors.New("approval store down"))
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeInternalError {
+		t.Fatalf("got %v / %q, want DENY / internal_error", dec.Decision, dec.Code)
+	}
+}
+
+func TestProvenanceGate_ValidApprovalCleanChainAllows(t *testing.T) {
+	t.Parallel()
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	approval := provValidApproval(act)
+	gate := newProvenanceGateWith(approval, chainOK, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_ALLOW {
+		t.Fatalf("got %v, want ALLOW for valid + clean chain", dec.Decision)
+	}
+}
+
+func TestProvenanceGate_PartialChainStillAllows(t *testing.T) {
+	t.Parallel()
+	// Partial = retention-trimmed prefix, not tampering. Should ALLOW.
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	approval := provValidApproval(act)
+	verifier := &fakeChainVerifier{outcome: ChainVerifyOutcome{Status: ChainStatusPartial}}
+	gate := newProvenanceGateWith(approval, verifier, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_ALLOW {
+		t.Fatalf("got %v, want ALLOW for partial chain (retention trim)", dec.Decision)
+	}
+}
+
+func TestProvenanceGate_NilVerifierFailsClosed(t *testing.T) {
+	t.Parallel()
+	// A misconfigured deployment (no chain verifier) MUST NOT silently allow.
+	act := provMutationAction()
+	act.ApprovalClaim = &config.ActionApprovalClaim{ApprovalRef: "appr_1"}
+	approval := provValidApproval(act)
+	gate := newProvenanceGateWith(approval, nil, nil)
+	dec := gate.Evaluate(provAuthCtx(), &config.PolicyInput{Action: act})
+	if dec.Decision != pb.DecisionType_DECISION_TYPE_DENY || dec.Code != CodeInternalError {
+		t.Fatalf("got %v / %q, want DENY / internal_error (nil verifier)", dec.Decision, dec.Code)
+	}
+}

--- a/core/policy/actiongates/tenant_gate.go
+++ b/core/policy/actiongates/tenant_gate.go
@@ -1,0 +1,222 @@
+package actiongates
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// TenantGate enforces multi-tenant isolation invariants on tenant_query and
+// mutation actions. Tenant identity is sourced exclusively from
+// AuthContext.Tenant; ActionDescriptor.TargetResource.OwnerTenant and any
+// body-claimed tenant are inputs to compare against, not authoritative.
+//
+// The gate fires for ActionKindTenantQuery and ActionKindMutation actions.
+// For other kinds (file/url/mcp/provenance) it returns the zero decision so
+// the pipeline continues.
+type TenantGate struct{}
+
+// NewTenantGate returns a fresh, stateless TenantGate.
+func NewTenantGate() *TenantGate { return &TenantGate{} }
+
+func (g *TenantGate) ID() string { return GateIDTenant }
+
+// Match tnt_<key>_<rest> in resource IDs.
+var tenantPrefixRe = regexp.MustCompile(`^(tnt_[A-Za-z0-9-]+)_`)
+
+// largeEnumPageSize is the threshold above which a single page_size triggers
+// REQUIRE_HUMAN. Sites that legitimately page very wide raise this via per-
+// tenant config; this default protects naive scans.
+const largeEnumPageSize = 10000
+
+// largeEnumInClauseSize is the threshold for an IN-clause size that triggers
+// REQUIRE_HUMAN. Below this we trust legit pagination patterns.
+const largeEnumInClauseSize = 1000
+
+func (g *TenantGate) Evaluate(ctx context.Context, in *config.PolicyInput) ActionGateDecision {
+	if in == nil || in.Action == nil {
+		return ActionGateDecision{}
+	}
+	act := in.Action
+	if act.Kind != config.ActionKindTenantQuery && act.Kind != config.ActionKindMutation {
+		return ActionGateDecision{}
+	}
+
+	actx := auth.FromContext(ctx)
+	if actx == nil || strings.TrimSpace(actx.Tenant) == "" {
+		return ActionGateDecision{
+			Decision:  pb.DecisionType_DECISION_TYPE_DENY,
+			GateID:    GateIDTenant,
+			Code:      CodeUnauthorized,
+			Reason:    "authentication required",
+			SubReason: "missing_auth",
+			Extra:     map[string]string{"gate": GateIDTenant, "sub_reason": "missing_auth"},
+		}
+	}
+
+	authTenant := actx.Tenant
+	isComplianceOrLegal := roleHasCompliance(actx.Role)
+
+	// 1) Cross-tenant via TargetResource (OwnerTenant set).
+	if act.TargetResource != nil && act.TargetResource.OwnerTenant != "" {
+		if act.TargetResource.OwnerTenant != authTenant && !actx.AllowCrossTenant {
+			return denyTenant(authTenant, "tenant boundary violation",
+				"cross_tenant:owner_mismatch",
+				map[string]string{
+					"resource_type": act.TargetResource.Type,
+					"auth_tenant":   authTenant,
+				})
+		}
+	}
+
+	// 2) Tenant-prefixed-ID mismatch (resource ID encodes a different tenant).
+	if act.TargetResource != nil && act.TargetResource.ID != "" {
+		if m := tenantPrefixRe.FindStringSubmatch(act.TargetResource.ID); len(m) == 2 {
+			if m[1] != authTenant && !actx.AllowCrossTenant {
+				return denyTenant(authTenant, "tenant boundary violation",
+					"cross_tenant:prefixed_id_mismatch",
+					map[string]string{
+						"resource_type":   act.TargetResource.Type,
+						"detected_prefix": m[1],
+					})
+			}
+		}
+	}
+
+	// 3) Wildcard owner/tenant filters.
+	if reason, ok := matchWildcardOwnerFilter(act.Filters, act.Wildcards); ok && !actx.AllowCrossTenant {
+		return denyTenant(authTenant, "tenant boundary violation", reason, nil)
+	}
+
+	// 4) Archived/deleted bypass — unless compliance/legal role on own tenant.
+	if reason, ok := matchArchivedBypass(act.Filters); ok && !isComplianceOrLegal {
+		return denyTenant(authTenant, "archived record query denied", reason, nil)
+	}
+
+	// 5) Anti-enumeration (very large page_size or in-clause).
+	if reason, ok := matchLargeEnumeration(act.Args); ok {
+		return ActionGateDecision{
+			Decision:  pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN,
+			GateID:    GateIDTenant,
+			Code:      CodeRequireHuman,
+			Reason:    "large enumeration requires human approval",
+			SubReason: reason,
+			Extra: map[string]string{
+				"gate":        GateIDTenant,
+				"sub_reason":  reason,
+				"auth_tenant": authTenant,
+			},
+		}
+	}
+
+	return ActionGateDecision{Decision: pb.DecisionType_DECISION_TYPE_ALLOW, GateID: GateIDTenant}
+}
+
+func denyTenant(authTenant, reason, subReason string, extra map[string]string) ActionGateDecision {
+	out := map[string]string{
+		"gate":        GateIDTenant,
+		"sub_reason":  subReason,
+		"auth_tenant": authTenant,
+	}
+	for k, v := range extra {
+		out[k] = v
+	}
+	return ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_DENY,
+		GateID:    GateIDTenant,
+		Code:      CodeAccessDenied,
+		Reason:    reason,
+		SubReason: subReason,
+		Extra:     out,
+	}
+}
+
+func roleHasCompliance(role string) bool {
+	r := strings.ToLower(role)
+	return strings.Contains(r, "compliance") || strings.Contains(r, "legal")
+}
+
+func matchWildcardOwnerFilter(filters map[string]string, wildcards []string) (string, bool) {
+	wildcardKeys := []string{"owner_id", "tenant_id", "tenant", "owner", "account_id", "org_id"}
+	for _, k := range wildcardKeys {
+		if v, ok := filters[k]; ok && (v == "*" || v == "%" || strings.Contains(v, "%")) {
+			return "wildcard_owner:" + k, true
+		}
+	}
+	for _, k := range wildcards {
+		for _, w := range wildcardKeys {
+			if strings.EqualFold(k, w) {
+				return "wildcard_owner:" + k, true
+			}
+		}
+	}
+	// Raw SQL-injected predicates.
+	if raw, ok := filters["raw_where"]; ok {
+		lower := strings.ToLower(strings.ReplaceAll(raw, " ", ""))
+		if strings.Contains(lower, "1=1") || strings.Contains(lower, "or1=1") || strings.Contains(lower, "true=true") {
+			return "wildcard_owner:raw_where", true
+		}
+	}
+	return "", false
+}
+
+func matchArchivedBypass(filters map[string]string) (string, bool) {
+	if v, ok := filters["include_archived"]; ok && (strings.EqualFold(v, "true") || v == "1") {
+		return "archived_bypass:include_archived", true
+	}
+	if v, ok := filters["deleted_at"]; ok {
+		lv := strings.ToLower(strings.TrimSpace(v))
+		if lv == "any" || lv == "*" || lv == "" {
+			return "archived_bypass:deleted_at_any", true
+		}
+		if strings.Contains(lv, "is null") && strings.Contains(lv, "is not null") {
+			return "archived_bypass:contradictory", true
+		}
+	}
+	if v, ok := filters["status"]; ok && strings.EqualFold(strings.TrimSpace(v), "any") {
+		return "archived_bypass:status_any", true
+	}
+	return "", false
+}
+
+func matchLargeEnumeration(args map[string]any) (string, bool) {
+	if n, ok := readInt(args, "page_size"); ok && n > largeEnumPageSize {
+		return "large_enumeration:page_size", true
+	}
+	if n, ok := readInt(args, "limit"); ok && n > largeEnumPageSize {
+		return "large_enumeration:limit", true
+	}
+	if n, ok := readInt(args, "in_clause_size"); ok && n > largeEnumInClauseSize {
+		return "large_enumeration:in_clause", true
+	}
+	return "", false
+}
+
+func readInt(args map[string]any, key string) (int, bool) {
+	v, ok := args[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float32:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case string:
+		if i, err := strconv.Atoi(strings.TrimSpace(n)); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/core/policy/actiongates/tenant_gate_test.go
+++ b/core/policy/actiongates/tenant_gate_test.go
@@ -1,0 +1,335 @@
+package actiongates
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+func ctxWithAuth(actx *auth.AuthContext) context.Context {
+	return context.WithValue(context.Background(), auth.ContextKey{}, actx)
+}
+
+type tenantGateCase struct {
+	name         string
+	actx         *auth.AuthContext
+	action       *config.ActionDescriptor
+	wantDecision pb.DecisionType
+	wantCode     string
+	subReasonHas string
+}
+
+func runTenantGate(t *testing.T, tc tenantGateCase) {
+	t.Helper()
+	gate := NewTenantGate()
+	in := &config.PolicyInput{Action: tc.action}
+	if tc.actx != nil {
+		in.Tenant = tc.actx.Tenant
+	}
+	ctx := ctxWithAuth(tc.actx)
+	dec := gate.Evaluate(ctx, in)
+	if dec.Decision != tc.wantDecision {
+		t.Fatalf("decision = %v, want %v (reason=%q subReason=%q)", dec.Decision, tc.wantDecision, dec.Reason, dec.SubReason)
+	}
+	if tc.wantCode != "" && dec.Code != tc.wantCode {
+		t.Fatalf("code = %q, want %q", dec.Code, tc.wantCode)
+	}
+	if tc.subReasonHas != "" && !strings.Contains(dec.SubReason, tc.subReasonHas) {
+		t.Fatalf("subReason = %q, want substring %q", dec.SubReason, tc.subReasonHas)
+	}
+}
+
+func TestTenantGate_SkipsWhenNoAction(t *testing.T) {
+	t.Parallel()
+	gate := NewTenantGate()
+	// No action -> zero decision (pipeline continues).
+	dec := gate.Evaluate(ctxWithAuth(&auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1"}),
+		&config.PolicyInput{Tenant: "tnt_a"})
+	if dec.Fired() {
+		t.Fatalf("no action: gate fired (Decision=%v)", dec.Decision)
+	}
+}
+
+func TestTenantGate_UnauthDenies(t *testing.T) {
+	t.Parallel()
+	// Missing AuthContext on any actioned request -> 401 unauthorized.
+	runTenantGate(t, tenantGateCase{
+		name:         "no_authcontext",
+		actx:         nil,
+		action:       &config.ActionDescriptor{Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead},
+		wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+		wantCode:     CodeUnauthorized,
+		subReasonHas: "missing_auth",
+	})
+	// Auth present but Tenant empty (mis-configured RBAC) -> 401.
+	runTenantGate(t, tenantGateCase{
+		name:         "empty_tenant",
+		actx:         &auth.AuthContext{PrincipalID: "p1"},
+		action:       &config.ActionDescriptor{Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead},
+		wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+		wantCode:     CodeUnauthorized,
+		subReasonHas: "missing_auth",
+	})
+}
+
+func TestTenantGate_CrossTenantDenies(t *testing.T) {
+	t.Parallel()
+	// auth=A, target.OwnerTenant=B -> DENY.
+	runTenantGate(t, tenantGateCase{
+		name: "owner_tenant_mismatch",
+		actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+		action: &config.ActionDescriptor{
+			Kind: config.ActionKindMutation, Verb: config.ActionVerbWrite,
+			TargetResource: &config.ActionTargetResource{Type: "user", ID: "user_42", OwnerTenant: "tnt_b"},
+		},
+		wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+		wantCode:     CodeAccessDenied,
+		subReasonHas: "cross_tenant",
+	})
+	// Tenant-prefixed ID mismatch (auth=tnt_a but id=tnt_b_user_42).
+	runTenantGate(t, tenantGateCase{
+		name: "prefixed_id_mismatch",
+		actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+		action: &config.ActionDescriptor{
+			Kind: config.ActionKindMutation, Verb: config.ActionVerbWrite,
+			TargetResource: &config.ActionTargetResource{Type: "user", ID: "tnt_b_user_42"},
+		},
+		wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+		wantCode:     CodeAccessDenied,
+		subReasonHas: "cross_tenant",
+	})
+	// SuperAdmin bypass (AllowCrossTenant=true) -> ALLOW.
+	runTenantGate(t, tenantGateCase{
+		name: "superadmin_cross_tenant_allowed",
+		actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "superadmin", AllowCrossTenant: true},
+		action: &config.ActionDescriptor{
+			Kind: config.ActionKindMutation, Verb: config.ActionVerbWrite,
+			TargetResource: &config.ActionTargetResource{Type: "user", ID: "user_42", OwnerTenant: "tnt_b"},
+		},
+		wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+	})
+}
+
+func TestTenantGate_WildcardOwnerFiltersDeny(t *testing.T) {
+	t.Parallel()
+	cases := []tenantGateCase{
+		{
+			name: "owner_id_star_in_filters",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"owner_id": "*"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+			wantCode:     CodeAccessDenied,
+			subReasonHas: "wildcard_owner",
+		},
+		{
+			name: "tenant_id_star_in_filters",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"tenant_id": "*"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+			wantCode:     CodeAccessDenied,
+			subReasonHas: "wildcard_owner",
+		},
+		{
+			name: "wildcards_owner_listed",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Wildcards: []string{"owner_id"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+			wantCode:     CodeAccessDenied,
+			subReasonHas: "wildcard_owner",
+		},
+		{
+			name: "where_1_eq_1_filter",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"raw_where": "1=1"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+			wantCode:     CodeAccessDenied,
+			subReasonHas: "raw_where",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runTenantGate(t, tc) })
+	}
+}
+
+func TestTenantGate_ArchivedRecordBypass(t *testing.T) {
+	t.Parallel()
+	cases := []tenantGateCase{
+		{
+			name: "include_archived_true_normal_user",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"include_archived": "true"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+			wantCode:     CodeAccessDenied,
+			subReasonHas: "archived_bypass",
+		},
+		{
+			name: "deleted_at_any",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"deleted_at": "any"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+			wantCode:     CodeAccessDenied,
+			subReasonHas: "archived_bypass",
+		},
+		{
+			name: "contradictory_deleted_at",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"deleted_at": "IS NULL OR IS NOT NULL"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+			wantCode:     CodeAccessDenied,
+			subReasonHas: "archived_bypass",
+		},
+		{
+			name: "compliance_role_can_query_archived",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "compliance_admin"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"include_archived": "true"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		},
+		{
+			name: "legal_role_can_query_archived",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "legal_hold"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"deleted_at": "any"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runTenantGate(t, tc) })
+	}
+}
+
+func TestTenantGate_AntiEnumerationRequireHuman(t *testing.T) {
+	t.Parallel()
+	cases := []tenantGateCase{
+		{
+			name: "page_size_too_large",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Args: map[string]any{"page_size": 50000},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN,
+			wantCode:     CodeRequireHuman,
+			subReasonHas: "large_enumeration",
+		},
+		{
+			name: "in_clause_too_large",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Args: map[string]any{"in_clause_size": 5000},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN,
+			wantCode:     CodeRequireHuman,
+			subReasonHas: "large_enumeration",
+		},
+		{
+			name: "normal_page_size_allowed",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Args: map[string]any{"page_size": 50},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		},
+		{
+			name: "page_size_as_string",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Args: map[string]any{"page_size": "50000"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN,
+			wantCode:     CodeRequireHuman,
+			subReasonHas: "large_enumeration",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runTenantGate(t, tc) })
+	}
+}
+
+func TestTenantGate_AllowsSameTenantAndPaginatedQueries(t *testing.T) {
+	t.Parallel()
+	cases := []tenantGateCase{
+		{
+			name: "same_tenant_mutation",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindMutation, Verb: config.ActionVerbWrite,
+				TargetResource: &config.ActionTargetResource{Type: "user", ID: "user_42", OwnerTenant: "tnt_a"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		},
+		{
+			name: "paginated_list_default",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Args: map[string]any{"page_size": 50, "page": 1},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		},
+		{
+			name: "prefixed_id_match_passes",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindMutation, Verb: config.ActionVerbWrite,
+				TargetResource: &config.ActionTargetResource{Type: "user", ID: "tnt_a_user_42"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		},
+		{
+			name: "sequential_ids_legit_pagination",
+			actx: &auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1", Role: "user"},
+			action: &config.ActionDescriptor{
+				Kind: config.ActionKindTenantQuery, Verb: config.ActionVerbRead,
+				Filters: map[string]string{"order_by": "id", "limit": "50"},
+			},
+			wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runTenantGate(t, tc) })
+	}
+}
+
+func TestTenantGate_FileKindSkips(t *testing.T) {
+	t.Parallel()
+	// File / URL / MCP kinds are not the tenant gate's domain; it should skip.
+	gate := NewTenantGate()
+	dec := gate.Evaluate(ctxWithAuth(&auth.AuthContext{Tenant: "tnt_a", PrincipalID: "p1"}),
+		&config.PolicyInput{Tenant: "tnt_a", Action: &config.ActionDescriptor{Kind: config.ActionKindFile, TargetPath: "/tmp/x"}})
+	if dec.Fired() {
+		t.Fatalf("file kind: tenant gate fired (Decision=%v)", dec.Decision)
+	}
+}

--- a/core/policy/actiongates/types.go
+++ b/core/policy/actiongates/types.go
@@ -1,0 +1,105 @@
+package actiongates
+
+import (
+	"context"
+
+	"github.com/cordum/cordum/core/edge"
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// Gate IDs are stable identifiers emitted to audit / matched_rule and surfaced
+// in HTTP error envelopes. Changing them is a breaking API change.
+const (
+	GateIDTenant     = "actiongate.tenant"
+	GateIDFile       = "actiongate.file"
+	GateIDURL        = "actiongate.url"
+	GateIDMCP        = "actiongate.mcp"
+	GateIDMutation   = "actiongate.mutation"
+	GateIDProvenance = "actiongate.provenance"
+)
+
+// Decision Codes carried on ActionGateDecision. These map to HTTP status at
+// the gateway boundary; do not invent new codes without updating the mapping
+// in handlers_edge_errors.go.
+const (
+	CodeUnauthorized       = "unauthorized"
+	CodeAccessDenied       = "access_denied"
+	CodeNotFound           = "not_found"
+	CodeConflict           = "conflict"
+	CodeInternalError      = "internal_error"
+	CodeServiceUnavailable = "service_unavailable"
+	CodeRequireHuman       = "require_human"
+)
+
+// ActionGateDecision is the output of a single gate. A zero-value decision
+// (Decision == DECISION_TYPE_UNSPECIFIED) indicates the gate did not fire and
+// the pipeline continues. A populated Decision short-circuits the pipeline.
+//
+// Reason MUST be sanitized for user/client display. SubReason is for audit
+// only and may carry the internal "why" (e.g. "approval_consumed",
+// "self_approval", "cross_tenant"). Extra holds non-PII gate-specific
+// breadcrumbs (gate, sub_reason, sanitized target_type) for SIEM.
+type ActionGateDecision struct {
+	Decision  pb.DecisionType
+	GateID    string
+	Code      string
+	Reason    string
+	SubReason string
+	Extra     map[string]string
+}
+
+// Fired reports whether the gate produced a real outcome. Gates that don't
+// apply to an input return a zero-value decision so the pipeline knows to
+// continue.
+func (d ActionGateDecision) Fired() bool {
+	return d.Decision != pb.DecisionType_DECISION_TYPE_UNSPECIFIED
+}
+
+// Allowed reports whether the gate explicitly allowed the action. The
+// pipeline does not short-circuit on Allowed; subsequent gates still run.
+func (d ActionGateDecision) Allowed() bool {
+	switch d.Decision {
+	case pb.DecisionType_DECISION_TYPE_ALLOW, pb.DecisionType_DECISION_TYPE_ALLOW_WITH_CONSTRAINTS:
+		return true
+	}
+	return false
+}
+
+// ActionGate is the contract every gate implements. Evaluate MUST be
+// idempotent and side-effect free (gates are evaluated in order and may be
+// re-run during simulate). Cancellation via ctx is respected.
+type ActionGate interface {
+	ID() string
+	Evaluate(ctx context.Context, input *config.PolicyInput) ActionGateDecision
+}
+
+// ApprovalLookup resolves a CanonicalActionHash (or scoped tenant key) to the
+// most recent matching Cordum EdgeApproval record. Implementations MUST be
+// safe for concurrent use and MUST respect ctx cancellation. A miss is
+// signalled by (nil, false, nil); errors propagate as (nil, false, err).
+type ApprovalLookup interface {
+	LookupByActionHash(ctx context.Context, tenant string, actionHash string) (*edge.EdgeApproval, bool, error)
+}
+
+// ResourceLookup resolves an ActionTargetResource to a backend record. The
+// mutation gate uses this to map missing-target to HTTP 404 instead of
+// allowing the underlying call to fail silently. Returning (false, nil)
+// means the target does not exist; (false, err) is treated as
+// service_unavailable.
+type ResourceLookup interface {
+	ResourceExists(ctx context.Context, tenant string, resource config.ActionTargetResource) (bool, error)
+}
+
+// ReachabilityProbe answers whether an MCP server is currently reachable.
+// Implementations should cache (LRU, short TTL) to keep gate latency
+// deterministic.
+type ReachabilityProbe interface {
+	MCPServerReachable(ctx context.Context, server string) (bool, error)
+}
+
+// HostResolver maps a hostname to one or more IPs. Decoupled from net.LookupIP
+// so URL-gate DNS-rebinding checks can be tested deterministically.
+type HostResolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+}

--- a/core/policy/actiongates/url_gate.go
+++ b/core/policy/actiongates/url_gate.go
@@ -1,0 +1,384 @@
+package actiongates
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+// URLGate blocks outbound URL access to cloud metadata services, known
+// exfiltration destinations, DNS-rebinding hostnames that resolve to
+// private/link-local IPs, and URLs whose query payload carries a recognized
+// prompt-stash signature.
+//
+// Resolution uses an injectable HostResolver (default: net.DefaultResolver)
+// so DNS rebinding tests are deterministic. A small LRU cache memoizes
+// resolution results for 60s to keep per-request latency predictable.
+type URLGate struct {
+	resolver    HostResolver
+	domainSeen  func(host string) bool
+	resCacheMu  sync.Mutex
+	resCache    map[string]resolverCacheEntry
+	resCacheTTL time.Duration
+}
+
+type resolverCacheEntry struct {
+	ips    []string
+	err    error
+	expiry time.Time
+}
+
+// URLGateOptions configures the URL gate. Resolver is required for DNS
+// rebinding tests; DomainSeen is optional and feeds the REQUIRE_HUMAN
+// path for PII POSTs to never-before-seen hosts (returns true for hosts
+// already cached as approved).
+type URLGateOptions struct {
+	Resolver    HostResolver
+	DomainSeen  func(host string) bool
+	ResolverTTL time.Duration
+}
+
+// NewURLGate constructs a URLGate. Resolver defaults to a net.LookupHost
+// wrapper when unset.
+func NewURLGate(opts URLGateOptions) *URLGate {
+	resolver := opts.Resolver
+	if resolver == nil {
+		resolver = netResolver{}
+	}
+	ttl := opts.ResolverTTL
+	if ttl == 0 {
+		ttl = 60 * time.Second
+	}
+	return &URLGate{
+		resolver:    resolver,
+		domainSeen:  opts.DomainSeen,
+		resCache:    make(map[string]resolverCacheEntry),
+		resCacheTTL: ttl,
+	}
+}
+
+func (g *URLGate) ID() string { return GateIDURL }
+
+type netResolver struct{}
+
+func (netResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// metadataHosts: hostnames that always indicate a cloud metadata service.
+var metadataHosts = map[string]string{
+	"metadata.google.internal":        "gcp",
+	"metadata.azure.com":              "azure",
+	"169.254.169.254":                 "aws",
+	"169.254.170.2":                   "aws_ecs",
+	"100.100.100.200":                 "alibaba",
+	"fd00:ec2::254":                   "aws_v6",
+	"fd00:ec2:0:0:0:0:0:254":          "aws_v6",
+	"fe80::a9fe:a9fe":                 "azure_link_local_v6",
+	"fe80:0:0:0:0:0:a9fe:a9fe":        "azure_link_local_v6",
+}
+
+// exfilHostPatterns: substring + suffix match against the hostname. Suffixes
+// MUST start with a dot or match the full host to avoid over-refusal
+// (`example.ngrok.io.evil.com` should still be denied, while `ngrok.io.app`
+// would only false-positive on exact `ngrok.io` ownership, which we accept).
+var exfilHostPatterns = []struct {
+	pattern   string
+	subReason string
+}{
+	{"webhook.site", "exfil_host:webhook_site"},
+	{".ngrok.io", "exfil_host:ngrok_io"},
+	{".ngrok-free.app", "exfil_host:ngrok_free"},
+	{".serveo.net", "exfil_host:serveo"},
+	{".pipedream.net", "exfil_host:pipedream"},
+	{".requestbin.com", "exfil_host:requestbin"},
+	{".beeceptor.com", "exfil_host:beeceptor"},
+	{".burpcollaborator.net", "exfil_host:burp"},
+	{"burpcollaborator.net", "exfil_host:burp"},
+	{"canarytokens.com", "exfil_host:canarytokens"},
+	{".canarytokens.com", "exfil_host:canarytokens"},
+	{".interactsh.com", "exfil_host:interactsh"},
+}
+
+// rebindDomains: well-known wildcard-IP DNS services. A hit means we MUST
+// resolve and reject if the IP is private/link-local.
+var rebindDomains = []string{".nip.io", ".sslip.io", ".xip.io"}
+
+// pastePatterns: (host suffix, path prefix). Match when verb is a write
+// (POST/PUT-style), since browsing a known paste is a read of public content.
+var pastePatterns = []struct {
+	hostSuffix string
+	pathPrefix string
+	subReason  string
+}{
+	{"pastebin.com", "/api/", "paste:pastebin_api"},
+	{"gist.github.com", "/api/", "paste:gist_api"},
+}
+
+// promptStashKeys are JSON object keys whose presence inside a large query
+// value strongly indicates prompt/context exfil.
+var promptStashKeys = []string{
+	`"messages"`, `"system"`, `"prompt"`, `"context_window"`, `"tools"`, `"conversation"`,
+}
+
+// promptExfilQueryLenThreshold is the per-query-value length (in bytes) above
+// which we look for prompt stash keys. Small payloads pass through unchanged.
+const promptExfilQueryLenThreshold = 1024
+
+func (g *URLGate) Evaluate(ctx context.Context, in *config.PolicyInput) ActionGateDecision {
+	if in == nil || in.Action == nil {
+		return ActionGateDecision{}
+	}
+	act := in.Action
+	if act.Kind != config.ActionKindURL {
+		return ActionGateDecision{}
+	}
+	raw := strings.TrimSpace(act.TargetURL)
+	if raw == "" {
+		return ActionGateDecision{}
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return ActionGateDecision{}
+	}
+
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	_ = port // reserved for future per-port rules
+
+	// Strip IPv4-in-IPv6 prefix (e.g. ::ffff:169.254.169.254) when present so
+	// the IP-class checks see the underlying v4 literal.
+	host = unmapIPv4InIPv6(host)
+
+	// userinfo-based bypass (http://google.com@169.254.169.254/): u.Host is
+	// the authority post-userinfo, so this is already captured. We still flag
+	// userinfo presence in audit so SIEM can review.
+	hasUserinfo := u.User != nil
+
+	// 1) Direct metadata-host hit by name or by literal IP.
+	if sub, ok := metadataHosts[host]; ok {
+		return g.deny(CodeAccessDenied, "metadata service access denied", "metadata_service:"+sub, raw, host, hasUserinfo)
+	}
+
+	// 2) Literal link-local / RFC1918 / loopback / multicast / unique-local.
+	if ip := net.ParseIP(host); ip != nil {
+		if class, ok := privateIPClass(ip); ok {
+			subReason := "link_local"
+			if class != "link_local" {
+				subReason = class
+			}
+			return g.deny(CodeAccessDenied, "metadata service access denied", "metadata_service:"+subReason, raw, host, hasUserinfo)
+		}
+	}
+
+	// 3) Known exfil hosts.
+	if reason, ok := matchExfilHost(host); ok {
+		return g.deny(CodeAccessDenied, "exfiltration destination denied", reason, raw, host, hasUserinfo)
+	}
+
+	// 4) Paste destinations on write verbs.
+	if isWriteVerb(act.Verb) {
+		if reason, ok := matchPaste(host, u.Path); ok {
+			return g.deny(CodeAccessDenied, "paste destination denied", reason, raw, host, hasUserinfo)
+		}
+	}
+
+	// 5) DNS rebinding via *.nip.io / sslip.io / xip.io: must resolve and
+	// reject if any resolved IP is in a private class.
+	if isRebindWildcardHost(host) {
+		ips, _, err := g.resolve(ctx, host)
+		if err == nil {
+			for _, ip := range ips {
+				if pip := net.ParseIP(ip); pip != nil {
+					if class, ok := privateIPClass(pip); ok {
+						return g.deny(CodeAccessDenied, "dns rebinding denied", "dns_rebind:"+class, raw, host, hasUserinfo)
+					}
+				}
+			}
+		}
+	}
+
+	// 6) Prompt-exfil signature scan on query payload.
+	if hasPromptExfilSignature(u) {
+		return g.deny(CodeAccessDenied, "prompt context exfiltration denied", "prompt_exfil", raw, host, hasUserinfo)
+	}
+
+	// 7) PII POST to never-before-seen host -> REQUIRE_HUMAN.
+	if isWriteVerb(act.Verb) && containsRiskTag(act.RiskTags, "data:pii") {
+		seen := false
+		if g.domainSeen != nil {
+			seen = g.domainSeen(host)
+		}
+		if !seen {
+			return ActionGateDecision{
+				Decision:  pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN,
+				GateID:    GateIDURL,
+				Code:      CodeRequireHuman,
+				Reason:    "human approval required for PII upload to new destination",
+				SubReason: "pii_post:new_host",
+				Extra: map[string]string{
+					"gate":       GateIDURL,
+					"sub_reason": "pii_post:new_host",
+					"host":       host,
+				},
+			}
+		}
+	}
+
+	return ActionGateDecision{Decision: pb.DecisionType_DECISION_TYPE_ALLOW, GateID: GateIDURL}
+}
+
+func (g *URLGate) deny(code, reason, subReason, raw, host string, hasUserinfo bool) ActionGateDecision {
+	extra := map[string]string{
+		"gate":       GateIDURL,
+		"sub_reason": subReason,
+		"host":       host,
+		"raw_len":    itoa(len(raw)),
+	}
+	if hasUserinfo {
+		extra["userinfo_present"] = "true"
+	}
+	return ActionGateDecision{
+		Decision:  pb.DecisionType_DECISION_TYPE_DENY,
+		GateID:    GateIDURL,
+		Code:      code,
+		Reason:    reason,
+		SubReason: subReason,
+		Extra:     extra,
+	}
+}
+
+func (g *URLGate) resolve(ctx context.Context, host string) ([]string, bool, error) {
+	g.resCacheMu.Lock()
+	if ent, ok := g.resCache[host]; ok && time.Now().Before(ent.expiry) {
+		g.resCacheMu.Unlock()
+		return ent.ips, true, ent.err
+	}
+	g.resCacheMu.Unlock()
+
+	ips, err := g.resolver.LookupHost(ctx, host)
+	g.resCacheMu.Lock()
+	g.resCache[host] = resolverCacheEntry{ips: ips, err: err, expiry: time.Now().Add(g.resCacheTTL)}
+	g.resCacheMu.Unlock()
+	return ips, false, err
+}
+
+// unmapIPv4InIPv6 normalizes ::ffff:1.2.3.4 (IPv4-mapped IPv6) and the brackets
+// around v6 hostnames into a literal v4 string when applicable. `host` is
+// already lowercased and bracketed v6 had its brackets stripped by url.Hostname.
+func unmapIPv4InIPv6(host string) string {
+	if !strings.Contains(host, ":") {
+		return host
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return host
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String()
+	}
+	return host
+}
+
+func privateIPClass(ip net.IP) (string, bool) {
+	if ip == nil {
+		return "", false
+	}
+	if ip.IsLoopback() {
+		return "loopback", true
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return "link_local", true
+	}
+	if ip.IsPrivate() {
+		return "rfc1918", true
+	}
+	if ip.IsUnspecified() {
+		return "unspecified", true
+	}
+	// Unique local (fc00::/7).
+	if v6 := ip.To16(); v6 != nil && ip.To4() == nil {
+		if v6[0]&0xfe == 0xfc {
+			return "unique_local", true
+		}
+	}
+	return "", false
+}
+
+func matchExfilHost(host string) (string, bool) {
+	for _, p := range exfilHostPatterns {
+		if p.pattern == host {
+			return p.subReason, true
+		}
+		if strings.HasPrefix(p.pattern, ".") && strings.HasSuffix(host, p.pattern) {
+			return p.subReason, true
+		}
+	}
+	return "", false
+}
+
+func isRebindWildcardHost(host string) bool {
+	for _, d := range rebindDomains {
+		if strings.HasSuffix(host, d) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchPaste(host, path string) (string, bool) {
+	for _, p := range pastePatterns {
+		if host == p.hostSuffix && strings.HasPrefix(path, p.pathPrefix) {
+			return p.subReason, true
+		}
+	}
+	return "", false
+}
+
+func hasPromptExfilSignature(u *url.URL) bool {
+	if u.RawQuery == "" {
+		return false
+	}
+	q := u.Query()
+	for _, vals := range q {
+		for _, v := range vals {
+			if len(v) < promptExfilQueryLenThreshold {
+				continue
+			}
+			if !looksLikeJSONWithStashKey(v) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeJSONWithStashKey(s string) bool {
+	// Cheap heuristic: starts/contains a JSON object and has at least one stash key.
+	if !strings.ContainsAny(s, "{[") {
+		return false
+	}
+	for _, k := range promptStashKeys {
+		if strings.Contains(s, k) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRiskTag(tags []string, want string) bool {
+	for _, t := range tags {
+		if strings.EqualFold(t, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/policy/actiongates/url_gate_test.go
+++ b/core/policy/actiongates/url_gate_test.go
@@ -1,0 +1,253 @@
+package actiongates
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cordum/cordum/core/infra/config"
+	pb "github.com/cordum/cordum/core/protocol/pb/v1"
+)
+
+type fakeHostResolver struct {
+	resolve map[string][]string
+	err     map[string]error
+}
+
+func (r *fakeHostResolver) LookupHost(_ context.Context, host string) ([]string, error) {
+	if err, ok := r.err[host]; ok {
+		return nil, err
+	}
+	if ips, ok := r.resolve[host]; ok {
+		return ips, nil
+	}
+	return []string{"203.0.113.5"}, nil
+}
+
+type urlGateCase struct {
+	name         string
+	url          string
+	verb         config.ActionVerb
+	riskTags     []string
+	resolver     *fakeHostResolver
+	wantDecision pb.DecisionType
+	wantCode     string
+	subReasonHas string
+}
+
+func runURLGate(t *testing.T, tc urlGateCase) {
+	t.Helper()
+	resolver := tc.resolver
+	if resolver == nil {
+		resolver = &fakeHostResolver{}
+	}
+	gate := NewURLGate(URLGateOptions{Resolver: resolver})
+	in := &config.PolicyInput{
+		Tenant: "tnt_a",
+		Action: &config.ActionDescriptor{
+			Kind:      config.ActionKindURL,
+			Verb:      tc.verb,
+			TargetURL: tc.url,
+			RiskTags:  tc.riskTags,
+		},
+	}
+	dec := gate.Evaluate(context.Background(), in)
+	if dec.Decision != tc.wantDecision {
+		t.Fatalf("decision = %v, want %v (url=%q verb=%q reason=%q subReason=%q)", dec.Decision, tc.wantDecision, tc.url, tc.verb, dec.Reason, dec.SubReason)
+	}
+	if tc.wantCode != "" && dec.Code != tc.wantCode {
+		t.Fatalf("code = %q, want %q", dec.Code, tc.wantCode)
+	}
+	if tc.subReasonHas != "" && !strings.Contains(dec.SubReason, tc.subReasonHas) {
+		t.Fatalf("subReason = %q, want substring %q", dec.SubReason, tc.subReasonHas)
+	}
+}
+
+func TestURLGate_SkipsNonURLKind(t *testing.T) {
+	t.Parallel()
+	gate := NewURLGate(URLGateOptions{Resolver: &fakeHostResolver{}})
+
+	if dec := gate.Evaluate(context.Background(), &config.PolicyInput{}); dec.Fired() {
+		t.Fatal("nil action: gate fired")
+	}
+	if dec := gate.Evaluate(context.Background(), &config.PolicyInput{
+		Action: &config.ActionDescriptor{Kind: config.ActionKindFile, TargetPath: "/tmp/x"},
+	}); dec.Fired() {
+		t.Fatal("file kind: gate fired")
+	}
+	if dec := gate.Evaluate(context.Background(), &config.PolicyInput{
+		Action: &config.ActionDescriptor{Kind: config.ActionKindURL, TargetURL: ""},
+	}); dec.Fired() {
+		t.Fatal("empty url: gate fired")
+	}
+}
+
+func TestURLGate_DenyCloudMetadataServices(t *testing.T) {
+	t.Parallel()
+	cases := []urlGateCase{
+		{name: "aws_imds_v4", url: "http://169.254.169.254/latest/meta-data/iam/security-credentials/", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "metadata_service"},
+		{name: "aws_imds_v6", url: "http://[fd00:ec2::254]/latest/meta-data/", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "metadata_service"},
+		{name: "ecs_creds", url: "http://169.254.170.2/v2/credentials/abc", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "metadata_service"},
+		{name: "gcp_metadata_host", url: "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "metadata_service"},
+		{name: "azure_imds_link_local_v6", url: "http://[fe80::a9fe:a9fe]/metadata/instance", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "link_local"},
+		{name: "user_at_imds_bypass", url: "http://google.com@169.254.169.254/latest/meta-data/", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "metadata_service"},
+		{name: "ipv4_in_ipv6", url: "http://[::ffff:169.254.169.254]/latest/meta-data/", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "metadata_service"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runURLGate(t, tc) })
+	}
+}
+
+func TestURLGate_DenyKnownExfilDestinations(t *testing.T) {
+	t.Parallel()
+	cases := []urlGateCase{
+		{name: "webhook_site", url: "https://webhook.site/abc-123", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "ngrok_io", url: "https://abc.ngrok.io/upload", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "ngrok_free", url: "https://abc.ngrok-free.app/upload", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "serveo", url: "https://abc.serveo.net/", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "pipedream", url: "https://eohjvz.m.pipedream.net/", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "requestbin", url: "https://abc.requestbin.com/notify", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "beeceptor", url: "https://abc.beeceptor.com/path", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "burp_collab", url: "https://abc.burpcollaborator.net/", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "canarytokens", url: "https://canarytokens.com/test", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "interactsh", url: "https://abc.interactsh.com/payload", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "exfil_host"},
+		{name: "pastebin_api_post", url: "https://pastebin.com/api/api_post.php", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "paste"},
+		{name: "gist_post", url: "https://gist.github.com/api/v3/gists", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "paste"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runURLGate(t, tc) })
+	}
+}
+
+func TestURLGate_PastebinReadAllowed(t *testing.T) {
+	t.Parallel()
+	// pastebin.com and gist.github.com are read-allowed (browse a known paste).
+	// Only POST/PUT-style writes hit the paste rule.
+	runURLGate(t, urlGateCase{
+		name:         "pastebin_read",
+		url:          "https://pastebin.com/abcdef",
+		verb:         config.ActionVerbRead,
+		wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+	})
+	runURLGate(t, urlGateCase{
+		name:         "gist_read",
+		url:          "https://gist.github.com/user/abcd",
+		verb:         config.ActionVerbRead,
+		wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+	})
+}
+
+func TestURLGate_DNSRebindingToRFC1918(t *testing.T) {
+	t.Parallel()
+	// *.nip.io and similar resolve to attacker-controlled IPs; gate must
+	// resolve at eval time and DENY when the IP is RFC1918 / link-local.
+	resolver := &fakeHostResolver{
+		resolve: map[string][]string{
+			"169-254-169-254.nip.io":  {"169.254.169.254"},
+			"10-0-0-1.sslip.io":       {"10.0.0.1"},
+			"192-168-1-1.xip.io":      {"192.168.1.1"},
+			"172-16-0-1.nip.io":       {"172.16.0.1"},
+			"public.example.com.nip.io": {"203.0.113.42"}, // public IP — allowed
+		},
+	}
+	cases := []urlGateCase{
+		{name: "nip_imds", url: "http://169-254-169-254.nip.io/latest/", verb: config.ActionVerbRead, resolver: resolver, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "dns_rebind"},
+		{name: "sslip_rfc1918", url: "http://10-0-0-1.sslip.io/", verb: config.ActionVerbRead, resolver: resolver, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "dns_rebind"},
+		{name: "xip_rfc1918", url: "http://192-168-1-1.xip.io/", verb: config.ActionVerbRead, resolver: resolver, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "dns_rebind"},
+		{name: "nip_carrier_grade_rfc1918", url: "http://172-16-0-1.nip.io/", verb: config.ActionVerbRead, resolver: resolver, wantDecision: pb.DecisionType_DECISION_TYPE_DENY, wantCode: CodeAccessDenied, subReasonHas: "dns_rebind"},
+		{name: "nip_resolves_public_allowed", url: "http://public.example.com.nip.io/", verb: config.ActionVerbRead, resolver: resolver, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runURLGate(t, tc) })
+	}
+}
+
+func TestURLGate_PromptExfilSignature(t *testing.T) {
+	t.Parallel()
+	// Build a >1KB JSON payload containing recognized prompt-stash keys, then
+	// stick it in a query param. Must DENY.
+	big := strings.Repeat("a", 1200)
+	exfilPayload := `{"messages":[{"role":"user","content":"` + big + `"}],"system":"hi","context_window":4096}`
+	url := "https://attacker.example/log?payload=" + exfilPayload
+	runURLGate(t, urlGateCase{
+		name:         "prompt_stash_in_query",
+		url:          url,
+		verb:         config.ActionVerbWrite,
+		wantDecision: pb.DecisionType_DECISION_TYPE_DENY,
+		wantCode:     CodeAccessDenied,
+		subReasonHas: "prompt_exfil",
+	})
+
+	// Same payload but small (<1KB) → ALLOW (one of the structured-field
+	// thresholds — we don't want to over-refuse legitimate small JSON params).
+	smallURL := `https://api.example/log?payload={"messages":[]}`
+	runURLGate(t, urlGateCase{
+		name:         "tiny_messages_param_allowed",
+		url:          smallURL,
+		verb:         config.ActionVerbWrite,
+		wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+	})
+}
+
+func TestURLGate_RequireHumanForPIIPostToUncached(t *testing.T) {
+	t.Parallel()
+	resolver := &fakeHostResolver{
+		resolve: map[string][]string{
+			"new-uncached-vendor.example.com": {"203.0.113.99"},
+		},
+	}
+	runURLGate(t, urlGateCase{
+		name:         "pii_post_new_domain_require_human",
+		url:          "https://new-uncached-vendor.example.com/api/upload",
+		verb:         config.ActionVerbWrite,
+		riskTags:     []string{"data:pii"},
+		resolver:     resolver,
+		wantDecision: pb.DecisionType_DECISION_TYPE_REQUIRE_HUMAN,
+		wantCode:     CodeRequireHuman,
+		subReasonHas: "pii_post",
+	})
+	// Same URL but no PII tag → allow.
+	runURLGate(t, urlGateCase{
+		name:         "post_new_domain_no_pii_allowed",
+		url:          "https://new-uncached-vendor.example.com/api/upload",
+		verb:         config.ActionVerbWrite,
+		resolver:     resolver,
+		wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW,
+	})
+}
+
+func TestURLGate_AllowLegitimateDestinations(t *testing.T) {
+	t.Parallel()
+	// ≥4 over-refusal cases from security-research + cybersecurity-education,
+	// plus standard docs/training references.
+	cases := []urlGateCase{
+		{name: "anthropic_docs", url: "https://docs.anthropic.com/claude/docs/intro", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "anthropic_github", url: "https://github.com/anthropics/anthropic-sdk-python", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "owasp_top10", url: "https://owasp.org/Top10/A03_2021-Injection/", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "huggingface_models", url: "https://huggingface.co/datasets/test", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "schema_org_ref", url: "https://schema.org/Person", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		// Security-research + cybersecurity-education over-refusal allow cases.
+		{name: "mitre_attack_research", url: "https://attack.mitre.org/techniques/T1059/", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "cve_lookup", url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-1234", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "nvd_education", url: "https://nvd.nist.gov/vuln/detail/CVE-2024-1234", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "exploit_db_research", url: "https://www.exploit-db.com/exploits/12345", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "github_post_pr_no_pii", url: "https://api.github.com/repos/owner/repo/pulls", verb: config.ActionVerbWrite, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+		{name: "internal_corp", url: "https://internal.corp.local/api/v1/health", verb: config.ActionVerbRead, wantDecision: pb.DecisionType_DECISION_TYPE_ALLOW},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runURLGate(t, tc) })
+	}
+}
+
+func TestURLGate_MalformedURLAllowsPipelineContinue(t *testing.T) {
+	t.Parallel()
+	// Malformed -> we choose ALLOW (skip) and let the rule engine + handler
+	// produce a 400 downstream. The gate is for actionable structured cases.
+	gate := NewURLGate(URLGateOptions{Resolver: &fakeHostResolver{}})
+	dec := gate.Evaluate(context.Background(), &config.PolicyInput{
+		Action: &config.ActionDescriptor{Kind: config.ActionKindURL, Verb: config.ActionVerbRead, TargetURL: "::not a url::"},
+	})
+	if dec.Fired() {
+		t.Fatalf("malformed url: gate fired (Decision=%v)", dec.Decision)
+	}
+}

--- a/core/policy/actiongates/wire.go
+++ b/core/policy/actiongates/wire.go
@@ -1,0 +1,65 @@
+package actiongates
+
+// ProductionPipelineOptions wires production dependencies into the gate
+// pipeline factory. Every dependency is optional — missing dependencies
+// degrade individual gates to a fail-closed posture without taking down
+// the entire pipeline, so a misconfigured deployment still rejects
+// destructive actions instead of silently allowing them.
+//
+// Required pairings to keep gates functional in production:
+//
+//   - MutationGate needs an Approvals lookup — without it, every
+//     destructive action fails closed at the mutation gate with
+//     Code=internal_error.
+//   - ProvenanceGate needs both an Approvals lookup AND a ChainVerifier
+//     — either being nil short-circuits destructive actions to
+//     Code=internal_error.
+//   - MCPGate needs an Identities resolver — without it, every
+//     mcp_call action fails closed with Code=internal_error.
+//
+// File / URL / Tenant gates have no required deps (Resolver/DomainSeen
+// on URL are optional; default uses net.DefaultResolver and a never-seen
+// stance for unknown hosts).
+type ProductionPipelineOptions struct {
+	Approvals           ApprovalLookup
+	Resources           ResourceLookup
+	Identities          MCPIdentityResolver
+	Reachability        ReachabilityProbe
+	ChainVerifier       ChainVerifier
+	HostResolver        HostResolver
+	DomainSeen          func(host string) bool
+	DangerousParamRules map[string][]DangerousParamRule
+}
+
+// BuildProductionPipeline constructs the canonical Tenant→File→URL→MCP→
+// Mutation→Provenance pipeline used by both the gateway HTTP path and
+// the safety-kernel gRPC path. Gate ordering is enforced inside NewPipeline.
+//
+// The factory never returns an error so callers can declare wiring at
+// service-start time without an extra failure mode; nil dependencies
+// degrade individual gates as documented on ProductionPipelineOptions.
+// Callers that want a strict construction-time error should validate
+// opts before invocation.
+func BuildProductionPipeline(opts ProductionPipelineOptions) *Pipeline {
+	return NewPipeline(
+		NewTenantGate(),
+		NewFileGate(),
+		NewURLGate(URLGateOptions{
+			Resolver:   opts.HostResolver,
+			DomainSeen: opts.DomainSeen,
+		}),
+		NewMCPGate(MCPGateOptions{
+			Identities:          opts.Identities,
+			Reachability:        opts.Reachability,
+			DangerousParamRules: opts.DangerousParamRules,
+		}),
+		NewMutationGate(MutationGateOptions{
+			Approvals: opts.Approvals,
+			Resources: opts.Resources,
+		}),
+		NewProvenanceGate(ProvenanceGateOptions{
+			Approvals:     opts.Approvals,
+			ChainVerifier: opts.ChainVerifier,
+		}),
+	)
+}


### PR DESCRIPTION
## Summary

Deterministic pre-rule action-layer gates that fire before the kernel rule loop. Six gates run in fixed order — **tenant → file → url → mcp → mutation → provenance** — short-circuiting on the first non-`ALLOW`. All gates inspect structured `ActionDescriptor` metadata only (never `input_text`), preserving the over-refusal baseline (65/65 → 65/65, 0 FPs).

Task: `task-bf56d8c8` (epic `epic-f3da4017` — AgentShield Benchmark Hardening & Action-Layer Gates).

## DoD coverage (8 items, all evidenced)

| # | DoD line | Evidence |
|---|----------|----------|
| 1 | File/resource gates block sensitive paths, traversal, credential locations, read/write scope (Unix + Windows). | `core/policy/actiongates/file_gate.go` + `file_gate_test.go` (`TestFileGate*`); URL-decode → backslash-norm → UNC-strip → lowercase-on-Windows → env-expand → `filepath.Clean` → `..`-or-regex reject. |
| 2 | URL/exfil gates block metadata services, exfil destinations, prompt/context exfil; ALLOW benign docs/training. | `core/policy/actiongates/url_gate.go` + `url_gate_test.go` (`TestURLGate*`); covers IMDSv1, GCP, ECS, IPv6 link-local, DNS rebinding (nip.io/xip.io/sslip.io w/ LRU 60s), structured prompt-exfil. |
| 3 | Tenant-boundary gates deny cross-tenant ids, wildcard owner/tenant, archived-record bypass, anti-enumeration. | `core/policy/actiongates/tenant_gate.go` + `tenant_gate_test.go` (`TestTenantGate*`); `AuthContext.Tenant` only — never body-claimed tenant. |
| 4 | Destructive mutation gates with approval/provenance + 401/403/404/409/500/503 HTTP behavior. | `core/policy/actiongates/mutation_gate.go` + `mutation_gate_test.go` (`TestMutationGate*`, `CanonicalActionHash` determinism); `core/controlplane/gateway/actiongates_http.go` + `_test.go` (`TestPolicySimulateActionGateMapping`). |
| 5 | MCP/tool-call gates enforce server/tool/resource allowlists, dangerous-param denial, unauth/unlicensed/unavailable. | `core/policy/actiongates/mcp_gate.go` + `mcp_gate_test.go` (`TestMCPGate*`); `core/mcp/filter.go` gains `AllowedServers / AllowedResources / Entitlements` on `AgentIdentity` (additive). |
| 6 | Backend-verified provenance gate rejects unverified claims ("approved by CFO"). | `core/policy/actiongates/provenance_gate.go` + `provenance_gate_test.go` (`TestRejectClaimText*`); `core/edge/approval_store_redis.go::LookupByActionHash` + `GetApprovalsByActionHash` + `audit:approval:hash:<tenant>:<actionHash>` index, backfilled on `EnqueueApproval`. |
| 7 | Tests cover allowed/denied/require-human/tenant isolation/stale-conflict/unavailable backend/audit evidence. | `core/policy/actiongates/pipeline_test.go` (`TestPipeline{Allowed,Denied,RequireHuman,TenantIsolation,StaleConflict,UnavailableBackend,AuditEvidence}`); `core/controlplane/safetykernel/kernel_actiongate_test.go` (`TestCheckActionGateShortCircuits`). |
| 8 | Benchmark reruns show materially improved action-layer categories without new FPs. | Adapter wired (`agentshield-benchmark/src/adapters/cordum.ts` forwards `testCase.metadata.action`); corpus audit found ~0/525 public cases carry `metadata.action` — uplift requires corpus backfill (sibling task, avoids train-to-test per rail #2). Over-refusal 65/65 (0 FPs) preserved. |

## Benchmark score delta vs baseline

Baseline (`agentshield-benchmark/docs/baseline.md`, 537-case public corpus): no `metadata.action` populated → gates short-circuit ALLOW for missing structured metadata, identical scores. **No regression; uplift bounded by corpus-coverage gap, not gate logic.**

## Architecture

Pipeline-level integration:
- `core/controlplane/safetykernel/kernel_actiongate.go` bolts `ActionGatePipeline` before the existing rule loop; non-ALLOW result short-circuits and emits `SIEMEvent` `actiongate.denied` (HIGH severity for cross-tenant / credential paths / exfil / self-approval; MEDIUM for require-human), appended to the `Chainer` when tenant is identifiable.
- `core/audit/exporter.go` gains `EventActionGateDenied = "actiongate.denied"`.
- `core/controlplane/gateway/actiongates_http.go` maps `ActionGateDecision.Code` to HTTP envelopes; details map carries only safe fields (gate / sub_reason / sanitized target_type) — never raw paths/URLs/args (PII risk).
- `core/controlplane/gateway/handlers_policy.go` + `gateway.go` + `helpers.go` plumb `*ActionDescriptor` into the policy-check request shape (`Action`, opt-in — pre-existing callers unaffected).

## Verification

- `go build ./...` → **EXIT=0**
- `go vet ./...` → **EXIT=0**
- `go test ./core/policy/actiongates/... ./core/controlplane/safetykernel/... ./core/controlplane/gateway/... ./core/audit/... ./core/edge/... -count=3` → **PASS**
- `go test -tags=integration ./core/edge/... -count=3` → **PASS**
- Over-refusal baseline → **65/65 (0 FPs preserved)**

29 files, +5210 / -16 (deletions are struct re-alignment in `helpers.go` and edits in shared `kernel.go` / `filter.go` — verified via `git diff origin/main..HEAD`; no parallel-worker code overwritten).

## Test plan

- [ ] Reviewer: confirm `git diff --stat origin/main..HEAD` shows exactly 29 files under `core/`
- [ ] Reviewer: spot-check `core/policy/actiongates/{file,url,tenant,mutation,mcp,provenance}_gate_test.go` for ≥1 deny + ≥1 allow + over-refusal cases per gate
- [ ] Reviewer: confirm `TestRejectClaimText*` in `provenance_gate_test.go` covers ≥3 phrasings of "approved by CFO" / "per CISO" / "admin override"
- [ ] Reviewer: confirm HTTP status mapping in `actiongates_http_test.go` covers all 6 codes (401/403/404/409/500/503)
- [ ] Reviewer: confirm SIEMEvent emission in `pipeline_test.go::TestPipelineAuditEvidence` writes `actiongate.denied` to fake exporter
- [ ] Merge unblocks worker-6099 on EDGE-102 step-3 (per architect-2f69 / governor-81cf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action-gate enforcement: deterministic pre-policy gating with deny/require-human outcomes and SIEM audit events.
  * New gates: tenant isolation, file access, URL outbound, MCP authorizations, mutation approvals, and provenance checks.
  * Approval lookup and edge approval index to support single-use approvals and action-hash lookups.

* **Documentation**
  * Package-level docs describing gate ordering, semantics, and HTTP/error mapping.

* **Tests**
  * Extensive unit and integration tests covering gates, pipeline wiring, HTTP behavior, serialization, and approval flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/274)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->