### PR TITLE
security(gosec): clear 25 gosec alerts and gate CI on new findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4
@@ -352,27 +352,72 @@ jobs:
         go mod edit -dropreplace github.com/cordum-io/cap/v2
         go mod tidy
 
-    - name: Run Gosec Security Scanner
+    - name: Install gosec
       env:
         GOFLAGS: ""
         GOTOOLCHAIN: local
-      run: |
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
-        gosec -no-fail -fmt sarif -out results.sarif -exclude-dir=vendor ./cmd/... ./core/... ./sdk/...
+      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
+
+    # gosec runs once per Go module (cmd+core live in the root module; the
+    # shipped SDK is a separate module). `./sdk/...` from the root module
+    # matches nothing, so each module is scanned with its own scoped patterns.
+    # -no-fail keeps these steps green; the "Fail on gosec findings" gate below
+    # is the single place that fails the job, so SARIF still uploads on failure.
+    - name: Run gosec (core platform + CLIs)
+      env:
+        GOFLAGS: ""
+        GOTOOLCHAIN: local
+      run: gosec -no-fail -fmt sarif -out gosec-core.sarif -exclude-dir=vendor ./cmd/... ./core/...
+
+    - name: Run gosec (Go SDK)
+      working-directory: sdk
+      env:
+        GOFLAGS: ""
+        GOTOOLCHAIN: local
+      run: gosec -no-fail -fmt sarif -out ../gosec-sdk.sarif -exclude-dir=vendor ./client/... ./runtime/...
 
     - name: Sanitize SARIF
+      # Strip rule relationship metadata and generated-protobuf (.pb.go)
+      # results (noise, not actionable). The SDK SARIF paths are relative to
+      # the sdk/ module dir, so prefix them back to repo-root for the Security
+      # tab. The gate counts the sanitized set.
       run: |
-        jq '
-          (.runs[]?.tool.driver.rules[]? |= del(.relationships))
-          | (.runs[]?.results |= ((. // []) | map(select(
-              ([.locations[]?.physicalLocation.artifactLocation.uri // ""] | any(endswith(".pb.go"))) | not
-            ))))
-        ' results.sarif > results.cleaned.sarif
+        sanitize() { # $1=in $2=out $3=uri-prefix(optional)
+          jq --arg p "${3:-}" '
+            (.runs[]?.tool.driver.rules[]? |= del(.relationships))
+            | (.runs[]?.results |= ((. // []) | map(select(
+                ([.locations[]?.physicalLocation.artifactLocation.uri // ""] | any(endswith(".pb.go"))) | not
+              ))))
+            | (if $p != "" then (.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri |= ($p + .)) else . end)
+          ' "$1" > "$2"
+        }
+        sanitize gosec-core.sarif gosec-core.cleaned.sarif ""
+        sanitize gosec-sdk.sarif  gosec-sdk.cleaned.sarif  "sdk/"
 
-    - name: Upload SARIF file
+    # Core keeps the default analysis category so the pre-existing gosec alerts
+    # uploaded under it are auto-resolved when they disappear from the SARIF.
+    - name: Upload SARIF (core)
+      if: always() && hashFiles('gosec-core.cleaned.sarif') != ''
       uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       with:
-        sarif_file: results.cleaned.sarif
+        sarif_file: gosec-core.cleaned.sarif
+
+    - name: Upload SARIF (sdk)
+      if: always() && hashFiles('gosec-sdk.cleaned.sarif') != ''
+      uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+      with:
+        sarif_file: gosec-sdk.cleaned.sarif
+        category: gosec-sdk
+
+    - name: Fail on gosec findings
+      run: |
+        total=$(jq -s '[.[].runs[].results[]] | length' gosec-core.cleaned.sarif gosec-sdk.cleaned.sarif)
+        echo "gosec findings after sanitize: $total"
+        if [ "$total" -gt 0 ]; then
+          echo "::error::gosec reported $total finding(s); see the Security tab (categories: default + gosec-sdk)"
+          jq -r '.runs[]?.results[]? | "  \(.ruleId) \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 0)"' gosec-core.cleaned.sarif gosec-sdk.cleaned.sarif || true
+          exit 1
+        fi
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,9 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read          # checkout
+      security-events: write  # upload-sarif to the code-scanning API
 
     steps:
     - uses: actions/checkout@v4

--- a/cmd/cordumctl/edge_init.go
+++ b/cmd/cordumctl/edge_init.go
@@ -188,7 +188,7 @@ func writeInitYAML(path string, s edgeInitScaffold) error {
 	writeYAMLField(&b, "agentd_path", s.AgentdPath)
 	writeYAMLField(&b, "hook_command", s.HookCommand)
 	writeYAMLField(&b, "approval_wait_timeout", s.ApprovalWaitTimeout)
-	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
@@ -210,14 +210,18 @@ func writeInitWrapper(cwd string, _ edgeInitScaffold) (string, error) {
 	if runtime.GOOS == "windows" {
 		path := filepath.Join(cwd, "cordum-claude.ps1")
 		body := wrapperPS1Body()
-		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 			return "", fmt.Errorf("write %s: %w", path, err)
 		}
 		return path, nil
 	}
 	path := filepath.Join(cwd, "cordum-claude.sh")
 	body := wrapperShBody()
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+	// The wrapper is invoked directly by the user, so it must keep the owner
+	// execute bit; 0700 is owner-only (no group/world) and as tight as an
+	// executable file can be.
+	err := os.WriteFile(path, []byte(body), 0o700) // #nosec G306 -- wrapper script must be owner-executable; 0700 is owner-only
+	if err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}
 	return path, nil

--- a/cmd/cordumctl/edge_init.go
+++ b/cmd/cordumctl/edge_init.go
@@ -191,6 +191,11 @@ func writeInitYAML(path string, s edgeInitScaffold) error {
 	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
+	// WriteFile only applies the mode on create; enforce owner-only perms on
+	// `--force` re-runs over a pre-existing, looser-permissioned file too.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
 	return nil
 }
 
@@ -213,6 +218,9 @@ func writeInitWrapper(cwd string, _ edgeInitScaffold) (string, error) {
 		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 			return "", fmt.Errorf("write %s: %w", path, err)
 		}
+		if err := os.Chmod(path, 0o600); err != nil {
+			return "", fmt.Errorf("chmod %s: %w", path, err)
+		}
 		return path, nil
 	}
 	path := filepath.Join(cwd, "cordum-claude.sh")
@@ -223,6 +231,11 @@ func writeInitWrapper(cwd string, _ edgeInitScaffold) (string, error) {
 	err := os.WriteFile(path, []byte(body), 0o700) // #nosec G306 -- wrapper script must be owner-executable; 0700 is owner-only
 	if err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
+	}
+	// Enforce the mode on re-runs over a pre-existing, looser-permissioned file.
+	chmodErr := os.Chmod(path, 0o700) // #nosec G302 -- wrapper script must be owner-executable; 0700 is owner-only
+	if chmodErr != nil {
+		return "", fmt.Errorf("chmod %s: %w", path, chmodErr)
 	}
 	return path, nil
 }

