### PR TITLE
fix(reqhash): strip policy.attachment_id so worker-originated approvals survive reconcile (task-821a6ebb)

### DIFF
--- a/config/timeouts.yaml
+++ b/config/timeouts.yaml
@@ -4,4 +4,9 @@ reconciler:
   dispatch_timeout_seconds: 300
   # Per-topic overrides available via topics.<topic>.running_timeout_seconds
   running_timeout_seconds: 900
+  # 30s is the default reconciler tick. The temporary 900s stopgap (task-821a6ebb)
+  # that masked approval auto-invalidation is removed now that reqhash strips the
+  # platform-injected policy.attachment_id label; pending approvals no longer drift
+  # the TOCTOU hash, so the prompt 30s tick is safe again (also restores timely
+  # dispatch/running timeout enforcement the 900s tick delayed).
   scan_interval_seconds: 30

--- a/core/infra/store/approval_repair_regression_test.go
+++ b/core/infra/store/approval_repair_regression_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/cordum/cordum/core/infra/bus"
+	"github.com/cordum/cordum/core/infra/config"
 	"github.com/cordum/cordum/core/model"
+	"github.com/cordum/cordum/core/policylabels"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 )
 
@@ -242,5 +244,142 @@ func TestClassifyApprovalRepair_EffectiveConfigEnvMutation_NotStale(t *testing.T
 	plan := ClassifyApprovalRepair(*snap, ApprovalRepairClassifyOptions{})
 	if plan.Kind != ApprovalRepairNone {
 		t.Fatalf("env-stripping drift must not trip StaleRequest, got %q", plan.Kind)
+	}
+}
+
+// TestClassifyApprovalRepair_PolicyAttachmentIDInjected_DoesNotTripStaleRequest
+// is the task-821a6ebb regression guard. A worker-originated workflow-step
+// approval gate pins its submit-time JobHash, then policy attachment injects
+// policylabels.PolicyAttachmentID onto the stored request (engine_job.go:228)
+// and the scheduler's attachEffectiveConfig adds config.EffectiveConfigEnvVar
+// to req.Env — both AFTER the pin, while the approval is still PENDING. reqhash
+// .Canonical strips both, so the reconciler's recomputed RequestHash must still
+// equal the pinned JobHash and the pending approval must classify None (survive
+// the reconciler tick) instead of being auto-invalidated as stale_request
+// before a human can act. Before the strip this tripped invalidate_stale_request
+// roughly one tick after creation.
+func TestClassifyApprovalRepair_PolicyAttachmentIDInjected_DoesNotTripStaleRequest(t *testing.T) {
+	t.Parallel()
+	srv := miniredis.RunT(t)
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	const jobID = "job-policy-attach"
+	// Submit-time shape, BEFORE policy attachment — what the JobHash pins.
+	req := &pb.JobRequest{
+		JobId:    jobID,
+		Topic:    "job.approval-gate",
+		TenantId: "default",
+		Labels: map[string]string{
+			"run_id":      "run-1",
+			"step_id":     "approve",
+			"workflow_id": "wf-1",
+		},
+	}
+	preHash, err := hashApprovalJobRequest(req)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if err := store.SetState(ctx, jobID, model.JobStateApproval); err != nil {
+		t.Fatalf("set state: %v", err)
+	}
+	if err := store.SetSafetyDecision(ctx, jobID, model.SafetyDecisionRecord{
+		Decision:         model.SafetyRequireApproval,
+		ApprovalRequired: true,
+		PolicySnapshot:   "snap-1",
+		JobHash:          preHash,
+	}); err != nil {
+		t.Fatalf("set safety: %v", err)
+	}
+
+	// Platform-injected metadata that lands on the stored request after the
+	// pin, while the approval is still pending. Both are stripped by Canonical.
+	req.Labels[policylabels.PolicyAttachmentID] = policylabels.JobAttachmentID(jobID)
+	req.Env = map[string]string{config.EffectiveConfigEnvVar: `{"tenant":"default","effective":true}`}
+	if err := store.SetJobRequest(ctx, req); err != nil {
+		t.Fatalf("set req: %v", err)
+	}
+
+	snap, err := store.InspectApprovalRepair(ctx, jobID)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if snap.RequestHash != preHash {
+		t.Fatalf("policy.attachment_id + EffectiveConfigEnvVar must not drift the hash: pinned=%s recomputed=%s",
+			preHash, snap.RequestHash)
+	}
+	plan := ClassifyApprovalRepair(*snap, ApprovalRepairClassifyOptions{})
+	if plan.Kind == ApprovalRepairInvalidateStaleRequest {
+		t.Fatal("policy.attachment_id injection must NOT invalidate a pending approval as stale_request")
+	}
+	if plan.Kind != ApprovalRepairNone {
+		t.Fatalf("a pending approval carrying only stripped platform churn must classify None, got %q", plan.Kind)
+	}
+}
+
+// TestClassifyApprovalRepair_PolicyAttachmentPlusRealDrift_StillTripsStaleRequest
+// is the fence counterpart to the survival test: stripping policy.attachment_id
+// must not blind the TOCTOU check. A pending approval carrying the (stripped)
+// platform label that ALSO has a genuine payload change (ContextPtr) between
+// safety-check and reconcile must STILL be invalidated as stale_request.
+func TestClassifyApprovalRepair_PolicyAttachmentPlusRealDrift_StillTripsStaleRequest(t *testing.T) {
+	t.Parallel()
+	srv := miniredis.RunT(t)
+	store, err := NewRedisJobStore("redis://" + srv.Addr())
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	const jobID = "job-policy-attach-drift"
+	req := &pb.JobRequest{
+		JobId:      jobID,
+		Topic:      "job.approval-gate",
+		TenantId:   "default",
+		ContextPtr: "ctx:original",
+		Labels: map[string]string{
+			"run_id":      "run-1",
+			"step_id":     "approve",
+			"workflow_id": "wf-1",
+		},
+	}
+	preHash, err := hashApprovalJobRequest(req)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if err := store.SetState(ctx, jobID, model.JobStateApproval); err != nil {
+		t.Fatalf("set state: %v", err)
+	}
+	if err := store.SetSafetyDecision(ctx, jobID, model.SafetyDecisionRecord{
+		Decision:         model.SafetyRequireApproval,
+		ApprovalRequired: true,
+		JobHash:          preHash,
+	}); err != nil {
+		t.Fatalf("set safety: %v", err)
+	}
+
+	// Benign stripped platform label AND a real payload change (ContextPtr,
+	// not stripped) — the latter must still trip the fence.
+	req.Labels[policylabels.PolicyAttachmentID] = policylabels.JobAttachmentID(jobID)
+	req.ContextPtr = "ctx:tampered"
+	if err := store.SetJobRequest(ctx, req); err != nil {
+		t.Fatalf("set req: %v", err)
+	}
+
+	snap, err := store.InspectApprovalRepair(ctx, jobID)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	plan := ClassifyApprovalRepair(*snap, ApprovalRepairClassifyOptions{})
+	if plan.Kind != ApprovalRepairInvalidateStaleRequest {
+		t.Fatalf("real payload drift alongside a stripped platform label must still trip StaleRequest, got %q", plan.Kind)
+	}
+	if plan.TargetState != model.JobStateDenied {
+		t.Fatalf("stale-request repair must target DENIED, got %s", plan.TargetState)
 	}
 }

