### PR TITLE
fix(edge): bind cordum-agentd loopback fresh on Windows (task-6b9299ff, supersedes task-02133692)

### DIFF
--- a/cmd/cordumctl/edge_claude_test.go
+++ b/cmd/cordumctl/edge_claude_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -55,7 +56,15 @@ func TestEdgeClaudeDryRunSettingsOutputRedactsSecrets(t *testing.T) {
 		t.Fatalf("agentd socket URL leaked nonce: %s", env["CORDUM_AGENTD_SOCKET"])
 	}
 	listenerKey, listenerValue := listenerhandoff.ValueForCurrentPlatform(env)
-	if listenerValue == "" {
+	if runtime.GOOS == "windows" {
+		// Windows uses the close-then-bind legacy path (handle inheritance is
+		// Unix-only — see core/edge/claude/listener_inheritance_windows.go), so
+		// agentd re-binds the freed loopback port itself and the launcher hands
+		// off no listener handle.
+		if listenerValue != "" {
+			t.Fatalf("windows agentd must not receive an inherited listener (legacy close-then-bind), got %s=%q", listenerKey, listenerValue)
+		}
+	} else if listenerValue == "" {
 		t.Fatalf("agentd helper did not receive inherited listener %s: %#v", listenerKey, env)
 	}
 }

--- a/core/edge/claude/launcher_helpers_test.go
+++ b/core/edge/claude/launcher_helpers_test.go
@@ -104,6 +104,14 @@ func TestFilepathExt(t *testing.T) {
 	}
 }
 
