### PR TITLE
feat(audit): governance/event-type filtering on compliance export + events endpoint (task-7f0f57bf)

### DIFF
--- a/cordum-helm/values.yaml
+++ b/cordum-helm/values.yaml
@@ -555,6 +555,11 @@ audit:
       logStream: "" # CORDUM_AUDIT_EXPORT_CW_LOG_STREAM
       awsRegion: "" # AWS_REGION
   bufferSize: 1000 # CORDUM_AUDIT_BUFFER_SIZE
+  # Fraction (0.0-1.0) of /api/v1/audit/events reads that emit an
+  # audit.read.events meta-event. Recommended prod default 0.0: raising it
+  # floods the chain with routine system.auth/audit.read.events rows that bury
+  # governance signal. For a governance-focused artifact, filter the export/read
+  # with ?category=governance instead of tuning this rate (see docs/audit.md §2/§7).
   readSampleRate: 0.0 # CORDUM_AUDIT_READ_SAMPLE_RATE
 
 outputPolicy:

--- a/core/audit/export_compliance.go
+++ b/core/audit/export_compliance.go
@@ -75,6 +75,25 @@ type ExportManifest struct {
 	TruncatedAtMax       bool                   `json:"truncated_at_max"`
 	MaxEventsCap         int                    `json:"max_events_cap"`
 	RetentionBoundarySeq int64                  `json:"retention_boundary_seq,omitempty"`
+	// RowFilter records the event_type/severity/category filter applied to
+	// the EVENT ROWS, when any. It is additive and self-describing: EventCount
+	// above is the POST-filter row count, while ChainVerification covers the
+	// FULL range — so a filtered export is never mistaken for a tamper gap.
+	// Omitted entirely when no filter is set.
+	RowFilter *ExportRowFilter `json:"row_filter,omitempty"`
+	// RowFilterApplied is always present so an auditor can distinguish "no
+	// filter" from "old export format" without ambiguity. False on every
+	// unfiltered export (byte-stable companion to TruncatedAtMax).
+	RowFilterApplied bool `json:"row_filter_applied"`
+}
+
+// ExportRowFilter is the machine-readable record of the row filter applied to
+// a compliance export. Fields mirror the ComplianceExportOptions filter knobs;
+// empty fields are omitted so the manifest only advertises active predicates.
+type ExportRowFilter struct {
+	EventType string `json:"event_type,omitempty"`
+	Severity  string `json:"severity,omitempty"`
+	Category  string `json:"category,omitempty"`
 }
 
 // BundleLookupFn resolves the signed policy bundles that were active