--- a/core/protocol/reqhash/reqhash.go
+++ b/core/protocol/reqhash/reqhash.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cordum/cordum/core/infra/bus"
 	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policylabels"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 	"github.com/cordum/cordum/core/protocol/protoutil"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -24,8 +25,9 @@ import (
 )
 
 // Canonical returns a copy of req with mutable fields stripped
-// (approval_* labels, bus.LabelBusMsgID, config.EffectiveConfigEnvVar)
-// and proto unknown fields removed via a protojson round-trip. The
+// (approval_* labels, bus.LabelBusMsgID, policylabels.PolicyAttachmentID,
+// config.EffectiveConfigEnvVar) and proto unknown fields removed via a
+// protojson round-trip. The
 // round-trip matches what the store persists into Redis, so the
 // canonical form is stable regardless of whether the caller holds the
 // original in-memory proto or a Redis-read form.
@@ -37,7 +39,11 @@ func Canonical(req *pb.JobRequest) (*pb.JobRequest, error) {
 	if clone.Labels != nil {
 		for key := range clone.Labels {
 			lower := strings.ToLower(key)
-			if strings.HasPrefix(lower, "approval_") || key == bus.LabelBusMsgID {
+			// policy.attachment_id is injected during policy attachment (after the
+			// submit-time hash is pinned), so it must be stripped here or the
+			// reconcile-time RequestHash drifts from the pinned JobHash and a
+			// still-pending approval is wrongly invalidated as stale_request.
+			if strings.HasPrefix(lower, "approval_") || key == bus.LabelBusMsgID || key == policylabels.PolicyAttachmentID {
 				delete(clone.Labels, key)
 			}
 		}

--- a/core/protocol/reqhash/reqhash_test.go
+++ b/core/protocol/reqhash/reqhash_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cordum/cordum/core/infra/bus"
 	"github.com/cordum/cordum/core/infra/config"
+	"github.com/cordum/cordum/core/policylabels"
 	pb "github.com/cordum/cordum/core/protocol/pb/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -121,6 +122,52 @@ func TestHash_IgnoresEffectiveConfigEnv(t *testing.T) {
 	}
 	if hashBase != hashAfter {
 		t.Fatalf("EffectiveConfigEnvVar must not affect hash — got %s vs %s", hashBase, hashAfter)
+	}
+}
+
+// TestHash_IgnoresPolicyAttachmentID pins that the platform-injected
+// policy.attachment_id label does not perturb the canonical hash. The label is
+// added during policy attachment — after the submit-time JobHash is pinned — so
+// without stripping it the reconcile-time RequestHash drifts and the reconciler
+// wrongly invalidates a still-pending approval as invalidate_stale_request.
+func TestHash_IgnoresPolicyAttachmentID(t *testing.T) {
+	t.Parallel()
+	base := baseRequest()
+	hashBase, err := Hash(base)
+	if err != nil {
+		t.Fatalf("hash base: %v", err)
+	}
+
+	mutated, ok := proto.Clone(base).(*pb.JobRequest)
+	if !ok {
+		t.Fatal("clone failed")
+	}
+	mutated.Labels[policylabels.PolicyAttachmentID] = "job/job-abc:governance_evaluate@1/policy"
+	hashAfter, err := Hash(mutated)
+	if err != nil {
+		t.Fatalf("hash after: %v", err)
+	}
+	if hashBase != hashAfter {
+		t.Fatalf("policy.attachment_id must not affect hash — got %s vs %s", hashBase, hashAfter)
+	}
+}
+
+// TestCanonical_StripsPolicyAttachmentID pins the strip as a Canonical API
+// contract, mirroring TestCanonical_StripsApprovalLabels.
+func TestCanonical_StripsPolicyAttachmentID(t *testing.T) {
+	t.Parallel()
+	base := baseRequest()
+	base.Labels[policylabels.PolicyAttachmentID] = "job/job-abc/policy"
+
+	canon, err := Canonical(base)
+	if err != nil {
+		t.Fatalf("Canonical: %v", err)
+	}
+	if _, present := canon.Labels[policylabels.PolicyAttachmentID]; present {
+		t.Fatal("Canonical must strip policy.attachment_id label")
+	}
+	if _, present := canon.Labels["run_id"]; !present {
+		t.Fatal("Canonical must preserve non-injected labels")
 	}
 }
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -591,6 +591,23 @@ these entries into a versioned release note and reset this file.
   `invalidate_stale_request` path should now see the benign approval
   succeed again. Follow-up to commit `297937c7` and guard task
   `task-035cdc8e`.
+- **Approvals — worker-originated approval gates no longer
+  auto-invalidated by `policy.attachment_id`
+  (`core/protocol/reqhash/reqhash.go`):** the shared canonicaliser
+  `reqhash.Canonical` now also strips the platform-injected
+  `policy.attachment_id` label (alongside `approval_*`,
+  `bus.LabelBusMsgID`, and `config.EffectiveConfigEnvVar`). That label
+  is attached during policy attachment *after* the submit-time JobHash
+  is pinned, so the reconciler's recomputed `RequestHash` used to
+  diverge from the pinned hash and wrongly classify a still-pending
+  worker-originated approval (e.g. a workflow-step approval gate) as
+  `invalidate_stale_request` → `DENIED` about one reconciler tick after
+  creation — before a human could approve. The TOCTOU fence is
+  unchanged: a genuine request-payload change still trips
+  `invalidate_stale_request`. The temporary 15-minute stopgap
+  (`config/timeouts.yaml` `reconciler.scan_interval_seconds` raised to
+  `900`, which also delayed dispatch/running timeout enforcement) is
+  removed — restored to the `30`s default. See `task-821a6ebb`.
 - **Approvals — canonical hash parity
   (`core/infra/store/job_store.go`):** the store-side
   `hashApprovalJobRequest` now protojson-roundtrips the cloned


### PR DESCRIPTION
## Summary

Fixes approval auto-invalidation: a pending approval on a **worker-originated** job (e.g. a workflow-step approval gate) was auto-invalidated by the scheduler reconciler as `invalidate_stale_request` → `DENIED` roughly one reconciler tick after creation, so a human couldn't approve in time. This was masked by a temporary 15-minute reconciler stopgap.

**Root cause:** `reqhash.Canonical` stripped `approval_*`, `bus.LabelBusMsgID`, and `config.EffectiveConfigEnvVar` from the canonical `JobRequest`, but **not** the platform-injected `policy.attachment_id` label (`core/policylabels`), which is attached during policy attachment *after* the submit-time `JobHash` is pinned. So the reconcile-time `RequestHash` (recomputed from the stored job, now carrying the label) diverged from the pinned `JobHash` → `invalidate_stale_request`.

**Fix:** `reqhash.Canonical` now also strips `policy.attachment_id` (exact-match constant — only platform-injected metadata, never user content). Both hash sites route through the same `reqhash.Hash`→`Canonical`, so the label is hash-neutral by construction. The TOCTOU fence is preserved — a genuine request-payload change still trips `invalidate_stale_request`.

Also removes the temporary stopgap (`config/timeouts.yaml reconciler.scan_interval_seconds` 900 → 30 default), restoring prompt dispatch/running timeout enforcement the 900s tick delayed.

## Diagnosis (DoD #1)

Deterministic pin-vs-reconcile canonical diff: the canonical protojson is **byte-identical** between the submit-time pin and the reconcile recompute even with the full post-submit churn (`policy.attachment_id` + `approval_*` + `bus.LabelBusMsgID` + `EffectiveConfigEnvVar`) — both hash `3afc4a68…2b1529`, **zero residual diverging fields**. Static write-path audit confirmed `safety_bypassed`/`safety_bypass_reason` (engine.go:1567-68) are fail-open-path-only and never re-persisted, so they cannot diverge a stored approval job. No hash-site instrumentation was committed (a throwaway test was used and removed).

## Tests

- `reqhash_test.go`: `TestHash_IgnoresPolicyAttachmentID`, `TestCanonical_StripsPolicyAttachmentID`, fence `TestHash_DetectsRealPayloadChange` — green at `-count=3`.
- `approval_repair_regression_test.go`: `TestClassifyApprovalRepair_PolicyAttachmentIDInjected_DoesNotTripStaleRequest` (pending approval survives → `None`) + `…_PolicyAttachmentPlusRealDrift_StillTripsStaleRequest` (real drift still → `InvalidateStaleRequest` / `DENIED`).
- Full regression `go test ./core/protocol/reqhash/... ./core/controlplane/scheduler/... ./core/infra/store/... -count=3` → all green (reqhash 0.4s, scheduler 101s, store 6s).
- **Live E2E:** rebuilt + restarted the dev scheduler at `scan_interval=30`; a pending worker-originated approval carrying `policy.attachment_id` stayed `APPROVAL_REQUIRED` across >90s / 3+ reconciler ticks, no auto-repair to `DENIED`.

## Scope / isolation

Single commit on `origin/main` containing exactly 5 files: `core/protocol/reqhash/reqhash.go`, `reqhash_test.go`, `core/infra/store/approval_repair_regression_test.go`, `config/timeouts.yaml`, `docs/release-notes/unreleased.md`. `engine.go`/`job_store.go` are byte-identical to HEAD (no instrumentation residue); no concurrent audit/edge peer WIP included.

task-821a6ebb

🤖 Generated with [Claude Code](https://claude.com/claude-code)
