### PR TITLE
ci(docs): add offline markdown link-check for docs/**

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -1,0 +1,55 @@
+name: docs-linkcheck
+
+# Markdown link-check for the in-repo docs/** surface (the canonical docs
+# source per RELEASING.md). Replaces the lychee check that was dropped with
+# .github/workflows/docs-deploy.yml when the orphan docs-site/ tree was retired
+# (task-729b21ef / PR #291). This is link-checking ONLY — it does NOT build or
+# deploy any docs-site.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "lychee.toml"
+      - ".github/workflows/docs-linkcheck.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "lychee.toml"
+      - ".github/workflows/docs-linkcheck.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-linkcheck-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  link-check:
+    name: link-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run lychee (offline, gating)
+        # SHA-pinned third-party action per the repo convention (dependabot
+        # github-actions ecosystem tracks it); same pin docs-deploy.yml used.
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          # Run options (offline, exclude_path, exclude, max_concurrency) live
+          # in ./lychee.toml. --offline checks relative FILE links + in-doc
+          # anchors only; external http(s) URLs are intentionally NOT checked
+          # (flaky / rate-limited in CI, and docs.cordum.io 403s CI clients),
+          # which keeps this gate deterministic.
+          args: >-
+            --config ./lychee.toml
+            --no-progress
+            'docs/**/*.md'
+          # Gating: fail the job on any NEW broken link. Pre-existing baseline
+          # breaks are snapshotted in lychee.toml (content fixes are tracked to
+          # task-8e555500), so the gate fails only on regressions, not debt.
+          fail: true

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,37 @@
+# Configuration for the docs/** offline markdown link-check.
+# Consumed by .github/workflows/docs-linkcheck.yml (lychee-action).
+#
+# Scope: relative FILE links + in-document anchors under docs/**/*.md.
+# External http(s) URLs are intentionally NOT checked (offline = true):
+# they are flaky / rate-limited in CI and docs.cordum.io 403s CI clients,
+# so checking them would make this gating job non-deterministic.
+
+offline = true
+no_progress = true
+max_concurrency = 32
+
+# --- Source trees excluded from scanning -------------------------------------
+# Historical / dated audit records that intentionally reference now-removed
+# paths (per the docs-consolidation epic), plus the Docusaurus static-asset
+# folder whose README placeholders use route-style (not-on-disk) links.
+exclude_path = [
+  "docs/internal/_audit",
+  "docs/internal/cleanup",
+  "docs/static",
+]
+
+# --- Individual links excluded (pre-existing baseline breaks) ----------------
+# These relative links were already broken when this gate was introduced
+# (lychee --offline baseline, 2026-05-24). The content fixes are owned by the
+# docs-accuracy task (task-8e555500); excluding them here snapshots the known
+# baseline so the gate fails only on NEW breakage, not pre-existing debt.
+exclude = [
+  # docs/cli-reference.md, docs/configuration-reference.md:
+  #   link "(delegation.md)" resolves to docs/delegation.md; file lives at docs/auth/delegation.md
+  "docs/delegation\\.md$",
+  # docs/mcp/resources.md: "(../../api/openapi.yaml)" — spec file not present in repo
+  "/api/openapi\\.yaml$",
+  # docs/troubleshooting/install.md: targets were never created under docs/deployment/
+  "docs/deployment/certs\\.md$",
+  "docs/deployment/worker-credentials\\.md$",
+]


### PR DESCRIPTION
## What
Adds `.github/workflows/docs-linkcheck.yml` — a lightweight **offline** markdown link-check over the in-repo `docs/**` surface — plus a `lychee.toml` config.

## Why
Retiring the orphan `docs-site/` tree (task-729b21ef / PR #291) removed `docs-deploy.yml`, which carried the only lychee link-check. `ci.yml` has none, so the canonical `docs/**` source (per RELEASING.md) was left unguarded against broken relative links. This restores that guard, scoped to the in-repo docs.

## Design
- **`--offline` only** — relative file links + in-document anchors; no external `http(s)` URLs (flaky/rate-limited in CI; `docs.cordum.io` 403s CI clients), keeping the gate deterministic.
- **Gating** (`fail: true`) — fails on any *new* broken link.
- **Baseline snapshot** — the 14 pre-existing `origin/main` breaks are excluded in `lychee.toml`: historical/static trees via `exclude_path` (`docs/internal/_audit`, `docs/internal/cleanup`, `docs/static`), and 6 individual content-link breaks via `exclude` (`delegation.md`, `api/openapi.yaml`, `deployment/certs.md`, `worker-credentials.md`). Those content fixes are owned by docs-accuracy task-8e555500; the gate fails only on regressions, not pre-existing debt.
- SHA-pinned `lychee-action` (same pin `docs-deploy.yml` used; dependabot tracks it); `actions/checkout@v4` per repo convention.
- **No docs-site build/deploy reintroduced** — link-checking only.

## Verification
- `lychee --config ./lychee.toml --offline 'docs/**/*.md'` against the full `origin/main` tree → **0 errors** (656 total, 614 OK, 42 excluded).
- Non-tautological: a planted broken relative link → lychee exits 2; removed → 0 again.

## Notes for maintainers
- The check **gates the run** (red/green on this PR) but won't be a *required* status check until added to branch-protection's required set (repo-admin action).
- Like the dropped check, the `paths:` filter means a break introduced by deleting a *non-docs* link target only surfaces on the next `docs/**` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated documentation link validation that runs on pull requests and main branch updates to catch broken links and maintain documentation quality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->