@@ -89,17 +108,56 @@ type ChainVerifierFn func(ctx context.Context, client redis.UniversalClient, str
 
 // ComplianceExportOptions configures a single export call.
 type ComplianceExportOptions struct {
-	TenantID     string
-	StreamKey    string
-	From         time.Time
-	To           time.Time
-	Format       ComplianceExportFormat
-	Excel        bool
-	MaxEvents    int
+	TenantID  string
+	StreamKey string
+	From      time.Time
+	To        time.Time
+	Format    ComplianceExportFormat
+	Excel     bool
+	MaxEvents int
+	// EventType / Severity / Category filter the EMITTED ROWS only — never
+	// the chain verification, which always runs over the full range. EventType
+	// and Severity match case-insensitively; Category ("governance"|"routine")
+	// is resolved per row via CategoryFor(ev.EventType). Empty means "no
+	// constraint on that dimension"; all empty means every in-range row emits.
+	EventType    string
+	Severity     string
+	Category     string
 	SOC2Mapping  SOC2Mapping
 	SOC2Legend   map[string]string
 	BundleLookup BundleLookupFn
 	Verifier     ChainVerifierFn
+}
+
+// rowMatches reports whether ev passes the configured row filter. Returns true
+// when no filter is set (the common, unfiltered path). EventType and Severity
+// compare case-insensitively; Category is derived from CategoryFor so the
+// caller filters by governance/routine without enumerating event types.
+func (o ComplianceExportOptions) rowMatches(ev SIEMEvent) bool {
+	if o.EventType != "" && !strings.EqualFold(ev.EventType, o.EventType) {
+		return false
+	}
+	if o.Severity != "" && !strings.EqualFold(ev.Severity, o.Severity) {
+		return false
+	}
+	if o.Category != "" && CategoryFor(ev.EventType) != o.Category {
+		return false
+	}
+	return true
+}
+
+// rowFilter returns the typed manifest record of the active row filter, or nil
+// when no dimension is constrained. Mirrors rowMatches: a nil result means
+// every in-range row is emitted.
+func (o ComplianceExportOptions) rowFilter() *ExportRowFilter {
+	if o.EventType == "" && o.Severity == "" && o.Category == "" {
+		return nil
+	}
+	return &ExportRowFilter{
+		EventType: o.EventType,
+		Severity:  o.Severity,
+		Category:  o.Category,
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -207,6 +265,14 @@ func WriteComplianceExport(
 		SOC2Legend:   cloneStringMap(opts.SOC2Legend),
 		MaxEventsCap: opts.MaxEvents,
 	}
+	// Record any row filter up-front so it is present in the manifest line the
+	// NDJSON path writes BEFORE the walk (and in the CSV comment). The filter
+	// only affects EVENT ROWS — ChainVerification below still covers the full
+	// range, making a filtered export self-describing rather than a tamper gap.
+	if filter := opts.rowFilter(); filter != nil {
+		manifest.RowFilter = filter
+		manifest.RowFilterApplied = true
+	}
 
 	// --- 1) Policy snapshots. Surfaced even on an empty event stream
 	// so a dev tenant with no activity still shows the current bundle
@@ -290,6 +356,14 @@ func writeNDJSONExport(
 	count := 0
 	truncated := false
 	err = walkChainStream(ctx, client, opts.StreamKey, opts.From, opts.To, int64(opts.MaxEvents), func(ev SIEMEvent) error {
+		// Row filter applies ONLY here, at the top of the emit callback —
+		// never in the opts.Verifier call above or in walkChainStream's cursor
+		// advance, so chain verification stays full-range. `count` below
+		// increments only on a successful write, so EventCount automatically
+		// becomes the POST-filter total.
+		if !opts.rowMatches(ev) {
+			return nil
+		}
 		controls := opts.SOC2Mapping.ControlsFor(ev)
 		line, err := buildNDJSONEventLine(ev, controls)
 		if err != nil {
@@ -426,6 +500,12 @@ func writeCSVExport(
 	count := 0
 	truncated := false
 	err = walkChainStream(ctx, client, opts.StreamKey, opts.From, opts.To, int64(opts.MaxEvents), func(ev SIEMEvent) error {
+		// Row filter applies ONLY here (see writeNDJSONExport for the full
+		// invariant note): the opts.Verifier pass above already covered the
+		// full range; this gate only decides which rows are written.
+		if !opts.rowMatches(ev) {
+			return nil
+		}
 		controls := opts.SOC2Mapping.ControlsFor(ev)
 		row := buildCSVRow(ev, controls)
 		if err := csvW.Write(row); err != nil {

--- a/core/audit/export_compliance_test.go
+++ b/core/audit/export_compliance_test.go
@@ -396,3 +396,320 @@ func TestBuildNDJSONEventLine_SOC2SortedAndNonEmpty(t *testing.T) {
 		t.Errorf("type = %v, want event", parsed["type"])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Row filter (event_type / severity / category) — task-7f0f57bf
+// ---------------------------------------------------------------------------
+
+// TestWriteComplianceExport_UnfilteredByteIdentical is the DoD-2 regression:
+// with NO row filter set, the export is byte-identical to today. Each emitted
+// event line must equal a fresh buildNDJSONEventLine recomputation, the
+// manifest must carry row_filter_applied:false with no row_filter object, and
+// no rows may be dropped.
+func TestWriteComplianceExport_UnfilteredByteIdentical(t *testing.T) {
+	client, cleanup := newExportClient(t)
+	defer cleanup()
+
+	chainer := NewChainer(client, "")
+	streamKey := chainer.StreamKey("default")
+	seeded := seedChainEvents(t, client, "default", 3, nil) // all governance (safety.decision)
+
+	var buf bytes.Buffer
+	manifest, err := WriteComplianceExport(context.Background(), &buf, client, ComplianceExportOptions{
+		TenantID:  "default",
+		StreamKey: streamKey,
+		Format:    ComplianceExportFormatJSON,
+		From:      time.Now().Add(-1 * time.Hour),
+		To:        time.Now().Add(1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("WriteComplianceExport: %v", err)
+	}
+
+	if manifest.RowFilterApplied {
+		t.Errorf("unfiltered: RowFilterApplied = true, want false")
+	}
+	if manifest.RowFilter != nil {
+		t.Errorf("unfiltered: RowFilter = %+v, want nil", manifest.RowFilter)
+	}
+	if manifest.EventCount != 3 {
+		t.Errorf("unfiltered: EventCount = %d, want 3 (no rows dropped)", manifest.EventCount)
+	}
+
+	// Collect emitted event lines + the raw manifest line.
+	var manifestLine string
+	var eventLines []string
+	scanner := bufio.NewScanner(&buf)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	idx := 0
+	for scanner.Scan() {
+		text := scanner.Text()
+		var line map[string]any
+		if err := json.Unmarshal([]byte(text), &line); err != nil {
+			t.Fatalf("line %d unmarshal: %v", idx, err)
+		}
+		switch line["type"] {
+		case "manifest":
+			manifestLine = text
+		case "event":
+			eventLines = append(eventLines, text)
+		}
+		idx++
+	}
+
+	// Manifest: additive field present-and-false; row_filter object omitted.
+	if !strings.Contains(manifestLine, `"row_filter_applied":false`) {
+		t.Errorf("manifest missing row_filter_applied:false:\n%s", manifestLine)
+	}
+	if strings.Contains(manifestLine, `"row_filter":`) {
+		t.Errorf("manifest unexpectedly contains a row_filter object:\n%s", manifestLine)
+	}
+
+	// Byte-identical: each event line equals a fresh recomputation.
+	if len(eventLines) != len(seeded) {
+		t.Fatalf("emitted %d event lines, want %d", len(eventLines), len(seeded))
+	}
+	for i, ev := range seeded {
+		want, berr := buildNDJSONEventLine(ev, DefaultSOC2Mapping().ControlsFor(ev))
+		if berr != nil {
+			t.Fatalf("recompute line %d: %v", i, berr)
+		}
+		wantLine := strings.TrimRight(string(want), "\n")
+		if eventLines[i] != wantLine {
+			t.Errorf("event line %d not byte-identical:\n got=%s\nwant=%s", i, eventLines[i], wantLine)
+		}
+	}
+}
+
+// TestWriteComplianceExport_CSVColumnsUnchanged guards the export-format
+// stability rail: the unfiltered CSV header row must still equal
+// complianceCSVHeaders verbatim (no reorder/rename).
+func TestWriteComplianceExport_CSVColumnsUnchanged(t *testing.T) {
+	client, cleanup := newExportClient(t)
+	defer cleanup()
+	chainer := NewChainer(client, "")
+	streamKey := chainer.StreamKey("default")
+	seedChainEvents(t, client, "default", 2, nil)
+
+	var buf bytes.Buffer
+	if _, err := WriteComplianceExport(context.Background(), &buf, client, ComplianceExportOptions{
+		TenantID:  "default",
+		StreamKey: streamKey,
+		Format:    ComplianceExportFormatCSV,
+		From:      time.Now().Add(-1 * time.Hour),
+		To:        time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("WriteComplianceExport: %v", err)
+	}
+	_, rest, _ := strings.Cut(buf.String(), "\n") // drop manifest comment
+	rdr := csv.NewReader(strings.NewReader(rest))
+	rows, err := rdr.ReadAll()
+	if err != nil {
+		t.Fatalf("csv: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("no CSV rows")
+	}
+	if !reflectStringSliceEqual(rows[0], complianceCSVHeaders) {
+		t.Errorf("CSV header drifted:\n got=%v\nwant=%v", rows[0], complianceCSVHeaders)
+	}
+}
+
+// TestWriteComplianceExport_CategoryGovernanceFilter is the DoD-6 / DoD-1 E2E:
+// category=governance emits ONLY governance rows, the manifest records the
+// filter, event_count is the post-filter count, and — critically — chain
+// verification still covers the FULL range (all seeded rows), proving the
+// filter never reached the verifier.
+func TestWriteComplianceExport_CategoryGovernanceFilter(t *testing.T) {
+	client, cleanup := newExportClient(t)
+	defer cleanup()
+	chainer := NewChainer(client, "")
+	streamKey := chainer.StreamKey("default")
+	// 5 seeded: i=0,2,4 routine (system.auth); i=1,3 governance (safety.decision).
+	seedChainEvents(t, client, "default", 5, func(i int, ev *SIEMEvent) {
+		if i%2 == 0 {
+			ev.EventType = EventSystemAuth
+		} else {
+			ev.EventType = EventSafetyDecision
+		}
+	})
+
+	var filteredBuf, fullBuf bytes.Buffer
+	opts := ComplianceExportOptions{
+		TenantID:  "default",
+		StreamKey: streamKey,
+		Format:    ComplianceExportFormatJSON,
+		From:      time.Now().Add(-1 * time.Hour),
+		To:        time.Now().Add(1 * time.Hour),
+	}
+	// Filtered (category=governance) and unfiltered exports over the SAME data.
+	filteredOpts := opts
+	filteredOpts.Category = CategoryGovernance
+	filtered, err := WriteComplianceExport(context.Background(), &filteredBuf, client, filteredOpts)
+	if err != nil {
+		t.Fatalf("filtered export: %v", err)
+	}
+	full, err := WriteComplianceExport(context.Background(), &fullBuf, client, opts)
+	if err != nil {
+		t.Fatalf("unfiltered export: %v", err)
+	}
+
+	// Only governance rows emitted under the filter; all rows unfiltered.
+	emitted := collectExportedEventTypes(t, &filteredBuf)
+	if len(emitted) != 2 {
+		t.Errorf("filtered emitted %d events, want 2 governance", len(emitted))
+	}
+	for _, et := range emitted {
+		if CategoryFor(et) != CategoryGovernance {
+			t.Errorf("filtered emitted non-governance event_type %q", et)
+		}
+	}
+	if got := len(collectExportedEventTypes(t, &fullBuf)); got != 5 {
+		t.Errorf("unfiltered emitted %d events, want 5", got)
+	}
+
+	// Manifest records the filter; event_count is the POST-filter count.
+	if !filtered.RowFilterApplied {
+		t.Error("filtered RowFilterApplied = false, want true")
+	}
+	if filtered.RowFilter == nil || filtered.RowFilter.Category != CategoryGovernance {
+		t.Errorf("filtered RowFilter = %+v, want Category=governance", filtered.RowFilter)
+	}
+	if filtered.EventCount != 2 {
+		t.Errorf("filtered EventCount = %d, want 2 (post-filter)", filtered.EventCount)
+	}
+	if full.EventCount != 5 {
+		t.Errorf("unfiltered EventCount = %d, want 5", full.EventCount)
+	}
+
+	// CRITICAL invariant: the row filter has ZERO effect on chain
+	// verification. The filtered export's ChainVerification must be identical
+	// to the unfiltered one — same total/verified/status over the FULL range
+	// (5), never the filtered subset (2). This is what makes a filtered export
+	// distinguishable from a tamper gap.
+	fv, uv := filtered.ChainVerification, full.ChainVerification
+	if fv == nil || uv == nil {
+		t.Fatalf("ChainVerification nil (filtered=%v unfiltered=%v)", fv, uv)
+	}
+	if fv.TotalEvents != 5 {
+		t.Errorf("filtered ChainVerification.TotalEvents = %d, want 5 (full range)", fv.TotalEvents)
+	}
+	if fv.TotalEvents != uv.TotalEvents || fv.VerifiedEvents != uv.VerifiedEvents || fv.Status != uv.Status {
+		t.Errorf("filter changed verification: filtered{total=%d verified=%d status=%q} vs unfiltered{total=%d verified=%d status=%q}",
+			fv.TotalEvents, fv.VerifiedEvents, fv.Status, uv.TotalEvents, uv.VerifiedEvents, uv.Status)
+	}
+	if fv.Status == VerifyStatusCompromised {
+		t.Errorf("filtered export reported compromised chain — filter leaked into verifier")
+	}
+}
+
+// TestWriteComplianceExport_EventTypeFilter exercises the event_type filter
+// (case-insensitive) and its manifest record.
+func TestWriteComplianceExport_EventTypeFilter(t *testing.T) {
+	client, cleanup := newExportClient(t)
+	defer cleanup()
+	chainer := NewChainer(client, "")
+	streamKey := chainer.StreamKey("default")
+	seedChainEvents(t, client, "default", 4, func(i int, ev *SIEMEvent) {
+		if i < 2 {
+			ev.EventType = EventSafetyDecision
+		} else {
+			ev.EventType = EventSystemAuth
+		}
+	})
+
+	var buf bytes.Buffer
+	manifest, err := WriteComplianceExport(context.Background(), &buf, client, ComplianceExportOptions{
+		TenantID:  "default",
+		StreamKey: streamKey,
+		Format:    ComplianceExportFormatJSON,
+		EventType: "SAFETY.DECISION", // upper-case: eq-fold must still match
+		From:      time.Now().Add(-1 * time.Hour),
+		To:        time.Now().Add(1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("WriteComplianceExport: %v", err)
+	}
+	emitted := collectExportedEventTypes(t, &buf)
+	if len(emitted) != 2 {
+		t.Errorf("emitted %d, want 2 safety.decision", len(emitted))
+	}
+	for _, et := range emitted {
+		if !strings.EqualFold(et, EventSafetyDecision) {
+			t.Errorf("emitted %q, want safety.decision", et)
+		}
+	}
+	if manifest.RowFilter == nil || manifest.RowFilter.EventType != "SAFETY.DECISION" {
+		t.Errorf("manifest.RowFilter = %+v, want EventType=SAFETY.DECISION", manifest.RowFilter)
+	}
+	if manifest.EventCount != 2 {
+		t.Errorf("EventCount = %d, want 2", manifest.EventCount)
+	}
+}
+
+// TestWriteComplianceExport_SeverityFilter exercises the severity filter
+// (case-insensitive).
+func TestWriteComplianceExport_SeverityFilter(t *testing.T) {
+	client, cleanup := newExportClient(t)
+	defer cleanup()
+	chainer := NewChainer(client, "")
+	streamKey := chainer.StreamKey("default")
+	seedChainEvents(t, client, "default", 4, func(i int, ev *SIEMEvent) {
+		if i < 3 {
+			ev.Severity = SeverityHigh
+		} else {
+			ev.Severity = SeverityInfo
+		}
+	})
+
+	var buf bytes.Buffer
+	manifest, err := WriteComplianceExport(context.Background(), &buf, client, ComplianceExportOptions{
+		TenantID:  "default",
+		StreamKey: streamKey,
+		Format:    ComplianceExportFormatJSON,
+		Severity:  "high", // lower-case: eq-fold must match HIGH
+		From:      time.Now().Add(-1 * time.Hour),
+		To:        time.Now().Add(1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("WriteComplianceExport: %v", err)
+	}
+	if manifest.EventCount != 3 {
+		t.Errorf("EventCount = %d, want 3 HIGH-severity", manifest.EventCount)
+	}
+	if manifest.RowFilter == nil || manifest.RowFilter.Severity != "high" {
+		t.Errorf("manifest.RowFilter = %+v, want Severity=high", manifest.RowFilter)
+	}
+}
+
+// collectExportedEventTypes drains an NDJSON export buffer and returns the
+// event_type of every type=="event" line.
+func collectExportedEventTypes(t *testing.T, buf *bytes.Buffer) []string {
+	t.Helper()
+	var out []string
+	scanner := bufio.NewScanner(buf)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if line["type"] == "event" {
+			et, _ := line["event_type"].(string)
+			out = append(out, et)
+		}
+	}
+	return out
+}
+
+func reflectStringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/core/audit/exporter.go
+++ b/core/audit/exporter.go
@@ -195,6 +195,65 @@ const (
 	EventGovernanceLabelSpoof = "governance.label_spoof"
 )
 
+// AllEventTypes is the canonical enumeration of every Event* constant declared
+// above, in declaration order. Go cannot reflect package-level constants, so
+// this slice is the single source the governance-category CI guard
+// (TestEventCategories_CoversAllEventTypes) ranges over to prove every audit
+// event type has an explicit governance/routine mapping in soc2.go. When you
+// add a new Event* constant, append it here AND add it to eventCategories —
+// the guard fails until both are in lockstep.
+var AllEventTypes = []string{
+	EventSafetyDecision,
+	EventDelegationLineage,
+	EventDelegationRejected,
+	EventDelegationRevokedBeforeDispatch,
+	EventSafetyApproval,
+	EventPolicyChange,
+	EventSafetyViolation,
+	EventSystemAuth,
+	EventMCPToolApproval,
+	EventMCPToolDenied,
+	EventMCPToolInvocation,
+	EventMCPToolOutboundInvocation,
+	EventMCPSignatureInvalid,
+	EventHeartbeatDisagreement,
+	EventApprovalRevisionMismatch,
+	EventWorkerTrustChange,
+	EventTopicRegistered,
+	EventTopicUnregistered,
+	EventLicenseLegacyRejected,
+	EventLicenseBreakglassActivated,
+	EventShadowEval,
+	EventAuthAPIKeyCreated,
+	EventAuthAPIKeyRevoked,
+	EventAuthRoleUpserted,
+	EventAuthRoleDeleted,
+	EventEdgeSessionStarted,
+	EventEdgeSessionEnded,
+	EventEdgeExecutionStarted,
+	EventEdgeExecutionEnded,
+	EventEdgeActionAttempted,
+	EventEdgePolicyDecision,
+	EventEdgeActionDenied,
+	EventEdgeApprovalRequested,
+	EventEdgeApprovalResolved,
+	EventEdgeApprovalRejected,
+	EventEdgeApprovalExpired,
+	EventEdgeArtifactExported,
+	EventSafetyBypassAdmit,
+	EventShadowAgentDetected,
+	EventShadowAgentResolved,
+	EventShadowAgentSuppressed,
+	EventShadowAgentExceptionCreated,
+	EventShadowAgentExceptionRevoked,
+	EventShadowAgentExceptionApplied,
+	EventActionGateDenied,
+	EventEdgeAgentdDegraded,
+	EventEdgeFailClosed,
+	EventGovernanceDecision,
+	EventGovernanceLabelSpoof,
+}
+
 // Severity levels for SIEM events.
 const (
 	SeverityCritical = "CRITICAL"

--- a/core/audit/soc2.go
+++ b/core/audit/soc2.go
@@ -227,3 +227,112 @@ func (m SOC2Mapping) String() string {
 	b.WriteByte('}')
 	return b.String()
 }
+
+// ---------------------------------------------------------------------------
+// Event categories (governance vs routine)
+// ---------------------------------------------------------------------------
+
+// Event categories partition audit event types into security-relevant
+// governance events and high-volume operational telemetry. The compliance
+// export (core/audit/export_compliance.go) and the /api/v1/audit/events read
+// surface both consume this single source of truth so their category filters
+// can never drift apart.
+const (
+	// CategoryGovernance marks security-relevant events an auditor cares
+	// about: policy decisions, approvals, denials, key/role changes, license
+	// break-glass, and shadow-agent findings.
+	CategoryGovernance = "governance"
+	// CategoryRoutine marks high-volume operational telemetry: auth checks,
+	// audit-read meta-events, edge/MCP lifecycle, worker handshakes, and topic
+	// registration. These dominate an unfiltered export and bury governance
+	// signal (the reason CORDUM_AUDIT_READ_SAMPLE_RATE defaults to 0.0).
+	CategoryRoutine = "routine"
+)
+
+// eventCategories is the canonical event-type → category map. It covers every
+// Event* constant in AllEventTypes (enforced by
+// TestEventCategories_CoversAllEventTypes) plus the bare-string event types
+// emitted from packages outside core/audit: "audit.read.events" (the audit
+// read handler), "mcp.tool_called" (core/mcp), and "worker_handshake" (the
+// scheduler). Any event type NOT listed here resolves to governance via
+// CategoryFor (fail-open) so a newly added or caller-supplied event is never
+// silently hidden from a governance-filtered export.
+//
+// Borderline calls (surfaced in docs/audit.md's category table for review):
+// the edge session/execution lifecycle and edge.action_attempted,
+// mcp.tool_invocation/outbound_invocation, and topic_(un)registered are
+// ROUTINE (operational volume); edge.policy_decision/action_denied/approval_*
+// /artifact_exported and every shadow_agent.* finding stay GOVERNANCE.
+var eventCategories = map[string]string{
+	// --- routine: operational telemetry / noise ---
+	EventSystemAuth:                CategoryRoutine,
+	EventEdgeSessionStarted:        CategoryRoutine,
+	EventEdgeSessionEnded:          CategoryRoutine,
+	EventEdgeExecutionStarted:      CategoryRoutine,
+	EventEdgeExecutionEnded:        CategoryRoutine,
+	EventEdgeActionAttempted:       CategoryRoutine,
+	EventMCPToolInvocation:         CategoryRoutine,
+	EventMCPToolOutboundInvocation: CategoryRoutine,
+	EventTopicRegistered:           CategoryRoutine,
+	EventTopicUnregistered:         CategoryRoutine,
+	"audit.read.events":            CategoryRoutine,
+	"mcp.tool_called":              CategoryRoutine,
+	"worker_handshake":             CategoryRoutine,
+
+	// --- governance: security-relevant ---
+	EventSafetyDecision:                  CategoryGovernance,
+	EventDelegationLineage:               CategoryGovernance,
+	EventDelegationRejected:              CategoryGovernance,
+	EventDelegationRevokedBeforeDispatch: CategoryGovernance,
+	EventSafetyApproval:                  CategoryGovernance,
+	EventPolicyChange:                    CategoryGovernance,
+	EventSafetyViolation:                 CategoryGovernance,
+	EventMCPToolApproval:                 CategoryGovernance,
+	EventMCPToolDenied:                   CategoryGovernance,
+	EventMCPSignatureInvalid:             CategoryGovernance,
+	EventHeartbeatDisagreement:           CategoryGovernance,
+	EventApprovalRevisionMismatch:        CategoryGovernance,
+	EventWorkerTrustChange:               CategoryGovernance,
+	EventLicenseLegacyRejected:           CategoryGovernance,
+	EventLicenseBreakglassActivated:      CategoryGovernance,
+	EventShadowEval:                      CategoryGovernance,
+	EventAuthAPIKeyCreated:               CategoryGovernance,
+	EventAuthAPIKeyRevoked:               CategoryGovernance,
+	EventAuthRoleUpserted:                CategoryGovernance,
+	EventAuthRoleDeleted:                 CategoryGovernance,
+	EventEdgePolicyDecision:              CategoryGovernance,
+	EventEdgeActionDenied:                CategoryGovernance,
+	EventEdgeApprovalRequested:           CategoryGovernance,
+	EventEdgeApprovalResolved:            CategoryGovernance,
+	EventEdgeApprovalRejected:            CategoryGovernance,
+	EventEdgeApprovalExpired:             CategoryGovernance,
+	EventEdgeArtifactExported:            CategoryGovernance,
+	EventSafetyBypassAdmit:               CategoryGovernance,
+	EventShadowAgentDetected:             CategoryGovernance,
+	EventShadowAgentResolved:             CategoryGovernance,
+	EventShadowAgentSuppressed:           CategoryGovernance,
+	EventShadowAgentExceptionCreated:     CategoryGovernance,
+	EventShadowAgentExceptionRevoked:     CategoryGovernance,
+	EventShadowAgentExceptionApplied:     CategoryGovernance,
+	EventActionGateDenied:                CategoryGovernance,
+	EventEdgeAgentdDegraded:              CategoryGovernance,
+	EventEdgeFailClosed:                  CategoryGovernance,
+	EventGovernanceDecision:              CategoryGovernance,
+	EventGovernanceLabelSpoof:            CategoryGovernance,
+}
+
+// CategoryFor returns the governance/routine category for an event type.
+// Unknown or empty types FAIL OPEN to governance: a security event must never
+// be silently dropped from a governance-filtered export just because it was
+// introduced without a category mapping.
+func CategoryFor(eventType string) string {
+	if cat, ok := eventCategories[eventType]; ok {
+		return cat
+	}
+	return CategoryGovernance
+}
+
+// IsGovernanceEvent reports whether an event type is governance-relevant.
+func IsGovernanceEvent(eventType string) bool {
+	return CategoryFor(eventType) == CategoryGovernance
+}

--- a/core/audit/soc2_test.go
+++ b/core/audit/soc2_test.go
@@ -263,3 +263,94 @@ func TestControlsFor_NilMapReturnsEmpty(t *testing.T) {
 		t.Errorf("nil map ControlsFor = %v, want empty non-nil slice", got)
 	}
 }
+
+// TestEventCategories_CoversAllEventTypes is the CI guard for governance
+// filtering: every Event* constant enumerated in AllEventTypes MUST have an
+// explicit entry in the eventCategories map. CategoryFor fail-opens to
+// governance, so a missing mapping would NOT surface via CategoryFor alone —
+// this test inspects the map directly so a newly-added Event* constant left
+// uncategorised fails the build rather than silently defaulting.
+func TestEventCategories_CoversAllEventTypes(t *testing.T) {
+	if len(AllEventTypes) < 46 {
+		t.Fatalf("AllEventTypes has %d entries, want >= 46 (a new Event* constant must be appended to AllEventTypes)", len(AllEventTypes))
+	}
+	seen := make(map[string]struct{}, len(AllEventTypes))
+	for _, et := range AllEventTypes {
+		if et == "" {
+			t.Error("AllEventTypes contains an empty string")
+			continue
+		}
+		if _, dup := seen[et]; dup {
+			t.Errorf("AllEventTypes contains duplicate %q", et)
+		}
+		seen[et] = struct{}{}
+		cat, ok := eventCategories[et]
+		if !ok {
+			t.Errorf("event type %q has no explicit eventCategories entry (add it to eventCategories in soc2.go)", et)
+			continue
+		}
+		if cat != CategoryGovernance && cat != CategoryRoutine {
+			t.Errorf("event type %q mapped to invalid category %q", et, cat)
+		}
+	}
+}
+
+// TestEventCategories_AllValuesValid pins that every value in the map (incl.
+// the bare-string event types emitted outside exporter.go) is one of the two
+// known categories, and that the three known bare strings are routine.
+func TestEventCategories_AllValuesValid(t *testing.T) {
+	for et, cat := range eventCategories {
+		if cat != CategoryGovernance && cat != CategoryRoutine {
+			t.Errorf("eventCategories[%q] = %q, want governance|routine", et, cat)
+		}
+	}
+	for _, bare := range []string{"audit.read.events", "mcp.tool_called", "worker_handshake"} {
+		if got := eventCategories[bare]; got != CategoryRoutine {
+			t.Errorf("bare event %q category = %q, want routine", bare, got)
+		}
+	}
+}
+
+// TestCategoryFor covers the routine/governance split plus the FAIL-OPEN
+// contract: any unknown or empty event type resolves to governance so a new
+// or caller-supplied event is never silently hidden from a governance export.
+func TestCategoryFor(t *testing.T) {
+	cases := []struct {
+		name string
+		et   string
+		want string
+	}{
+		{"unknown fail-open to governance", "some.brand.new.event", CategoryGovernance},
+		{"empty fail-open to governance", "", CategoryGovernance},
+		{"routine system.auth", EventSystemAuth, CategoryRoutine},
+		{"routine audit.read.events bare", "audit.read.events", CategoryRoutine},
+		{"routine mcp.tool_invocation", EventMCPToolInvocation, CategoryRoutine},
+		{"routine topic_registered", EventTopicRegistered, CategoryRoutine},
+		{"routine edge.session_started", EventEdgeSessionStarted, CategoryRoutine},
+		{"governance safety.decision", EventSafetyDecision, CategoryGovernance},
+		{"governance governance.decision", EventGovernanceDecision, CategoryGovernance},
+		{"governance auth.api_key_revoked", EventAuthAPIKeyRevoked, CategoryGovernance},
+		{"governance edge.action_denied", EventEdgeActionDenied, CategoryGovernance},
+		{"governance shadow_agent.detected", EventShadowAgentDetected, CategoryGovernance},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CategoryFor(tc.et); got != tc.want {
+				t.Errorf("CategoryFor(%q) = %q, want %q", tc.et, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsGovernanceEvent is the boolean façade over CategoryFor.
+func TestIsGovernanceEvent(t *testing.T) {
+	if !IsGovernanceEvent(EventSafetyDecision) {
+		t.Error("safety.decision must be governance")
+	}
+	if IsGovernanceEvent(EventSystemAuth) {
+		t.Error("system.auth must not be governance (routine)")
+	}
+	if !IsGovernanceEvent("unknown.event.type") {
+		t.Error("unknown event must fail-open to governance")
+	}
+}

--- a/core/controlplane/gateway/handlers_audit_compliance.go
+++ b/core/controlplane/gateway/handlers_audit_compliance.go
@@ -151,6 +151,18 @@ func (s *server) handleAuditExport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", "attachment; filename="+strconv.Quote(filename))
 	w.Header().Set("X-Cordum-Export-Format", string(opts.Format))
 	w.Header().Set("X-Cordum-Tenant", tenant)
+	// Echo the applied row filter so a client/proxy can confirm the artifact
+	// is scoped without parsing the manifest. category/severity come from
+	// fixed allow-lists; event_type is sanitised against header injection.
+	if opts.Category != "" {
+		w.Header().Set("X-Cordum-Export-Filter-Category", opts.Category)
+	}
+	if opts.Severity != "" {
+		w.Header().Set("X-Cordum-Export-Filter-Severity", opts.Severity)
+	}
+	if opts.EventType != "" {
+		w.Header().Set("X-Cordum-Export-Filter-Event-Type", headerSafe(opts.EventType))
+	}
 	// Flushing is important for client progress bars; the handler is
 	// explicitly one-shot and streams rather than buffers.
 	flusher, _ := w.(http.Flusher)
@@ -173,6 +185,15 @@ func (s *server) handleAuditExport(w http.ResponseWriter, r *http.Request) {
 		observeAuditExport(string(opts.Format), "error", manifestEventCount(manifest))
 		return
 	}
+	slog.Info("compliance export",
+		"tenant", tenant,
+		"format", opts.Format,
+		"events", manifestEventCount(manifest),
+		"filter_category", opts.Category,
+		"filter_event_type", opts.EventType,
+		"filter_severity", opts.Severity,
+		"row_filter_applied", manifestRowFilterApplied(manifest),
+	)
 	observeAuditExport(string(opts.Format), "ok", manifestEventCount(manifest))
 }
 
@@ -182,6 +203,11 @@ func manifestEventCount(m *audit.ExportManifest) int {
 		return 0
 	}
 	return m.EventCount
+}
+
+// manifestRowFilterApplied is nil-safe for the slog success line.
+func manifestRowFilterApplied(m *audit.ExportManifest) bool {
+	return m != nil && m.RowFilterApplied
 }
 
 // parseComplianceExportQuery parses + validates the ?from ?to ?format
@@ -244,7 +270,55 @@ func parseComplianceExportQuery(r *http.Request) (audit.ComplianceExportOptions,
 		}
 		opts.MaxEvents = n
 	}
+
+	// Row filters (event_type / severity / category). These constrain the
+	// EMITTED ROWS only; the chain verifier always runs over the full range
+	// (enforced in core/audit/export_compliance.go). event_type is matched
+	// case-insensitively and accepted loosely (any non-empty string filters by
+	// exact eq-fold); severity must be a known level; category must resolve to
+	// the governance/routine taxonomy.
+	if v := strings.TrimSpace(q.Get("event_type")); v != "" {
+		opts.EventType = v
+	}
+	if v := strings.TrimSpace(q.Get("severity")); v != "" {
+		if !isKnownSeverity(v) {
+			return opts, &verifyHTTPError{http.StatusBadRequest, "invalid severity"}
+		}
+		opts.Severity = v
+	}
+	if v := strings.TrimSpace(q.Get("category")); v != "" {
+		cat := strings.ToLower(v)
+		if cat != audit.CategoryGovernance && cat != audit.CategoryRoutine {
+			return opts, &verifyHTTPError{http.StatusBadRequest, "invalid category"}
+		}
+		opts.Category = cat
+	}
 	return opts, nil
+}
+
+// isKnownSeverity reports whether s (case-insensitive) is one of the audit
+// severity levels. Used to 400 a malformed ?severity= rather than silently
+// returning an empty export.
+func isKnownSeverity(s string) bool {
+	switch strings.ToUpper(s) {
+	case audit.SeverityCritical, audit.SeverityHigh, audit.SeverityMedium, audit.SeverityLow, audit.SeverityInfo:
+		return true
+	default:
+		return false
+	}
+}
+
+// headerSafe strips CR/LF and other control characters from a caller-supplied
+// value before it is echoed into a response header, so a crafted ?event_type=
+// can never inject additional headers (defense-in-depth atop net/http's own
+// header-value guard).
+func headerSafe(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // sanitiseFilenameSegment strips characters that would break the

--- a/core/controlplane/gateway/handlers_audit_compliance_test.go
+++ b/core/controlplane/gateway/handlers_audit_compliance_test.go
@@ -430,3 +430,195 @@ func TestParseComplianceExportQuery_FormatValidation(t *testing.T) {
 		}
 	}
 }
+
+// TestParseComplianceExportQuery_FilterParams covers the new
+// event_type/severity/category parsing: governance/routine accepted
+// (case-insensitive, normalised lower), unknown category + unknown severity
+// rejected with 400, event_type accepted loosely.
+func TestParseComplianceExportQuery_FilterParams(t *testing.T) {
+	base := "/api/v1/audit/export?format=json&from=2026-04-17T00:00:00Z&to=2026-04-18T00:00:00Z"
+
+	t.Run("category governance", func(t *testing.T) {
+		opts, err := parseComplianceExportQuery(httptest.NewRequest(http.MethodGet, base+"&category=governance", nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if opts.Category != "governance" {
+			t.Errorf("Category = %q, want governance", opts.Category)
+		}
+	})
+	t.Run("category mixed-case normalised", func(t *testing.T) {
+		opts, err := parseComplianceExportQuery(httptest.NewRequest(http.MethodGet, base+"&category=Routine", nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if opts.Category != "routine" {
+			t.Errorf("Category = %q, want routine", opts.Category)
+		}
+	})
+	t.Run("category unknown rejected", func(t *testing.T) {
+		_, err := parseComplianceExportQuery(httptest.NewRequest(http.MethodGet, base+"&category=bogus", nil))
+		if err == nil || err.status != http.StatusBadRequest {
+			t.Fatalf("category=bogus: err = %+v, want 400", err)
+		}
+	})
+	t.Run("severity case-insensitive accepted", func(t *testing.T) {
+		opts, err := parseComplianceExportQuery(httptest.NewRequest(http.MethodGet, base+"&severity=high", nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if opts.Severity != "high" {
+			t.Errorf("Severity = %q, want high", opts.Severity)
+		}
+	})
+	t.Run("severity unknown rejected", func(t *testing.T) {
+		_, err := parseComplianceExportQuery(httptest.NewRequest(http.MethodGet, base+"&severity=spicy", nil))
+		if err == nil || err.status != http.StatusBadRequest {
+			t.Fatalf("severity=spicy: err = %+v, want 400", err)
+		}
+	})
+	t.Run("event_type accepted loosely", func(t *testing.T) {
+		opts, err := parseComplianceExportQuery(httptest.NewRequest(http.MethodGet, base+"&event_type=safety.decision", nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if opts.EventType != "safety.decision" {
+			t.Errorf("EventType = %q, want safety.decision", opts.EventType)
+		}
+	})
+}
+
+// TestHandleAuditExport_CategoryGovernanceFilter is the handler-level E2E:
+// category=governance emits ONLY governance rows and echoes the applied filter
+// in the response header + manifest.
+func TestHandleAuditExport_CategoryGovernanceFilter(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	grantExportEntitlement(t, s)
+	// 5 seeded types cycle safety.decision, safety.approval, safety.policy_change,
+	// system.auth (ROUTINE), mcp.tool_approval -> 4 governance, 1 routine.
+	seedComplianceEvents(t, s.redisClient(), "default", 5)
+
+	req := adminCtx(httptest.NewRequest(http.MethodGet,
+		"/api/v1/audit/export?format=json&category=governance"+rangeQS(), nil))
+	rec := httptest.NewRecorder()
+	s.handleAuditExport(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-Cordum-Export-Filter-Category"); got != "governance" {
+		t.Errorf("filter-category header = %q, want governance", got)
+	}
+
+	scanner := bufio.NewScanner(rec.Body)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	events := 0
+	var manifestRowFilterApplied bool
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		switch line["type"] {
+		case "manifest":
+			manifestRowFilterApplied, _ = line["row_filter_applied"].(bool)
+		case "event":
+			events++
+			et, _ := line["event_type"].(string)
+			if audit.CategoryFor(et) != audit.CategoryGovernance {
+				t.Errorf("emitted non-governance event_type %q", et)
+			}
+		}
+	}
+	if events != 4 {
+		t.Errorf("emitted %d events, want 4 governance", events)
+	}
+	if !manifestRowFilterApplied {
+		t.Error("manifest row_filter_applied = false, want true")
+	}
+}
+
+// TestHandleAuditExport_CategoryGovernanceFilterCSV is the literal DoD-6 E2E:
+// GET /api/v1/audit/export?category=governance&format=csv returns ONLY
+// governance rows, the manifest comment records row_filter, and
+// chain_verification still attests the full range (not the filtered subset).
+func TestHandleAuditExport_CategoryGovernanceFilterCSV(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	grantExportEntitlement(t, s)
+	// 5 seeded types: safety.decision, safety.approval, safety.policy_change,
+	// system.auth (ROUTINE), mcp.tool_approval -> 4 governance, 1 routine.
+	seedComplianceEvents(t, s.redisClient(), "default", 5)
+
+	req := adminCtx(httptest.NewRequest(http.MethodGet,
+		"/api/v1/audit/export?format=csv&category=governance"+rangeQS(), nil))
+	rec := httptest.NewRecorder()
+	s.handleAuditExport(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-Cordum-Export-Filter-Category"); got != "governance" {
+		t.Errorf("filter-category header = %q, want governance", got)
+	}
+
+	firstLine, rest, found := strings.Cut(rec.Body.String(), "\n")
+	if !found || !strings.HasPrefix(firstLine, "# cordum-manifest: ") {
+		t.Fatalf("missing manifest comment: %q", firstLine)
+	}
+	var manifest struct {
+		RowFilterApplied bool `json:"row_filter_applied"`
+		RowFilter        *struct {
+			Category string `json:"category"`
+		} `json:"row_filter"`
+		ChainVerification *struct {
+			TotalEvents int    `json:"total_events"`
+			Status      string `json:"status"`
+		} `json:"chain_verification"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(firstLine, "# cordum-manifest: ")), &manifest); err != nil {
+		t.Fatalf("manifest JSON: %v", err)
+	}
+	if !manifest.RowFilterApplied || manifest.RowFilter == nil || manifest.RowFilter.Category != "governance" {
+		t.Errorf("manifest row_filter not recorded: applied=%v filter=%+v", manifest.RowFilterApplied, manifest.RowFilter)
+	}
+	// chain_verification must reflect the FULL range (all 5 seeded), not the
+	// filtered 4 — proving the filter never reached the verifier. (The CSV
+	// comment manifest is written BEFORE the walk, so its event_count is
+	// structurally 0 there; the authoritative post-filter count is the CSV
+	// data-row count asserted below.)
+	if manifest.ChainVerification == nil || manifest.ChainVerification.TotalEvents != 5 {
+		t.Errorf("chain_verification not full-range: %+v (want total_events=5)", manifest.ChainVerification)
+	}
+
+	// Every CSV data row must be a governance event (event_type column index 1),
+	// and there must be exactly 4 — the post-filter count for this seed.
+	rdr := csv.NewReader(strings.NewReader(rest))
+	rdr.FieldsPerRecord = -1
+	rows, err := rdr.ReadAll()
+	if err != nil {
+		t.Fatalf("csv: %v", err)
+	}
+	if len(rows) != 1+4 {
+		t.Fatalf("got %d CSV rows (incl header), want 5 (header + 4 governance)", len(rows))
+	}
+	for _, row := range rows[1:] {
+		if audit.CategoryFor(row[1]) != audit.CategoryGovernance {
+			t.Errorf("CSV row emitted non-governance event_type %q", row[1])
+		}
+	}
+}
+
+// TestHandleAuditExport_RejectsUnknownCategory pins the 400 on a bad category.
+func TestHandleAuditExport_RejectsUnknownCategory(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	grantExportEntitlement(t, s)
+
+	req := adminCtx(httptest.NewRequest(http.MethodGet,
+		"/api/v1/audit/export?format=json&category=bogus"+rangeQS(), nil))
+	rec := httptest.NewRecorder()
+	s.handleAuditExport(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}

--- a/core/controlplane/gateway/handlers_audit_events.go
+++ b/core/controlplane/gateway/handlers_audit_events.go
@@ -25,12 +25,13 @@ const MaxAuditEventsLimit = 200
 // AuditErrCodeInvalid* values are stable machine-readable 400 codes that
 // dashboard / SIEM clients can pin against without message-string matching.
 const (
-	AuditErrCodeInvalidCursor = "INVALID_CURSOR"
-	AuditErrCodeInvalidLimit  = "INVALID_LIMIT"
-	AuditErrCodeInvalidFrom   = "INVALID_FROM"
-	AuditErrCodeInvalidTo     = "INVALID_TO"
-	AuditErrCodeInvalidRange  = "INVALID_RANGE"
-	AuditErrCodeInvalidQuery  = "INVALID_QUERY"
+	AuditErrCodeInvalidCursor   = "INVALID_CURSOR"
+	AuditErrCodeInvalidLimit    = "INVALID_LIMIT"
+	AuditErrCodeInvalidFrom     = "INVALID_FROM"
+	AuditErrCodeInvalidTo       = "INVALID_TO"
+	AuditErrCodeInvalidRange    = "INVALID_RANGE"
+	AuditErrCodeInvalidCategory = "INVALID_CATEGORY"
+	AuditErrCodeInvalidQuery    = "INVALID_QUERY"
 )
 
 // These sentinel parse errors let the handler choose stable code fields while
@@ -40,10 +41,11 @@ var (
 	errInvalidAuditCursor = errors.New(
 		"invalid cursor: must be redis stream id '<unsigned-ms>-<unsigned-seq>'",
 	)
-	errInvalidAuditLimit = errors.New("invalid limit: must be a positive integer")
-	errInvalidAuditFrom  = errors.New("invalid from: must be RFC3339 timestamp")
-	errInvalidAuditTo    = errors.New("invalid to: must be RFC3339 timestamp")
-	errInvalidAuditRange = errors.New("invalid range: to must not precede from")
+	errInvalidAuditLimit    = errors.New("invalid limit: must be a positive integer")
+	errInvalidAuditFrom     = errors.New("invalid from: must be RFC3339 timestamp")
+	errInvalidAuditTo       = errors.New("invalid to: must be RFC3339 timestamp")
+	errInvalidAuditRange    = errors.New("invalid range: to must not precede from")
+	errInvalidAuditCategory = errors.New("invalid category: must be governance or routine")
 )
 
 // defaultAuditEventsLimit is the page size when the caller omits ?limit.
@@ -107,6 +109,7 @@ type auditEventsResponse struct {
 type auditEventsFilters struct {
 	eventType string
 	severity  string
+	category  string
 	from      time.Time
 	to        time.Time
 	search    string
@@ -170,6 +173,7 @@ func (s *server) handleListAuditEvents(w http.ResponseWriter, r *http.Request) {
 		"next_cursor_present", nextCursor != "",
 		"filter_event_type", filters.eventType,
 		"filter_severity", filters.severity,
+		"filter_category", filters.category,
 		"filter_from", filters.from.Format(time.RFC3339),
 		"filter_to", filters.to.Format(time.RFC3339),
 		"filter_search", filters.search != "",
@@ -196,6 +200,8 @@ func auditEventsParseErrorCode(err error) string {
 		return AuditErrCodeInvalidTo
 	case errors.Is(err, errInvalidAuditRange):
 		return AuditErrCodeInvalidRange
+	case errors.Is(err, errInvalidAuditCategory):
+		return AuditErrCodeInvalidCategory
 	default:
 		return AuditErrCodeInvalidQuery
 	}
@@ -254,6 +260,16 @@ func parseAuditEventsQuery(r *http.Request) (int, string, auditEventsFilters, er
 		eventType: strings.TrimSpace(q.Get("event_type")),
 		severity:  strings.TrimSpace(q.Get("severity")),
 		search:    strings.ToLower(strings.TrimSpace(q.Get("search"))),
+	}
+	// category is additive to event_type/severity/search. Reject an unknown
+	// value (400) rather than silently returning an empty page; accept the
+	// governance/routine taxonomy case-insensitively, normalised to lower.
+	if raw := strings.TrimSpace(q.Get("category")); raw != "" {
+		cat := strings.ToLower(raw)
+		if cat != audit.CategoryGovernance && cat != audit.CategoryRoutine {
+			return 0, "", auditEventsFilters{}, errInvalidAuditCategory
+		}
+		filters.category = cat
 	}
 	if raw := strings.TrimSpace(q.Get("from")); raw != "" {
 		t, err := time.Parse(time.RFC3339, raw)
@@ -400,6 +416,9 @@ func matchesFilters(ev *audit.SIEMEvent, f auditEventsFilters) bool {
 	if f.severity != "" && !strings.EqualFold(ev.Severity, f.severity) {
 		return false
 	}
+	if f.category != "" && audit.CategoryFor(ev.EventType) != f.category {
+		return false
+	}
 	if f.hasFrom && ev.Timestamp.Before(f.from) {
 		return false
 	}
@@ -497,6 +516,9 @@ func emitAuditReadMetaEvent(
 	}
 	if filters.severity != "" {
 		extra["filter_severity"] = filters.severity
+	}
+	if filters.category != "" {
+		extra["filter_category"] = filters.category
 	}
 	if filters.hasFrom {
 		extra["filter_from"] = filters.from.Format(time.RFC3339)

--- a/core/controlplane/gateway/handlers_audit_events_test.go
+++ b/core/controlplane/gateway/handlers_audit_events_test.go
@@ -68,6 +68,7 @@ func TestHandleAuditEvents_400ErrorEnvelopeIncludesCode(t *testing.T) {
 			query:        "from=2020-01-01T00:00:00Z&to=2019-01-01T00:00:00Z",
 			expectedCode: "INVALID_RANGE",
 		},
+		{name: "invalid category", query: "category=bogus", expectedCode: "INVALID_CATEGORY"},
 	}
 
 	for _, tc := range cases {
@@ -705,6 +706,72 @@ func TestHandleAuditEvents_InvalidCursor_Returns400InvalidCursorCode(t *testing.
 				t.Errorf("body leaks generic 500 internal-error: %s", rec.Body.String())
 			}
 		})
+	}
+}
+
+// TestHandleAuditEvents_CategoryFilter pins ?category=governance as an
+// additive filter: only governance event types surface; routine telemetry
+// (system.auth, mcp.tool_invocation) is dropped.
+func TestHandleAuditEvents_CategoryFilter(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	seedAuditEvents(t, s, "default", []audit.SIEMEvent{
+		{EventType: audit.EventSafetyDecision, Severity: audit.SeverityInfo, Action: "gov1"},
+		{EventType: audit.EventSystemAuth, Severity: audit.SeverityInfo, Action: "routine1"},
+		{EventType: audit.EventEdgePolicyDecision, Severity: audit.SeverityInfo, Action: "gov2"},
+		{EventType: audit.EventMCPToolInvocation, Severity: audit.SeverityInfo, Action: "routine2"},
+	})
+
+	rec := httptest.NewRecorder()
+	req := adminCtx(httptest.NewRequest(http.MethodGet,
+		"/api/v1/audit/events?tenant=default&category=governance", nil))
+	s.handleListAuditEvents(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeAuditEventsResponse(t, rec)
+	if len(resp.Items) != 2 {
+		t.Fatalf("returned %d items, want 2 governance; items=%+v", len(resp.Items), resp.Items)
+	}
+	for _, it := range resp.Items {
+		if audit.CategoryFor(it.EventType) != audit.CategoryGovernance {
+			t.Errorf("returned non-governance event_type %q", it.EventType)
+		}
+	}
+}
+
+// TestHandleAuditEvents_MetaAuditCarriesFilterCategory pins that the
+// audit.read.events meta-event records the applied category filter in Extra,
+// alongside the existing filter_event_type/filter_severity reflection.
+func TestHandleAuditEvents_MetaAuditCarriesFilterCategory(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	seedAuditEvents(t, s, "default", []audit.SIEMEvent{
+		{EventType: audit.EventSafetyDecision, Severity: audit.SeverityInfo, Action: "seed"},
+	})
+	streamKey := audit.NewChainer(s.redisClient(), "").StreamKey("default")
+
+	req := adminCtx(httptest.NewRequest(http.MethodGet,
+		"/api/v1/audit/events?tenant=default&category=governance", nil))
+	rec := httptest.NewRecorder()
+	s.handleListAuditEvents(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Newest stream entry is the audit.read.events meta-event this call appended.
+	entries, err := s.redisClient().XRevRangeN(context.Background(), streamKey, "+", "-", 1).Result()
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("xrevrange: %v (n=%d)", err, len(entries))
+	}
+	payload, _ := entries[0].Values["event"].(string)
+	var ev audit.SIEMEvent
+	if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+		t.Fatalf("unmarshal meta-event: %v", err)
+	}
+	if ev.EventType != "audit.read.events" {
+		t.Fatalf("newest event type = %q, want audit.read.events", ev.EventType)
+	}
+	if ev.Extra["filter_category"] != "governance" {
+		t.Errorf("meta-event filter_category = %q, want governance", ev.Extra["filter_category"])
 	}
 }
 

--- a/docs/audit-operations.md
+++ b/docs/audit-operations.md
@@ -55,6 +55,7 @@ Expected response for a healthy chain:
 | `CORDUM_AUDIT_CHAIN_FAIL` | `strict` | `strict`: drop unchained events; `permissive`: export anyway |
 | `CORDUM_AUDIT_EXPORT_TYPE` | `none` | SIEM backend: `webhook`, `syslog`, `datadog`, `cloudwatch`, `chain-only` |
 | `CORDUM_AUDIT_RETENTION_HOURS` | `168` (7 days) | Audit retention window in hours |
+| `CORDUM_AUDIT_READ_SAMPLE_RATE` | `0.0` | Fraction (`0.0`–`1.0`) of `/api/v1/audit/events` reads that emit an `audit.read.events` meta-event. **Recommended prod default `0.0`** — raising it floods the chain with routine `system.auth` / `audit.read.events` rows that bury governance signal. If your goal is a governance-focused audit artifact, filter with `?category=governance` (see below) rather than tuning this sample rate. |
 
 ## HMAC Key Management
 
@@ -250,3 +251,23 @@ The audit chain maps to SOC2 2017 Trust Services Criteria:
 
 See `core/audit/soc2.go` for the authoritative mapping and override
 instructions.
+
+### Governance-focused exports
+
+Routine telemetry (`system.auth`, `audit.read.events`, edge/MCP lifecycle) can
+dominate an unfiltered export — observed ~90% noise when the read sample rate
+was raised — burying the governance events an auditor needs. Rather than tuning
+`CORDUM_AUDIT_READ_SAMPLE_RATE` (keep it at the recommended `0.0`), scope the
+artifact at query time:
+
+```bash
+# Governance-only compliance export (CSV), chain integrity still attested over
+# the full range — the manifest's row_filter records the scope.
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://your-cordum/api/v1/audit/export?format=csv&category=governance&from=<RFC3339>&to=<RFC3339>"
+```
+
+The export's `event_count` is then the post-filter row count while
+`chain_verification` still covers the full range, so a filtered export is never
+mistaken for a tamper gap (see `docs/audit.md` §7). The same `?category=` filter
+works on `GET /api/v1/audit/events` for the dashboard read surface.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -108,6 +108,42 @@ Severity levels: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`.
 
 <!-- TODO: document which actions map to which event types and severities -->
 
+### Event categories (governance vs routine)
+
+Every event type is classified as **governance** (security-relevant — the
+events an auditor cares about) or **routine** (high-volume operational
+telemetry). The classification is a single source of truth in
+`core/audit/soc2.go` (`CategoryFor` / `IsGovernanceEvent`, keyed off the
+`Event*` constants and CI-guarded so no constant can ship uncategorised) and is
+reused by both the compliance export and the `/api/v1/audit/events` read
+surface. **Unknown or newly added event types fail open to `governance`**, so a
+security event is never silently hidden from a governance-filtered view.
+
+**Routine** (operational telemetry): `system.auth`, `audit.read.events`,
+`edge.session_started`, `edge.session_ended`, `edge.execution_started`,
+`edge.execution_ended`, `edge.action_attempted`, `mcp.tool_invocation`,
+`mcp.tool_outbound_invocation`, `mcp.tool_called`, `worker_handshake`,
+`topic_registered`, `topic_unregistered`.
+
+**Governance** (everything else): `safety.*`, `delegation.*`,
+`auth.api_key_*` / `auth.role_*`, `edge.policy_decision`, `edge.action_denied`,
+`edge.approval_*`, `edge.artifact_exported`, `edge.fail_closed`,
+`edge.agentd_degraded`, `shadow_agent.*`, `shadow_eval`, `governance.*`,
+`actiongate.denied`, `approval.revision_mismatch`, `license.*`,
+`mcp.tool_approval`, `mcp.tool_denied`, `mcp.signature_invalid`,
+`heartbeat_disagreement`, `worker_trust_change`.
+
+> **Borderline calls** (review here; adjust the map in `soc2.go` if your threat
+> model differs): the edge session/execution lifecycle and
+> `edge.action_attempted` are **routine** — they fire on every action, not just
+> denials. `mcp.tool_invocation` / `mcp.tool_outbound_invocation` are **routine**
+> call-volume telemetry, whereas `mcp.tool_approval` / `mcp.tool_denied` are
+> **governance**. `topic_registered` / `topic_unregistered` are **routine**;
+> `heartbeat_disagreement` and `edge.artifact_exported` are **governance**.
+
+Both the compliance export and the events endpoint filter on this taxonomy via
+`?category=governance` (or `routine`) — see §6 and §7.
+
 ## 3. SIEM Event Schema
 
 Each exported event uses the `SIEMEvent` struct:
@@ -153,8 +189,29 @@ The gateway records fine-grained audit entries via `appendAuditEntryNamed` for:
 ## 6. Query API
 
 - `GET /api/v1/policy/audit` — List policy audit entries
+- `GET /api/v1/audit/events` — Paginated SIEM-feed read surface over the
+  per-tenant audit chain (see [`audit/list-api.md`](audit/list-api.md))
 
-<!-- TODO: document query parameters, pagination, filtering, and response format -->
+`/api/v1/audit/events` accepts these additive filters (all optional; an absent
+param means "no constraint on that dimension"):
+
+| Query param | Description |
+|-------------|-------------|
+| `event_type` | Exact event type, matched case-insensitively |
+| `severity` | One of `CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO`, case-insensitive |
+| `category` | `governance` or `routine` (see §2); an unknown value is rejected with `400 INVALID_CATEGORY` |
+| `search` | Substring match over action / type / agent / job / identity / reason |
+| `from` / `to` | RFC 3339 timestamp bounds (inclusive) |
+| `limit` | Page size, capped at 200 |
+| `cursor` | Opaque Redis stream id from the previous page's `next_cursor` |
+
+`category` is resolved per row from the governance/routine taxonomy, so
+`?category=governance` returns only security-relevant events and drops routine
+telemetry such as `system.auth` and `mcp.tool_invocation`. The applied
+`event_type` / `severity` / `category` filters are reflected in the
+`audit.read.events` meta-event so the read surface is itself auditable.
+
+<!-- TODO: document the full response envelope (items / next_cursor / returned) -->
 
 ## 7. SIEM Export Configuration
 
@@ -191,6 +248,41 @@ The gateway records fine-grained audit entries via `appendAuditEntryNamed` for:
 |---------|-------------|
 | `CORDUM_AUDIT_EXPORT_CW_LOG_GROUP` | CloudWatch log group name |
 | `CORDUM_AUDIT_EXPORT_CW_LOG_STREAM` | CloudWatch log stream name |
+
+### Compliance export filters (`GET /api/v1/audit/export`)
+
+The on-demand compliance export streams the per-tenant audit chain as NDJSON or
+CSV with a leading manifest. Alongside `format` / `from` / `to` / `excel` /
+`limit`, it accepts the same row filters as the events endpoint (§6):
+
+| Query param | Description |
+|-------------|-------------|
+| `event_type` | Exact event type, matched case-insensitively |
+| `severity` | `CRITICAL`/`HIGH`/`MEDIUM`/`LOW`/`INFO`, case-insensitive (unknown → `400`) |
+| `category` | `governance` or `routine` (see §2); unknown → `400 invalid category` |
+
+The applied filter is echoed in the response headers
+(`X-Cordum-Export-Filter-Category` / `-Severity` / `-Event-Type`) and recorded
+in the manifest:
+
+| Manifest field | Meaning |
+|----------------|---------|
+| `row_filter_applied` | `true` when any row filter was applied (always present) |
+| `row_filter` | The applied `{event_type, severity, category}` (omitted when none) |
+
+**A filtered export is not a tamper gap.** The manifest's `event_count` is the
+**post-filter** row count, but `chain_verification` always runs over the
+**full** range — the filter only gates which rows are *emitted*, never the
+integrity check. A governance-only export can therefore show an `event_count`
+far smaller than the verified chain length; the `row_filter` record is exactly
+what tells an auditor that difference is a filter, not missing events.
+`GET /api/v1/audit/verify` is unaffected by export filters.
+
+> **Truncation caveat.** `limit` / `MaxEvents` counts events *before* the row
+> filter is applied. A narrow `?category=governance` filter over a very noisy
+> range can hit the cap and set `truncated_at_max` before emitting many
+> governance rows. When you see `truncated_at_max` together with a `row_filter`,
+> narrow the `from`/`to` window rather than raising the cap.
 
 ## 8. Dashboard UI
 


### PR DESCRIPTION
## Summary
Adds governance/event-type/severity filtering to the compliance export (`GET /api/v1/audit/export`) and a category filter to the events endpoint (`GET /api/v1/audit/events`), so routine telemetry (`system.auth`, `audit.read.events`, edge/MCP lifecycle) no longer buries governance signal in audit artifacts.

## Design
- **Single source of truth** — `audit.CategoryFor` / `IsGovernanceEvent` (`soc2.go`) keyed off a new `AllEventTypes` slice (`exporter.go`), CI-guarded so every `Event*` constant is categorized. Unknown/new events **fail open to `governance`** (never silently hidden). Reused by both endpoints.
- **Chain integrity preserved** — the row filter applies in the emit callback **only**; `opts.Verifier`, `walkChainStream`, and the cursor advance are untouched, so chain verification always runs over the **full** range. The manifest gains `row_filter` / `row_filter_applied` (additive, appended after `retention_boundary_seq`) so a filtered export is never mistaken for a tamper gap (`event_count` is post-filter; `chain_verification` is full-range).
- **Handler** — parses `event_type`/`severity`/`category` (rejects unknown with 400), echoes `X-Cordum-Export-Filter-*` headers + slog. Events endpoint adds an additive `category` filter reflected in the `audit.read.events` meta-event.

## DoD evidence
1. Export filter in emit callback only, manifest records filter + attests full chain — `TestWriteComplianceExport_CategoryGovernanceFilter` (filtered `ChainVerification` == unfiltered, TotalEvents=5).
2. Unfiltered output byte-identical — `TestWriteComplianceExport_UnfilteredByteIdentical` + `..._CSVColumnsUnchanged`.
3. Events endpoint category (additive) + meta-event — `TestHandleAuditEvents_CategoryFilter` / `..._MetaAuditCarriesFilterCategory` / `INVALID_CATEGORY` 400.
4. `CategoryFor` covers every `Event*` + CI guard — `TestEventCategories_CoversAllEventTypes`.
5. `CORDUM_AUDIT_READ_SAMPLE_RATE` documented (0.0) + `category=governance` pointer — `docs/audit.md` §2/§7, `docs/audit-operations.md`, `cordum-helm/values.yaml`.
6. E2E `?category=governance&format=csv` returns only governance rows, manifest `row_filter`, chain intact — `TestHandleAuditExport_CategoryGovernanceFilterCSV`.
7. `go test ./core/audit/... ./core/controlplane/gateway/... -count=3` green (audit 31.8s, gateway 190.8s, auth 73.5s, + packs/policybundles/pools).

## Notes
- Additive only: no CSV column reorder/rename, no manifest field reorder, `edge.export.v1` unbumped.
- Dashboard: deferred (params are API-usable now; a governance toggle is an optional follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)