+// TestLoopbackReservationNoTOCTOU asserts the per-platform reservation contract.
+// On inheritance platforms (Unix) reserveLoopbackHookURL holds the reserved
+// listener open until it is handed to agentd across exec, so the port must NOT be
+// re-bindable — the no-TOCTOU guarantee. On non-inheritance platforms (Windows,
+// where supportsAgentdListenerInheritance() is false; see
+// listener_inheritance_windows.go) the wrapper deliberately uses the close-then-
+// bind legacy path: the port is released so agentd can re-bind it fresh, which is
+// the accepted Option-A reserve->bind race tradeoff.
 func TestLoopbackReservationNoTOCTOU(t *testing.T) {
 	rawURL, err := reserveLoopbackHookURL()
 	if err != nil {
@@ -115,11 +123,21 @@ func TestLoopbackReservationNoTOCTOU(t *testing.T) {
 		t.Fatalf("parse reserved URL: %v", err)
 	}
 
-	attacker, err := net.Listen("tcp", u.Host)
-	if err == nil {
-		_ = attacker.Close()
-		t.Fatalf("reserved loopback port %s was bindable after reservation; launcher has a TOCTOU window", u.Host)
+	attacker, attackErr := net.Listen("tcp", u.Host)
+	if supportsAgentdListenerInheritance() {
+		if attackErr == nil {
+			_ = attacker.Close()
+			t.Fatalf("reserved loopback port %s was bindable after reservation; launcher has a TOCTOU window", u.Host)
+		}
+		return
 	}
+	// Legacy close-then-bind path: the reserved port is expected to be free so
+	// agentd can re-bind it. A failure here means the freed port is not
+	// re-bindable, which would break the Windows fix's core assumption.
+	if attackErr != nil {
+		t.Fatalf("legacy reservation should release %s for agentd to re-bind, but it was not bindable: %v", u.Host, attackErr)
+	}
+	_ = attacker.Close()
 }
 
 func TestRejectSettingsOverrideBlocksAllSettingsVariants(t *testing.T) {

--- a/core/edge/claude/launcher_windows_test.go
+++ b/core/edge/claude/launcher_windows_test.go
@@ -10,17 +10,29 @@ import (
 	"testing"
 )
 
-func TestLaunchEdgeClaudeWindowsInheritedListenerUsesHandleAndBlocksHijack(t *testing.T) {
+// TestLaunchEdgeClaudeWindowsUsesLegacyCloseThenBind verifies the Windows agentd
+// bind fix. supportsAgentdListenerInheritance() returns false on Windows (see
+// listener_inheritance_windows.go), so prepareLaunchConfig reserves the loopback
+// port with reserveLoopbackHookURLLegacy (net.Listen -> Close), hands cordum-agentd
+// only the URL, and never sets CORDUM_AGENTD_LISTENER_HANDLE/_FD. agentd then binds
+// the freed port itself and becomes ready. Pre-fix, this path inherited the held
+// socket handle and agentd failed with "Only one usage of each socket address"
+// before becoming ready.
+//
+// Tradeoff note: the close-then-bind path does NOT hold the port across the
+// reserve->bind window, so — unlike the held-listener handoff — it cannot block a
+// same-user loopback hijack of that port. That is the deliberate, documented
+// Option-A tradeoff (identical to the Unix legacy fallback). There is no held port
+// to assert a hijack-block against, so the prior held-handle hijack assertion is
+// intentionally gone.
+func TestLaunchEdgeClaudeWindowsUsesLegacyCloseThenBind(t *testing.T) {
 	helperPath := os.Args[0]
-	dir := t.TempDir()
-	capture := filepath.Join(dir, "agentd-env.json")
-	probe := filepath.Join(dir, "hijack-probe.json")
+	capture := filepath.Join(t.TempDir(), "agentd-env.json")
 
 	result, err := LaunchEdgeClaude(context.Background(), LaunchOptions{
 		Env: envWith(
 			"CORDUM_TEST_HELPER_PROCESS", "1",
 			"CORDUM_TEST_AGENTD_ENV_PATH", capture,
-			"CORDUM_TEST_AGENTD_HIJACK_PROBE_PATH", probe,
 		),
 		Gateway: "http://gateway.local", APIKey: "secret-token", TenantID: "tenant-a",
 		PrincipalID: "user-a", CWD: t.TempDir(), AgentdPath: helperPath, HookCommand: helperPath,
@@ -30,35 +42,20 @@ func TestLaunchEdgeClaudeWindowsInheritedListenerUsesHandleAndBlocksHijack(t *te
 		t.Fatalf("LaunchEdgeClaude returned error: %v", err)
 	}
 
+	// agentd bound the freed loopback port fresh, became ready, and the edge
+	// session was created (the helper writes session state only after it binds).
+	if result.SessionID != "sess-launch" || result.ExecutionID != "exec-launch" {
+		t.Fatalf("expected edge session created via fresh agentd bind, got %#v", result)
+	}
+
 	env := readJSONMap(t, capture)
-	if got := strings.TrimSpace(env["CORDUM_AGENTD_LISTENER_HANDLE"]); got == "" {
-		t.Fatalf("Windows launcher must pass inherited listener as CORDUM_AGENTD_LISTENER_HANDLE, env=%#v", env)
+	if got := strings.TrimSpace(env["CORDUM_AGENTD_LISTENER_HANDLE"]); got != "" {
+		t.Fatalf("Windows legacy path must not hand off a listener handle, got CORDUM_AGENTD_LISTENER_HANDLE=%q in %#v", got, env)
 	}
 	if got := strings.TrimSpace(env["CORDUM_AGENTD_LISTENER_FD"]); got != "" {
-		t.Fatalf("Windows launcher must not expose Unix fd handoff env, got CORDUM_AGENTD_LISTENER_FD=%q in %#v", got, env)
+		t.Fatalf("Windows legacy path must not expose Unix fd handoff, got CORDUM_AGENTD_LISTENER_FD=%q in %#v", got, env)
 	}
 	if strings.Contains(string(result.SettingsJSON), "CORDUM_AGENTD_LISTENER_") {
 		t.Fatalf("settings leaked internal listener handoff env: %s", result.SettingsJSON)
 	}
-
-	probeResult := readJSONMap(t, probe)
-	if probeResult["bind"] == "succeeded" {
-		t.Fatalf("same-user hijack bind succeeded while agentd inherited listener should hold %s: %#v", probeResult["host"], probeResult)
-	}
-	if strings.TrimSpace(probeResult["bind_error"]) == "" {
-		t.Fatalf("hijack probe did not record the expected bind failure: %#v", probeResult)
-	}
-	for _, forbidden := range []string{env["CORDUM_AGENTD_NONCE"], env["CORDUM_API_KEY"], result.SessionID, result.ExecutionID} {
-		if forbidden != "" && strings.Contains(strings.Join(mapValues(probeResult), "\n"), forbidden) {
-			t.Fatalf("hijack probe leaked launcher payload or nonce %q in %#v", forbidden, probeResult)
-		}
-	}
-}
-
-func mapValues(values map[string]string) []string {
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		out = append(out, value)
-	}
-	return out
 }

--- a/core/edge/claude/listener_inheritance_windows.go
+++ b/core/edge/claude/listener_inheritance_windows.go
@@ -13,8 +13,28 @@ import (
 	"github.com/cordum/cordum/core/edge/listenerhandoff"
 )
 
+// supportsAgentdListenerInheritance reports whether the launcher hands its
+// reserved loopback listener to cordum-agentd across exec (true) or releases the
+// port and lets agentd re-bind it (false).
+//
+// Windows returns false. Duplicating the loopback socket handle into the agentd
+// child across this exec.Cmd path is unreliable in this build: agentd ends up
+// re-binding the 127.0.0.1:<port> the launcher reserved and fails with "Only one
+// usage of each socket address (protocol/network address/port) is normally
+// permitted", so cordum-agentd exits before becoming ready (reproduces across
+// random ports). Returning false routes the Windows launcher through
+// reserveLoopbackHookURLLegacy (net.Listen -> Close -> pass URL only, no
+// CORDUM_AGENTD_LISTENER_HANDLE handoff); agentd then binds the freed port fresh
+// and starts reliably.
+//
+// Tradeoff: this reintroduces the small reserve->bind race window (a same-user
+// loopback process could grab the port between Close and agentd's bind) that the
+// held-listener handoff was designed to close. Accepted as identical to the
+// pre-inheritance behavior and to the Unix legacy fallback (loopback, same-user).
+// Real Windows socket-handle passing (Option B) stays available via the dormant
+// inheritance helpers below if it is ever revisited.
 func supportsAgentdListenerInheritance() bool {
-	return true
+	return false
 }
 
 func listenerFileForInheritance(ln net.Listener) (*os.File, string, string, error) {

--- a/docs/edge-claude-code.md
+++ b/docs/edge-claude-code.md
@@ -35,6 +35,21 @@ Claude Code command hook -> cordum-hook -> local cordum-agentd -> Gateway evalua
 - Gateway/Safety Kernel own tenant-aware policy evaluation, approvals, audit,
   metrics, and redaction before persistence.
 
+### Local agentd loopback listener (platform note)
+
+`cordumctl edge claude` reserves a loopback `127.0.0.1` port for `cordum-agentd`
+and starts agentd on it automatically — no `--agentd-url` override is required on
+any platform.
+
+- On Unix/macOS the launcher hands the reserved listener socket to `cordum-agentd`
+  across `exec` (handle inheritance), so there is no reserve-then-bind gap.
+- On Windows the launcher uses a close-then-bind path instead: it reserves the
+  loopback port, releases it, passes only the URL, and `cordum-agentd` binds that
+  port itself. Socket-handle inheritance is Unix-only here, and the close-then-bind
+  path avoids the Windows `bind: Only one usage of each socket address` failure that
+  the inheritance path triggered (`cordum-agentd exited before becoming ready`). The
+  `--agentd-url` override is therefore **not** required on Windows.
+
 ## Settings generation
 
 The wrapper renders temporary Claude command-hook settings with:

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -70,7 +70,10 @@ stable hashes, and artifact pointer metadata.
 
 - `cordumctl edge claude` is the developer/demo launcher. It starts local
   `cordum-agentd`, renders temporary Claude command-hook settings, injects a
-  runtime-only hook nonce, and launches Claude Code.
+  runtime-only hook nonce, and launches Claude Code. It reserves the local
+  `cordum-agentd` loopback port automatically (close-then-bind on Windows, where
+  listener handle inheritance is Unix-only), so `--agentd-url` is not required on
+  any platform.
 - `cordum-hook` is the Claude command hook. It reads one bounded hook payload,
   redacts/maps it, and calls only the local agentd endpoint.
 - `cordum-agentd` owns local session lifecycle, hook authentication, Gateway


### PR DESCRIPTION
## Problem
`cordumctl edge claude` failed on Windows — `cordum-agentd` re-bound the loopback `127.0.0.1:<port>` the launcher reserved for socket-handle inheritance and exited before becoming ready (`bind: Only one usage of each socket address`), deterministically across random ports. Windows socket-handle inheritance across the agentd `exec.Cmd` path is unreliable in this build.

## Fix (Option A)
Flip `supportsAgentdListenerInheritance()` to `false` on **Windows only** (`listener_inheritance_windows.go`). The launcher then uses the close-then-bind legacy path (`reserveLoopbackHookURLLegacy`: `net.Listen` → `Close` → pass URL only, no `CORDUM_AGENTD_LISTENER_HANDLE` handoff) and `cordum-agentd` binds the freed port fresh. Unix/macOS keep listener inheritance — `listener_inheritance_unix.go` is untouched.

**Accepted tradeoff:** the small reserve→bind race window, identical to the existing Unix legacy fallback (loopback, same-user). Real Windows socket-handle passing (Option B) stays available via the dormant helpers; full removal of that code and the cordum-edge wrapper `--agentd-url` shim simplification are explicit follow-ups.

## Verification (real Windows 11 host)
- `cordumctl edge claude --dry-run` **without** `--agentd-url`, against the live gateway: edge session created across 4 random loopback ports (55009 / 54973 / 54977 / 49491), all `exit_code: 0`, zero bind errors.
- `go test ./core/edge/claude/... ./cmd/cordum-agentd/... ./cmd/cordumctl/... -count=3` → all `ok` (37.2s / 0.28s / 132.5s).
- `GOOS=windows` / `GOOS=linux go build` + `GOOS=linux go vet` clean; `golangci-lint` on touched packages → 0 issues.

## Tests
- Rewrote `launcher_windows_test.go` to assert the legacy close-then-bind path (no handoff env, fresh bind, session created).
- Made `cmd/cordumctl/edge_claude_test.go` and `launcher_helpers_test.go` (`TestLoopbackReservationNoTOCTOU`) platform-aware for the Windows gate.

## Docs
`docs/edge-claude-code.md` + `docs/edge.md`: `--agentd-url` is not required on Windows (close-then-bind on Windows, handle inheritance Unix-only).

## Reconciliation
Supersedes **task-02133692** (`b796bae5`), which added the Windows inheritance machinery + tests but never flipped the gate; its `launcher_windows_test.go` asserted the inheritance path and is rewritten here for the legacy path.

Task: `task-6b9299ff` · Epic: `epic-77680752`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loopback port reservation reliability on Windows for the Edge Claude launcher.

* **Tests**
  * Updated platform-specific test assertions to verify correct behavior on Windows versus Unix platforms.

* **Documentation**
  * Clarified how the Edge Claude launcher automatically reserves loopback ports across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->