--- a/cmd/cordumctl/mcp_attach_common.go
+++ b/cmd/cordumctl/mcp_attach_common.go
@@ -173,7 +173,7 @@ func RollbackAttach(adapter AttachAdapter, stdout io.Writer) int {
 // (nil, false, err) for any other IO error. Used by preview + apply to
 // distinguish "absent" from "broken".
 func readMaybeMissing(path string) ([]byte, bool, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- operator-supplied MCP config path; cordumctl runs with the invoking user's own privileges (no privilege boundary crossed)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, true, nil
@@ -200,7 +200,7 @@ func backupExistingFile(path string, payload []byte) (string, error) {
 // /tmp is mounted separately from the user's home).
 func atomicWriteAttachConfig(path string, payload []byte) error {
 	clean := filepath.Clean(path)
-	if err := os.MkdirAll(filepath.Dir(clean), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(clean), 0o750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(clean), err)
 	}
 	dir := filepath.Dir(clean)
@@ -255,7 +255,7 @@ func newestBackup(path string) (string, error) {
 // copyFile reads src and writes dst atomically. Used as the
 // cross-filesystem rollback fallback when os.Rename returns EXDEV.
 func copyFile(src, dst string) error {
-	data, err := os.ReadFile(src)
+	data, err := os.ReadFile(src) // #nosec G304 -- rollback source derived from the operator-supplied config path; cordumctl runs with the invoking user's own privileges
 	if err != nil {
 		return err
 	}

--- a/cmd/cordumctl/shadow_remediate.go
+++ b/cmd/cordumctl/shadow_remediate.go
@@ -83,7 +83,7 @@ func readFindingInput(path string, stdin io.Reader) ([]byte, error) {
 	if path == "-" {
 		return io.ReadAll(io.LimitReader(stdin, 64*1024))
 	}
-	return os.ReadFile(path)
+	return os.ReadFile(path) // #nosec G304 -- operator-supplied finding-input path; cordumctl runs with the invoking user's own privileges
 }
 
 // generatePlanFromRaw inspects the JSON payload to choose between the

--- a/core/controlplane/gateway/handlers_identity_admin_error_codes.go
+++ b/core/controlplane/gateway/handlers_identity_admin_error_codes.go
@@ -1,8 +1,8 @@
 package gateway
 
 const (
-	errorCodeAuthInvalidCredentials = "AUTH_INVALID_CREDENTIALS"
-	errorCodeAuthTokenInvalid       = "AUTH_TOKEN_INVALID"
+	errorCodeAuthInvalidCredentials = "AUTH_INVALID_CREDENTIALS" // #nosec G101 -- API error-code identifier returned to clients, not a credential
+	errorCodeAuthTokenInvalid       = "AUTH_TOKEN_INVALID"       // #nosec G101 -- API error-code identifier returned to clients, not a credential
 	errorCodeAuthOIDCCallbackFailed = "AUTH_OIDC_CALLBACK_FAILED"
 	errorCodeAuthRequestInvalid     = "AUTH_REQUEST_INVALID"
 	errorCodeAuthPasswordInvalid    = "AUTH_PASSWORD_INVALID"
@@ -36,8 +36,8 @@ const (
 	errorCodeTopicSchemaViolation = "TOPIC_SCHEMA_VIOLATION"
 	errorCodeTopicNotFound        = "TOPIC_NOT_FOUND"
 
-	errorCodeWorkerCredBindingInvalid = "WORKER_CRED_BINDING_INVALID"
-	errorCodeWorkerCredNotFound       = "WORKER_CRED_NOT_FOUND"
+	errorCodeWorkerCredBindingInvalid = "WORKER_CRED_BINDING_INVALID" // #nosec G101 -- API error-code identifier returned to clients, not a credential
+	errorCodeWorkerCredNotFound       = "WORKER_CRED_NOT_FOUND"       // #nosec G101 -- API error-code identifier returned to clients, not a credential
 
 	errorCodeWorkerSessionInvalid = "WORKER_SESSION_INVALID"
 	errorCodeWorkerNotFound       = "WORKER_NOT_FOUND"

--- a/core/edge/agentd/gateway_client.go
+++ b/core/edge/agentd/gateway_client.go
@@ -53,7 +53,7 @@ func NewGatewayClient(cfg GatewayClientConfig) (*GatewayClient, error) {
 	if client == nil {
 		httpClient := &http.Client{Timeout: timeout}
 		if caFile := strings.TrimSpace(cfg.TLSCAFile); caFile != "" {
-			pem, err := os.ReadFile(caFile)
+			pem, err := os.ReadFile(caFile) // #nosec G304 -- operator-configured TLS CA file path set at agentd startup; not request-derived
 			if err != nil {
 				return nil, fmt.Errorf("read TLS CA file %q: %w", caFile, err)
 			}

--- a/core/edge/agentd/local_server.go
+++ b/core/edge/agentd/local_server.go
@@ -524,7 +524,7 @@ func subtleMismatch(got, want string) bool {
 	copy(gotPadded[:], got)
 	copy(wantPadded[:], want)
 
-	match := subtle.ConstantTimeEq(int32(len(got)), int32(len(want)))
+	match := subtle.ConstantTimeEq(int32(len(got)), int32(len(want))) // #nosec G115 -- subtle.ConstantTimeEq requires int32; nonce lengths are tiny/bounded and the check must stay branch-free for constant time
 	match &= subtle.ConstantTimeLessOrEq(1, len(got))
 	match &= subtle.ConstantTimeLessOrEq(1, len(want))
 	match &= subtle.ConstantTimeLessOrEq(len(got), subtleMismatchPadLen)
@@ -549,7 +549,7 @@ func PrepareUnixSocketPath(_ context.Context, socketPath string) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket dir: %w", err)
 	}
-	_ = os.Chmod(dir, 0o700)
+	_ = os.Chmod(dir, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
 	if info, err := os.Lstat(socketPath); err == nil {
 		if info.Mode()&os.ModeSocket == 0 {
 			return fmt.Errorf("refusing to remove non-socket path %s", socketPath)

--- a/core/edge/agentd/local_server.go
+++ b/core/edge/agentd/local_server.go
@@ -549,7 +549,10 @@ func PrepareUnixSocketPath(_ context.Context, socketPath string) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create socket dir: %w", err)
 	}
-	_ = os.Chmod(dir, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
+	chmodErr := os.Chmod(dir, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
+	if chmodErr != nil {
+		return fmt.Errorf("harden socket dir perms: %w", chmodErr)
+	}
 	if info, err := os.Lstat(socketPath); err == nil {
 		if info.Mode()&os.ModeSocket == 0 {
 			return fmt.Errorf("refusing to remove non-socket path %s", socketPath)

--- a/core/edge/agentd/state_store.go
+++ b/core/edge/agentd/state_store.go
@@ -63,7 +63,7 @@ func NewFileStateStore(root string) (*FileStateStore, error) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		return nil, fmt.Errorf("create state root: %w", err)
 	}
-	_ = os.Chmod(root, 0o700)
+	_ = os.Chmod(root, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
 	store := &FileStateStore{root: root, strictPerms: stateStoreStrictPermsEnabled()}
 	if err := store.verifyRootPermissions(); err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (s *FileStateStore) Save(_ context.Context, state SessionState) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create session state dir: %w", err)
 	}
-	_ = os.Chmod(dir, 0o700)
+	_ = os.Chmod(dir, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
 	if err := s.hardenPath(dir); err != nil {
 		return err
 	}

--- a/core/edge/claude/launcher.go
+++ b/core/edge/claude/launcher.go
@@ -133,7 +133,10 @@ func LaunchEdgeClaude(ctx context.Context, opts LaunchOptions) (LaunchResult, er
 	if err := os.MkdirAll(cfg.StateDir, 0o700); err != nil {
 		return LaunchResult{}, fmt.Errorf("create agentd state dir: %w", err)
 	}
-	_ = os.Chmod(cfg.StateDir, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
+	chmodErr := os.Chmod(cfg.StateDir, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
+	if chmodErr != nil {
+		return LaunchResult{}, fmt.Errorf("harden agentd state dir perms: %w", chmodErr)
+	}
 	agentd, err := startLaunchAgentd(ctx, cfg, opts, meta, stderr)
 	if err != nil {
 		return LaunchResult{}, err

--- a/core/edge/claude/launcher.go
+++ b/core/edge/claude/launcher.go
@@ -133,7 +133,7 @@ func LaunchEdgeClaude(ctx context.Context, opts LaunchOptions) (LaunchResult, er
 	if err := os.MkdirAll(cfg.StateDir, 0o700); err != nil {
 		return LaunchResult{}, fmt.Errorf("create agentd state dir: %w", err)
 	}
-	_ = os.Chmod(cfg.StateDir, 0o700)
+	_ = os.Chmod(cfg.StateDir, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
 	agentd, err := startLaunchAgentd(ctx, cfg, opts, meta, stderr)
 	if err != nil {
 		return LaunchResult{}, err

--- a/core/edge/claude/launcher_helpers.go
+++ b/core/edge/claude/launcher_helpers.go
@@ -55,7 +55,7 @@ func prepareLaunchTempRoot(parent string) (string, func(), error) {
 	if err != nil {
 		return "", nil, fmt.Errorf("create launcher temp dir: %w", err)
 	}
-	_ = os.Chmod(root, 0o700)
+	_ = os.Chmod(root, 0o700) // #nosec G302 -- directory needs the owner execute bit to be traversable; 0700 is owner-only
 	return root, func() { removeAllWithRetry(root, 2*time.Second, 20*time.Millisecond) }, nil
 }
 

--- a/core/edge/claude/launcher_metadata.go
+++ b/core/edge/claude/launcher_metadata.go
@@ -178,7 +178,7 @@ func waitForLaunchStateOrAgentdExit(ctx context.Context, dir string, timeout tim
 func readFirstLaunchState(dir string) (launchSessionState, bool) {
 	matches, _ := filepath.Glob(filepath.Join(dir, "*", "state.json"))
 	for _, path := range matches {
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) // #nosec G304 -- path is internally derived from a glob of the 0700 agentd state dir created by this process; not external input
 		if err != nil {
 			continue
 		}

--- a/core/edge/claude/managed_settings_verify.go
+++ b/core/edge/claude/managed_settings_verify.go
@@ -90,7 +90,7 @@ func VerifyManagedSettings(data []byte) (ManagedSettingsVerifyResult, error) {
 // VerifyManagedSettings on the contents. Returns a non-nil error for IO
 // failures, oversized files, or unparseable JSON.
 func VerifyManagedSettingsFromPath(path string) (ManagedSettingsVerifyResult, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) // #nosec G304 -- operator/config-supplied managed-settings.json path, read locally with a size cap; no remote-attacker input
 	if err != nil {
 		return ManagedSettingsVerifyResult{}, fmt.Errorf("open managed-settings.json: %w", err)
 	}

--- a/core/edge/runtimeingest/adapter.go
+++ b/core/edge/runtimeingest/adapter.go
@@ -498,7 +498,7 @@ func (a *Adapter) shouldAccept(sourceID string, env RuntimeEventEnvelope) bool {
 	}
 	h := fnv.New64a()
 	_, _ = fmt.Fprintf(h, "%s|%s|%s", sourceID, env.Kind, env.SourceEventID)
-	return int(h.Sum64()%uint64(a.sampleDen)) < a.sampleNum
+	return int(h.Sum64()%uint64(a.sampleDen)) < a.sampleNum // #nosec G115 -- modulo by the positive int sampleDen yields a value in [0, sampleDen), which always fits int
 }
 
 // DecodeBatch decodes the wire batch with strict-schema enforcement so

--- a/core/edge/safeexec/safeexec.go
+++ b/core/edge/safeexec/safeexec.go
@@ -44,7 +44,7 @@ func CommandContext(ctx context.Context, argv0 string, args []string, opts Optio
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- hardened wrapper: name is allowlist-normalized by NormalizeExecutablePath and args/arg-paths/env are validated above
 	cmd.Env = env
 	if strings.TrimSpace(opts.Dir) != "" {
 		dir, err := NormalizeDir(opts.Dir, nil)

--- a/core/edge/safeexec/safeexec.go
+++ b/core/edge/safeexec/safeexec.go
@@ -44,7 +44,7 @@ func CommandContext(ctx context.Context, argv0 string, args []string, opts Optio
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- hardened wrapper: name is allowlist-normalized by NormalizeExecutablePath and args/arg-paths/env are validated above
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- hardened wrapper: NormalizeExecutablePath resolves name to an absolute path (bare names via LookPath, traversal rejected, optional allow-prefix gate) so exec does no implicit PATH lookup; args/arg-paths/env validated above
 	cmd.Env = env
 	if strings.TrimSpace(opts.Dir) != "" {
 		dir, err := NormalizeDir(opts.Dir, nil)
@@ -75,10 +75,20 @@ func NormalizeExecutablePath(argv0 string, allowedPrefixes []string) (string, er
 	if containsTraversal(raw) {
 		return "", fmt.Errorf("safeexec: argv0 path traversal rejected: %s", raw)
 	}
+	candidate := raw
 	if !hasPath {
-		return filepath.Clean(raw), nil
+		// A bare name (no path separator) would otherwise be resolved by
+		// exec.Command against $PATH at spawn time, which an attacker who
+		// controls PATH can influence. Resolve it explicitly now so the
+		// caller always execs a fully-qualified path and the result goes
+		// through the same allow-prefix gate as a path-qualified argv0.
+		resolved, err := exec.LookPath(raw)
+		if err != nil {
+			return "", fmt.Errorf("safeexec: resolve argv0 %q: %w", raw, err)
+		}
+		candidate = resolved
 	}
-	abs, err := filepath.Abs(filepath.Clean(raw))
+	abs, err := filepath.Abs(filepath.Clean(candidate))
 	if err != nil {
 		return "", fmt.Errorf("safeexec: normalize argv0: %w", err)
 	}

--- a/core/edge/safeexec/safeexec_test.go
+++ b/core/edge/safeexec/safeexec_test.go
@@ -108,6 +108,41 @@ func TestNormalizeExecutablePathRejectsAbsoluteTraversal(t *testing.T) {
 	}
 }
 
+// A bare name must be resolved to an absolute path here rather than left for
+// exec.Command to look up against $PATH at spawn time.
+func TestNormalizeExecutablePathResolvesBareNameToAbsolute(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX exec-bit / PATHEXT semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	const name = "cordum-bare-helper"
+	exe := filepath.Join(dir, name)
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	got, err := NormalizeExecutablePath(name, nil)
+	if err != nil {
+		t.Fatalf("NormalizeExecutablePath(bare) returned error: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("bare name resolved to non-absolute path %q", got)
+	}
+	if filepath.Base(got) != name {
+		t.Fatalf("resolved path %q does not end in %q", got, name)
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Fatalf("resolved path %q not statable: %v", got, err)
+	}
+}
+
+func TestNormalizeExecutablePathRejectsUnresolvableBareName(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir: nothing resolves
+	if _, err := NormalizeExecutablePath("cordum-definitely-not-on-path-xyz", nil); err == nil {
+		t.Fatalf("NormalizeExecutablePath resolved a bare name that is not on PATH")
+	}
+}
+
 func TestValidateArgPathsRejectsTraversalAndOutsidePrefix(t *testing.T) {
 	base := t.TempDir()
 	if err := ValidateArgPaths([]string{"--settings", filepath.Join(base, "settings.json")}, base, []string{base}); err != nil {

--- a/sdk/conformance/harness/go/main.go
+++ b/sdk/conformance/harness/go/main.go
@@ -190,7 +190,7 @@ func loadFixtures(dir string) ([]*Fixture, error) {
 	var mu sync.Mutex
 	var out []*Fixture
 	for _, p := range paths {
-		data, err := os.ReadFile(p)
+		data, err := os.ReadFile(p) // #nosec G304 -- conformance dev/test harness reading fixture files from an operator-supplied fixtures dir
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
 		}
@@ -237,7 +237,7 @@ func writeReport(path string, suite *TestSuite) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
-	f, err := os.Create(path)
+	f, err := os.Create(path) // #nosec G304 -- conformance dev/test harness writing a JUnit report to an operator-supplied output path
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

Clears **all 25 open gosec code-scanning alerts** on `main` and makes the **Security Scan** CI job *fail* on new findings instead of running report-only (`-no-fail`).

## Triage (25 findings)

| Rule | Count | Disposition |
|------|-------|-------------|
| G304 | 8 | `#nosec` — operator-supplied / internally-derived paths in CLIs, edge components, and the SDK conformance dev-harness; all run with the invoking user's own privileges (no privilege boundary crossed) |
| G302 | 5 | `#nosec` — `os.Chmod(dir, 0700)` targets **directories**, which need the owner execute bit (gosec wants ≤0600, which breaks dir traversal) |
| G101 | 4 | `#nosec` — `AUTH_*` / `WORKER_CRED_*` are API **error-code identifiers** returned to clients, not credentials |
| G306 | 3 | **real fix** — `cordum.yaml` + `.ps1` wrapper `0644→0600`; `.sh` wrapper `0755→0700` (still owner-executable, annotated) |
| G115 | 3 | `#nosec` — `subtle.ConstantTimeEq` int32 (bounded, must stay branch-free for constant time) + modulo-by-positive-int that is provably in range |
| G301 | 1 | **real fix** — MCP config parent dir `0755→0750` |
| G204 | 1 | `#nosec` — `safeexec` *is* the hardened exec wrapper (argv0 allowlist + arg/env validation upstream) |

Net: **4 real hardening fixes** + **21 justified `#nosec` annotations**, each documenting *why* the site is safe at the call site. A global rule-exclusion was deliberately avoided — it would hide future real bugs of these classes, defeating the new gate.

## CI gate (`.github/workflows/ci.yml`)

- **Latent bug fixed:** gosec scanned `./cmd/... ./core/... ./sdk/...` from the root module, but `sdk` is a **separate module** — so `./sdk/...` matched nothing and the shipped SDK was never actually scanned. gosec now runs **per module**: root (`cmd`+`core`) and `sdk` (`client`+`runtime`).
- Report-only removed: a dedicated **gate step fails the job** on any post-sanitize finding, while SARIF still uploads to the Security tab (`if: always()`).
- SDK SARIF paths re-prefixed to repo root; core keeps the default analysis category so the pre-existing alerts auto-resolve.

## Verification

Local gosec **v2.22.4** with `GOOS=linux` + the CI sanitize filter:

- `cmd` + `core`: **0 findings**
- `sdk` (client+runtime): **0 findings**
- conformance harness: **0 findings**
- Affected-package tests (`cordumctl`, `core/edge/...`) pass — including the assertion that the `.sh` wrapper stays executable.

## Notes

- The 2 conformance-harness alerts (#304/#305) live in a nested module the CI gate intentionally does not scan (dev/test tooling); they are annotated here and dismissed separately as *used in tests*.
- Out of scope: the 4 Dependabot **dependency** advisories on `main` (qs/express) — those are SCA, not gosec SAST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforced stricter owner-only file and directory permissions for generated artifacts and runtime state.
  * CI security scanning now runs separate core and SDK analyses and uploads consolidated findings.

* **Chores**
  * Increased security scan timeout to 15 minutes.
  * Added security-suppression annotations to reduce false positives from scanners.

* **Tests**
  * Added tests validating executable resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->