### PR TITLE
feat(edge): redacted descriptive action targets on governance events (task-6a93a0fc)

### DIFF
--- a/core/edge/observability.go
+++ b/core/edge/observability.go
@@ -708,6 +708,32 @@ func SendSIEMEvent(sender audit.AuditSender, event audit.SIEMEvent) {
 	sender.Send(event)
 }
 
+// actionTargetLabelAllowlist is the HARD-CODED, ORDERED set of classifier
+// descriptor label keys that actionExtra copies from event.Labels into the
+// SIEM Extra map under stable, redaction-safe names. This allowlist is the
+// ONLY thing read from event.Labels for descriptive targeting; actionExtra
+// MUST NEVER range over event.Labels because Labels also carries
+// caller-supplied keys (agent.product and arbitrary context labels) whose
+// values are not safe to surface in the audit trail. Every value the
+// classifier writes under these keys is already a bounded enum or a
+// safeLabelValue (secret-redacted + length-bounded) by the time the gateway
+// merges classification.Labels onto event.Labels (handlers_edge_evaluate.go
+// edgeEvaluateMergeLabels); each copied value is re-bounded via
+// boundedShortString defensively. A slice (not a map) keeps the allowlist a
+// single grep-able list and structurally forbids an accidental range-over-Labels.
+var actionTargetLabelAllowlist = []struct{ src, dst string }{
+	{"path.class", "target_class"},
+	{"path.sensitive_area", "target_sensitive_area"},
+	{"path.traversal", "target_traversal"},
+	{"command.class", "command_class"},
+	{"command.family", "command_family"},
+	{"mcp.server", "mcp_server"},
+	{"mcp.tool", "mcp_tool"},
+	{"mcp.action", "mcp_action"},
+	{"runtime.event", "runtime_event"},
+	{"runtime.host", "runtime_host"},
+}
+
 // actionExtra builds the safe Extra map for an AgentActionEvent.
 func actionExtra(event AgentActionEvent) map[string]string {
 	extra := map[string]string{
@@ -732,8 +758,62 @@ func actionExtra(event AgentActionEvent) map[string]string {
 	if v := strings.TrimSpace(event.ApprovalRef); v != "" {
 		extra["approval_ref"] = boundedShortString(v, 64)
 	}
+	// EDGE governance descriptive targets (task-6a93a0fc): copy ONLY the
+	// hard-coded classifier-descriptor allowlist from event.Labels into Extra
+	// so an incident responder sees WHAT class of thing was targeted (secret
+	// file? destructive shell? MCP mutation?) without ever exposing the raw
+	// path/command/prompt. NEVER range over event.Labels (it carries
+	// caller-supplied keys); each value is re-bounded via boundedShortString.
+	for _, pair := range actionTargetLabelAllowlist {
+		if v := strings.TrimSpace(event.Labels[pair.src]); v != "" {
+			extra[pair.dst] = boundedShortString(v, 64)
+		}
+	}
+	if summary := actionTargetSummary(event); summary != "" {
+		extra["target_summary"] = summary
+	}
 	extra["redaction_status"] = redactionStatusForAction(event)
 	return extra
+}
+
+// actionTargetSummary composes a single compact, pivotable "class:subclass"
+// descriptor for an action from the SAME hard-coded classifier enums that
+// actionTargetLabelAllowlist copies — never from raw input. Priority follows
+// the most security-relevant axis first: shell command, then file path, then
+// MCP call, then runtime event. The result is human-readable AND greppable
+// (e.g. "shell:destructive/filesystem_delete", "file:secret",
+// "mcp:github/create_issue", "runtime:network.connect/api.example.com").
+// Returns "" when the event carries none of the allowlisted descriptors
+// (e.g. nil/empty Labels) so the caller omits the key. Bounded defensively.
+func actionTargetSummary(event AgentActionEvent) string {
+	label := func(key string) string { return strings.TrimSpace(event.Labels[key]) }
+	var summary string
+	switch {
+	case label("command.class") != "":
+		summary = "shell:" + label("command.class")
+		if family := label("command.family"); family != "" {
+			summary += "/" + family
+		}
+	case label("path.class") != "":
+		summary = "file:" + label("path.class")
+		if area := label("path.sensitive_area"); area != "" {
+			summary += "/" + area
+		}
+	case label("mcp.server") != "" || label("mcp.tool") != "" || label("mcp.action") != "":
+		primary := firstNonEmpty(label("mcp.server"), label("mcp.tool"))
+		summary = "mcp:" + primary
+		if secondary := firstNonEmpty(label("mcp.action"), label("mcp.tool")); secondary != "" && secondary != primary {
+			summary += "/" + secondary
+		}
+	case label("runtime.event") != "":
+		summary = "runtime:" + label("runtime.event")
+		if host := label("runtime.host"); host != "" {
+			summary += "/" + host
+		}
+	default:
+		return ""
+	}
+	return boundedShortString(summary, 96)
 }
 
 func redactionStatusForAction(event AgentActionEvent) string {

--- a/core/edge/observability_test.go
+++ b/core/edge/observability_test.go
@@ -814,6 +814,180 @@ func TestEDGE072ActionAuditIncludesReviewerFieldsAndNoRawSecrets(t *testing.T) {
 	}
 }
 
+// TestSIEMEventForActionDescriptiveTargets pins the EDGE governance
+// descriptive-target contract (task-6a93a0fc): actionExtra copies a
+// HARD-CODED allowlist of classifier descriptor labels into Extra under
+// stable names, and actionTargetSummary composes one pivotable
+// class:subclass string from the same enums. Each scenario seeds the
+// classifier labels exactly as edgeEvaluateMergeLabels would have merged
+// them onto event.Labels before the SIEM emit.
+func TestSIEMEventForActionDescriptiveTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		layer       Layer
+		kind        EventKind
+		toolName    string
+		decision    EdgeDecision
+		labels      Labels
+		wantExtra   map[string]string // keys that MUST be present with these exact values
+		wantSummary string
+	}{
+		{
+			name:     "hook bash destructive",
+			layer:    LayerHook,
+			kind:     EventKindHookPreToolUse,
+			toolName: "Bash",
+			decision: DecisionDeny,
+			labels:   Labels{"command.class": "destructive", "command.family": "filesystem_delete"},
+			wantExtra: map[string]string{
+				"command_class":  "destructive",
+				"command_family": "filesystem_delete",
+			},
+			wantSummary: "shell:destructive/filesystem_delete",
+		},
+		{
+			name:     "secret file read with traversal",
+			layer:    LayerHook,
+			kind:     EventKindHookPreToolUse,
+			toolName: "Read",
+			decision: DecisionDeny,
+			labels:   Labels{"path.class": "secret", "path.traversal": "true"},
+			wantExtra: map[string]string{
+				"target_class":     "secret",
+				"target_traversal": "true",
+			},
+			wantSummary: "file:secret",
+		},
+		{
+			name:     "source code auth area",
+			layer:    LayerHook,
+			kind:     EventKindHookPreToolUse,
+			toolName: "Edit",
+			decision: DecisionAllow,
+			labels:   Labels{"path.class": "source_code", "path.sensitive_area": "auth"},
+			wantExtra: map[string]string{
+				"target_class":          "source_code",
+				"target_sensitive_area": "auth",
+			},
+			wantSummary: "file:source_code/auth",
+		},
+		{
+			name:     "mcp mutate",
+			layer:    LayerMCP,
+			kind:     EventKindMCPToolPre,
+			toolName: "create_issue",
+			decision: DecisionRequireApproval,
+			labels:   Labels{"mcp.server": "github", "mcp.tool": "create_issue", "mcp.action": "create_issue"},
+			wantExtra: map[string]string{
+				"mcp_server": "github",
+				"mcp_tool":   "create_issue",
+				"mcp_action": "create_issue",
+			},
+			wantSummary: "mcp:github/create_issue",
+		},
+		{
+			name:     "runtime network connect",
+			layer:    LayerRuntime,
+			kind:     EventKindRuntimeNetworkConnect,
+			decision: DecisionRecorded,
+			labels:   Labels{"runtime.event": "network.connect", "runtime.host": "api.example.com"},
+			wantExtra: map[string]string{
+				"runtime_event": "network.connect",
+				"runtime_host":  "api.example.com",
+			},
+			wantSummary: "runtime:network.connect/api.example.com",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			event := AgentActionEvent{
+				EventID:     "evt-" + tc.name,
+				SessionID:   "edge_sess_targets",
+				ExecutionID: "edge_exec_targets",
+				TenantID:    "tenant-targets",
+				PrincipalID: "principal-targets",
+				Timestamp:   time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+				Layer:       tc.layer,
+				Kind:        tc.kind,
+				ToolName:    tc.toolName,
+				Decision:    tc.decision,
+				Status:      ActionStatusOK,
+				InputHash:   "sha256:" + strings.Repeat("b", 64),
+				Labels:      tc.labels,
+			}
+			got := SIEMEventForAction(event)
+			for k, want := range tc.wantExtra {
+				if got.Extra[k] != want {
+					t.Errorf("Extra[%q] = %q, want %q; full Extra=%#v", k, got.Extra[k], want, got.Extra)
+				}
+			}
+			if got.Extra["target_summary"] != tc.wantSummary {
+				t.Errorf("Extra[target_summary] = %q, want %q", got.Extra["target_summary"], tc.wantSummary)
+			}
+		})
+	}
+}
+
+// TestSIEMEventForActionTargetRedactionBoundary proves the descriptive-target
+// allowlist is the ONLY thing copied into Extra: allowlisted classifier keys
+// appear, but raw input (InputRedacted) and non-allowlisted caller-supplied
+// labels (token, leak, agent.product) never reach any Extra value or the
+// target_summary. This is the redaction boundary the task rail mandates —
+// actionExtra MUST read the hard-coded allowlist only, never range over Labels.
+func TestSIEMEventForActionTargetRedactionBoundary(t *testing.T) {
+	const rawSecret = "ghp_edge6a93secretTOKENvalue0123456789abcd"
+	event := AgentActionEvent{
+		EventID:       "evt-target-redaction",
+		SessionID:     "edge_sess_redaction",
+		ExecutionID:   "edge_exec_redaction",
+		TenantID:      "tenant-redaction",
+		PrincipalID:   "principal-redaction",
+		Timestamp:     time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+		Layer:         LayerHook,
+		Kind:          EventKindHookPreToolUse,
+		ToolName:      "Bash",
+		Decision:      DecisionDeny,
+		Status:        ActionStatusBlocked,
+		InputHash:     "sha256:" + strings.Repeat("c", 64),
+		InputRedacted: map[string]any{"command": rawSecret},
+		Labels: Labels{
+			// allowlisted classifier descriptors — MUST be copied.
+			"command.class":  "destructive",
+			"command.family": "filesystem_delete",
+			// caller-supplied / non-allowlisted — MUST NOT be copied.
+			"token":         rawSecret,
+			"leak":          rawSecret,
+			"agent.product": "claude-code/" + rawSecret,
+		},
+	}
+	got := SIEMEventForAction(event)
+
+	// Allowlisted descriptors are present and pivotable.
+	if got.Extra["command_class"] != "destructive" {
+		t.Errorf("Extra[command_class] = %q, want destructive", got.Extra["command_class"])
+	}
+	if got.Extra["command_family"] != "filesystem_delete" {
+		t.Errorf("Extra[command_family] = %q, want filesystem_delete", got.Extra["command_family"])
+	}
+	if got.Extra["target_summary"] != "shell:destructive/filesystem_delete" {
+		t.Errorf("Extra[target_summary] = %q, want shell:destructive/filesystem_delete", got.Extra["target_summary"])
+	}
+
+	// No raw secret anywhere in Extra (keys or values), including target_summary.
+	for k, v := range got.Extra {
+		if strings.Contains(k, rawSecret) || strings.Contains(v, rawSecret) {
+			t.Errorf("Extra leaked raw secret in %q=%q", k, v)
+		}
+	}
+
+	// Non-allowlisted / caller-supplied label keys must never be copied,
+	// neither under their raw key nor any derived key.
+	for _, banned := range []string{"token", "leak", "agent.product", "agent_product"} {
+		if _, ok := got.Extra[banned]; ok {
+			t.Errorf("Extra copied non-allowlisted caller label %q: %#v", banned, got.Extra)
+		}
+	}
+}
+
 // TestSIEMEventForSessionLifecycle pins start/end event types + severity
 // (info on clean end, high on failed/degraded).
 func TestSIEMEventForSessionLifecycle(t *testing.T) {

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -96,6 +96,24 @@ mode/component, and stable reason codes. Raw prompts, tool payloads, signed URLs
 approval reason text, `InputRedacted` maps, arbitrary labels, bearer tokens, and
 API keys must never be placed in SIEM `extra`.
 
+**Descriptive action targets.** `edge.action_denied` and `edge.policy_decision`
+additionally carry a hard-coded allowlist of classifier-derived descriptors so a
+responder can see *what class of thing* was targeted without any raw
+path/command/prompt: `target_class` (`secret`/`source_code`/`file`/`unknown`),
+`target_sensitive_area` (`auth`), `target_traversal` (`true`), `command_class`
+(`destructive`/`deploy`/`network`/`dependency_change`/`safe`/`unknown`),
+`command_family` (e.g. `filesystem_delete`/`git_push`/`network_egress`/`install`),
+`mcp_server` / `mcp_tool` / `mcp_action`, and `runtime_event`
+(`process.exec`/`file.read`/`file.write`/`network.connect`/`dns.query`) /
+`runtime_host`. A composed `target_summary` gives one pivotable string —
+`shell:<class>/<family>`, `file:<class>/<area>`, `mcp:<server>/<action>`, or
+`runtime:<event>/<host>` (e.g. `shell:destructive/filesystem_delete`,
+`file:secret`, `mcp:github/create_issue`). Each key is copied from classifier
+output only (never raw input), bounded, and emitted only when present;
+caller-supplied labels are never copied. The full classifier label set is
+available to auditors via `events[].labels` in the session export bundle
+(`edge.export.v1`, unchanged).
+
 For destructive Edge actions, `ProvenanceGate` accepts only a resolved approval
 audit event with decision `approved` or `approve` and exact tenant,
 `approval_ref`, and `action_hash` matches. A requested-only approval event does

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -49,6 +49,18 @@ Raw prompts, tool payloads, transcripts, command output, API keys, bearer tokens
 and hook nonces must not be stored in Edge events. Use redacted summaries,
 stable hashes, and artifact pointer metadata.
 
+Governance events (`edge.action_denied`, `edge.policy_decision`) surface
+*descriptive* action targets without violating that rule: a hard-coded allowlist
+of classifier-derived enums is copied into the audit `extra` map — `target_class`,
+`target_sensitive_area`, `target_traversal`, `command_class`, `command_family`,
+`mcp_server` / `mcp_tool` / `mcp_action`, `runtime_event` / `runtime_host`, plus a
+composed `target_summary` (e.g. `shell:destructive/filesystem_delete`,
+`file:secret`, `mcp:github/create_issue`). No raw file path, command, prompt, or
+secret is ever written — only these safe, bounded descriptors, and caller-supplied
+labels are never copied. Auditors needing the complete label set read
+`events[].labels` in the session export bundle (`edge.export.v1`, unchanged). See
+[Edge observability](edge/observability.md) for the full key/value reference.
+
 ## Five P0 capabilities
 
 1. **Sessions and executions** register, heartbeat, end, and inspect governed

--- a/docs/edge/observability.md
+++ b/docs/edge/observability.md
@@ -236,13 +236,40 @@ errors, or copied into audit `extra`.
 
 | Builder | Allowed `extra` keys |
 | --- | --- |
-| `actionExtra` | `session_id`, `execution_id`, `event_id`, `layer`, `kind`, `tool_name`, `input_hash`, `policy_snapshot`, `tier`, `approval_ref`, `redaction_status`. |
+| `actionExtra` | `session_id`, `execution_id`, `event_id`, `layer`, `kind`, `tool_name`, `input_hash`, `policy_snapshot`, `tier`, `approval_ref`, `redaction_status`, plus the classifier descriptive targets `target_class`, `target_sensitive_area`, `target_traversal`, `command_class`, `command_family`, `mcp_server`, `mcp_tool`, `mcp_action`, `runtime_event`, `runtime_host`, and the composed `target_summary` (each emitted only when the classifier produced it). |
 | `sessionExtra` | `session_id`, `mode`, `status`, `agent_product`. |
 | `executionExtra` | `execution_id`, `session_id`, `adapter`, `mode`, `status`, `workflow_run_id`, `step_id`, `attempt`, `event_counts`. |
 | `approvalExtra` / approval requested | `approval_ref`, `session_id`, `execution_id`, `event_id`, `rule_id`, `policy_snapshot`, plus bounded `action_hash` / `input_hash` when available. |
 | `approvalExtra` / approval resolved | `approval_ref` plus bounded terminal metadata such as `action_hash`, `input_hash`, and `policy_snapshot`. This is the only approval lifecycle event kind that can satisfy `ProvenanceGate` for approved destructive actions. |
 | `artifact` export | `artifact_type`, `result`, `session_id`, `execution_id`, `event_id`, `sha256`, `redaction_level`, `retention_class`. Raw artifact URI is never included. |
 | degraded / fail-closed | `mode`, `component`, `reason_code`. |
+
+#### Descriptive action targets (`actionExtra`)
+
+`edge.action_denied` / `edge.policy_decision` copy a **hard-coded allowlist** of
+classifier descriptors from `AgentActionEvent.Labels` into `extra` so a responder
+can see *what class of thing* an action targeted without any raw path/command/
+prompt. The allowlist is the only thing read from `Labels`; caller-supplied label
+keys (e.g. `agent.product`) are never copied, and `actionExtra` never ranges over
+`Labels`.
+
+| `extra` key | Source label | Values |
+| --- | --- | --- |
+| `target_class` | `path.class` | `secret`, `source_code`, `file`, `unknown` |
+| `target_sensitive_area` | `path.sensitive_area` | `auth` |
+| `target_traversal` | `path.traversal` | `true` |
+| `command_class` | `command.class` | `destructive`, `deploy`, `network`, `dependency_change`, `safe`, `unknown` |
+| `command_family` | `command.family` | e.g. `filesystem_delete`, `git_push`, `network_egress`, `install` |
+| `mcp_server` / `mcp_tool` / `mcp_action` | `mcp.server` / `mcp.tool` / `mcp.action` | classifier `safeLabelValue` (secret-redacted, bounded) |
+| `runtime_event` | `runtime.event` | `process.exec`, `file.read`, `file.write`, `network.connect`, `dns.query` |
+| `runtime_host` | `runtime.host` | classifier `safeLabelValue` (secret-redacted, bounded) |
+| `target_summary` | composed from the enums above | `shell:<class>/<family>`, `file:<class>/<area>`, `mcp:<server>/<action>`, `runtime:<event>/<host>` |
+
+`target_summary` is a single compact, pivotable string (e.g.
+`shell:destructive/filesystem_delete`, `file:secret`, `mcp:github/create_issue`)
+composed only from the enums above — never from raw input. Every value passes
+through `boundedShortString`. Auditors needing the full classifier label set read
+`events[].labels` in the session export bundle (`edge.export.v1`, unchanged).
 
 Forbidden raw fields and payloads must never appear in audit JSON or `extra`:
 `raw_prompt`, `raw_tool_input`, `raw_stderr`, `secret_token`, `.env_content`,


### PR DESCRIPTION
## task-6a93a0fc — Audit: redacted-but-descriptive action target on edge governance events

### Problem
`edge.action_denied` / `edge.policy_decision` SIEM events surfaced only `tool_name` + `input_hash`, so an incident responder saw "a Read was denied" but not **what class of thing** was targeted (secret file? destructive shell? MCP mutation?).

### Change
`actionExtra` (core/edge/observability.go) now copies a **hard-coded allowlist** of classifier-derived descriptors from `event.Labels` into the SIEM `Extra` map, and adds a composed, pivotable `target_summary`:

| `extra` key | source label |
| --- | --- |
| `target_class` / `target_sensitive_area` / `target_traversal` | `path.class` / `path.sensitive_area` / `path.traversal` |
| `command_class` / `command_family` | `command.class` / `command.family` |
| `mcp_server` / `mcp_tool` / `mcp_action` | `mcp.server` / `mcp.tool` / `mcp.action` |
| `runtime_event` / `runtime_host` | `runtime.event` / `runtime.host` |
| `target_summary` | composed: `shell:<class>/<family>`, `file:<class>/<area>`, `mcp:<server>/<action>`, `runtime:<event>/<host>` |

### Redaction boundary (rails)
- The allowlist (a **slice**, not a map) is the ONLY thing read from `Labels` — `actionExtra` **never ranges** over `Labels` (which also carries caller-supplied keys like `agent.product`).
- Values come only from classifier output (enums or already-`safeLabelValue`-redacted), never raw input; each is re-bounded via `boundedShortString`.
- No raw file path / command / prompt / secret reaches `Extra` or the summary.
- `edge.export.v1` is **not** bumped; `EventLogAttrs` and `export.go` untouched. Auditors needing the full label set read `events[].labels` in the session export bundle.

### Tests
- `TestSIEMEventForActionDescriptiveTargets` — 5 layer scenarios (hook bash-destructive, secret-file read + traversal, source_code+auth, MCP mutate, runtime network).
- `TestSIEMEventForActionTargetRedactionBoundary` — injects a secret into `InputRedacted` + non-allowlisted labels (`token`/`leak`/`agent.product`); asserts allowlisted keys appear, no raw secret in any Extra value/summary, caller labels never copied.
- `go test ./core/edge/... -count=3` → all `ok` (no `-race`; CGO off per CLAUDE.md). `go vet` + `gofmt` clean.

### Docs
`docs/audit.md`, `docs/edge.md`, `docs/edge/observability.md` — new Extra keys + value enums + `target_summary` format; no-raw-content invariant reaffirmed.

Dashboard: deferred (the `extra` map renders as JSON, so new keys appear automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SIEM/audit events with improved governance target descriptors and summary composition.

* **Documentation**
  * Clarified Edge governance event recording practices and audit field specifications.
  * Updated observability documentation detailing safe descriptor fields for audit events.

* **Tests**
  * Added comprehensive test coverage for SIEM event descriptor handling and redaction safeguards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->