### PR TITLE
Mirror docs accuracy fixes and generate tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,15 @@ openapi:
 openapi-validate:
 	./tools/scripts/openapi-validate.sh
 
+# docs-tables regenerates the code-derived enumeration tables (RBAC permissions,
+# REST route index, MCP tool catalog) into the in-repo docs between their
+# BEGIN/END markers. docs-tables-check fails (for CI) when they are out of date.
+docs-tables:
+	go run ./tools/scripts/gen_docs_tables
+
+docs-tables-check:
+	go run ./tools/scripts/gen_docs_tables -check
+
 docker:
 	@test -n "$(SERVICE)" || (echo "SERVICE is required (e.g. SERVICE=cordum-scheduler)" && exit 1)
 	@BASE="$(SERVICE)"; BASE="$${BASE#cordum-}"; \
@@ -156,4 +165,4 @@ soak-ws-full:
 release-local:
 	@bash tools/scripts/release-local.sh
 
-.PHONY: help proto build build-all $(SERVICES:%=build-%) test test-integration coverage coverage-core openapi openapi-validate docker smoke verify-images demo-quickstart-test demo-mock-bank-test dev-up dev-down dev-logs edge-rebuild-e2e soak-ws soak-ws-quick soak-ws-full release-local
+.PHONY: help proto build build-all $(SERVICES:%=build-%) test test-integration coverage coverage-core openapi openapi-validate docs-tables docs-tables-check docker smoke verify-images demo-quickstart-test demo-mock-bank-test dev-up dev-down dev-logs edge-rebuild-e2e soak-ws soak-ws-quick soak-ws-full release-local

--- a/core/protocol/capsdk/constants.go
+++ b/core/protocol/capsdk/constants.go
@@ -16,6 +16,6 @@ const (
 	SubjectWorkflowApprovalGate = "job.cordum.approval-gate"
 
 	// DefaultProtocolVersion matches CAP wire version 1.
-	// Corresponds to CAP SDK v2.5.2 — wire protocol version remains 1.
+	// Corresponds to CAP SDK v2.13.1 — wire protocol version remains 1.
 	DefaultProtocolVersion = 1
 )

--- a/docs/AGENT_PROTOCOL.md
+++ b/docs/AGENT_PROTOCOL.md
@@ -102,7 +102,7 @@ Priority semantics:
   - `UpdateMemory(memory_id, logical_payload, model_response, mode)` → appends chat history or summaries.
 - Uses the same Redis instance; keys are namespaced under `mem:<memory_id>:*`.
 
-## Error Codes (CAP v2.5.2)
+## Error Codes (CAP v2.13.1)
 
 The `ErrorCode` enum provides structured error classification, replacing ad-hoc string error codes. Both string `error_code` and numeric `error_code_enum` are populated during the transition period.
 
@@ -137,7 +137,7 @@ Cordum upgraded its CAP dependency from v2.8.6 to v2.9.0. The wire contract gain
 
 See `AGENTS.md` § "Control Plane Boundary Hardening (recent)" for the operator-facing surface that consumes these fields (Topic Registry, Worker Credentials, schema enforcement modes).
 
-## Enhanced SystemAlert (CAP v2.5.2)
+## Enhanced SystemAlert (CAP v2.13.1)
 
 `SystemAlert` now carries structured fields alongside the deprecated string-based fields:
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -114,7 +114,7 @@ If no mapping exists: fail fast to DLQ with `no_pool_mapping`.
 - Workers come online in that pool.
 - Scheduler behavior remains unchanged.
 
-### CAP v2.5.2 Protocol Features (Scheduler)
+### CAP v2.13.1 Protocol Features (Scheduler)
 - **Handshake handling**: The scheduler subscribes to `sys.handshake` and processes `BusPacket{Handshake}` messages. Worker-role handshakes update the in-memory worker registry with component capabilities, enabling capability-aware routing.
 - **ErrorCode enum**: Job failures now carry a structured `error_code_enum` (`ErrorCode` enum) alongside the deprecated string `error_code`. The scheduler auto-populates `error_code_enum` from the string code when only the string is provided (e.g., `"timeout"` maps to `ERROR_CODE_JOB_TIMEOUT`). DLQ entries also carry the structured code.
 - **Bus-layer validation**: Incoming `JobRequest` and `JobResult` packets are validated using CAP SDK helpers (`ValidateJobRequest`/`ValidateJobResult`). Invalid packets are rejected, logged, and counted via the `validation_rejections_total` metric.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -20,7 +20,7 @@ Prereqs: Docker + Docker Compose. The smoke test script requires `curl` and `jq`
 | `context-engine` | `Dockerfile` (SERVICE=cordum-context-engine) | 50070 (gRPC) | `nc -z localhost 50070` | redis |
 | `safety-kernel` | `Dockerfile` (SERVICE=cordum-safety-kernel) | 50051 (gRPC) | `nc -z localhost 50051` | nats |
 | `scheduler` | `Dockerfile` (SERVICE=cordum-scheduler) | 9090 (metrics) | `GET /metrics` on :9090 | nats, redis, safety-kernel |
-| `api-gateway` | `Dockerfile` (SERVICE=cordum-api-gateway) | 8080 (HTTP), 8081 (health), 9092 (metrics) | `GET /health` on :8081 | nats, redis, scheduler, safety-kernel |
+| `api-gateway` | `Dockerfile` (SERVICE=cordum-api-gateway) | 8080 (gRPC, host: 9080), 8081 (HTTPS REST), 9092 (metrics) | `GET /health` on :8081 (HTTPS) | nats, redis, scheduler, safety-kernel |
 | `workflow-engine` | `Dockerfile` (SERVICE=cordum-workflow-engine) | 9093 (HTTP) | `GET /health` on :9093 | nats, redis, scheduler |
 | `dashboard` | `dashboard/Dockerfile` | 8082→8080 (nginx) | `GET /healthz` on :8080 | api-gateway |
 
@@ -190,7 +190,7 @@ healthcheck:
 | context-engine | `nc -z localhost 50070` | gRPC port open |
 | safety-kernel | `nc -z localhost 50051` | gRPC port open |
 | scheduler | `wget --spider -q http://127.0.0.1:9090/metrics` | Prometheus metrics endpoint |
-| api-gateway | `wget --spider -q http://127.0.0.1:8081/health` | Dedicated health HTTP endpoint |
+| api-gateway | `wget --spider -q --no-check-certificate https://127.0.0.1:8081/health` | Dedicated health HTTPS endpoint (gateway is TLS by default) |
 | workflow-engine | `wget --spider -q http://127.0.0.1:9093/health` | Dedicated health HTTP endpoint |
 | dashboard | `curl -f http://127.0.0.1:8080/healthz` | Nginx healthz endpoint |
 
@@ -206,12 +206,12 @@ docker inspect --format='{{.State.Health.Status}}' cordum-api-gateway-1
 # View recent health check logs
 docker inspect --format='{{range .State.Health.Log}}{{.Output}}{{end}}' cordum-redis-1
 
-# Hit gateway health endpoint directly
-curl -s http://localhost:8081/health | jq .
+# Hit gateway health endpoint directly (TLS on by default)
+curl -s --cacert ./certs/ca/ca.crt https://localhost:8081/health | jq .
 
 # Hit gateway status endpoint (detailed)
-curl -s -H "X-API-Key: $CORDUM_API_KEY" -H "X-Tenant-ID: default" \
-  http://localhost:8080/api/v1/status | jq .
+curl -s --cacert ./certs/ca/ca.crt -H "X-API-Key: $CORDUM_API_KEY" -H "X-Tenant-ID: default" \
+  https://localhost:8081/api/v1/status | jq .
 ```
 
 ### Tuning Health Checks for Slow Machines
@@ -252,8 +252,8 @@ healthcheck:
 | `REDIS_URL` | `redis://:$REDIS_PASSWORD@redis:6379` | Redis connection URL |
 | `SAFETY_KERNEL_ADDR` | `safety-kernel:50051` | gRPC address of safety kernel |
 | `TENANT_ID` | `default` | Default tenant ID |
-| `API_RATE_LIMIT_RPS` | `2000` | Requests per second limit |
-| `API_RATE_LIMIT_BURST` | `4000` | Burst capacity |
+| `API_RATE_LIMIT_RPS` | `30` | Authenticated per-tenant requests/sec limit |
+| `API_RATE_LIMIT_BURST` | `50` | Authenticated burst capacity |
 | `REDIS_DATA_TTL` | `24h` | TTL for cached data in Redis |
 | `JOB_META_TTL` | `168h` | TTL for job metadata |
 | `CORDUM_USER_AUTH_ENABLED` | `false` | Enable user/password authentication |
@@ -479,7 +479,7 @@ The Go services don't support hot reload inside Docker. For rapid iteration:
 2. Run Go services locally with `go run ./cmd/cordum-api-gateway`
 3. Point local services at Docker infra: `NATS_URL=nats://localhost:4222 REDIS_URL=redis://:$REDIS_PASSWORD@localhost:6379`
 
-For the dashboard, run `npm run dev` in `dashboard/` and configure `VITE_API_URL=http://localhost:8080/api/v1`.
+For the dashboard, run `npm run dev` in `dashboard/` and configure `VITE_API_URL=https://localhost:8081/api/v1` (the gateway HTTP API listens on `8081` over TLS; `8080` is the internal gRPC port, host-mapped to `9080`).
 
 ---
 
@@ -601,7 +601,7 @@ CORDUM_API_KEYS='[{"key":"k1","role":"admin","tenant":"default","expires_at":"20
 To rotate keys without a restart, set `CORDUM_API_KEYS_PATH` to a file with the
 same content; the gateway reloads on change.
 
-Enterprise deployments (multi-tenant keys, RBAC, SSO, SIEM export) are configured in the enterprise repo.
+Enterprise features (multi-tenant keys, RBAC, SSO, SIEM export) are built into core behind license entitlements — the standalone `cordum-enterprise` repo was retired 2026-04-23. See [`enterprise.md`](enterprise.md).
 
 ## Config Mounts
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -614,28 +614,72 @@ All endpoints require admin role. Write operations (PUT, DELETE) require the `RB
 
 ### Available Permissions
 
-| Permission | Description |
-|-----------|-------------|
-| `admin.*` | Full access (wildcard) |
-| `jobs.read` | View jobs |
-| `jobs.write` | Create/edit jobs |
-| `jobs.approve` | Approve jobs |
-| `workflows.read` | View workflows |
-| `workflows.write` | Create/edit workflows |
-| `workers.read` | View workers |
-| `config.read` | View configuration |
-| `config.write` | Edit configuration |
-| `audit.read` | View audit log |
-| `packs.install` | Install packs |
-| `packs.uninstall` | Uninstall packs |
-| `policy.read` | View policies |
-| `policy.write` | Edit policies |
-| `schemas.read` | View schemas |
-| `schemas.write` | Edit schemas |
-| `users.read` | View users |
-| `users.write` | Manage users |
-| `roles.read` | View roles |
-| `roles.write` | Manage roles |
+<!-- BEGIN:rbac-permissions -->
+
+_Generated from `core/controlplane/gateway/auth/rbac.go` (`auth.AllPermissions`) — do not edit by hand; run `make docs-tables`. 58 permissions._
+
+| Permission | Resource | Action |
+|------------|----------|--------|
+| `admin.*` | `admin` | `*` |
+| `agents.delegate` | `agents` | `delegate` |
+| `agents.read` | `agents` | `read` |
+| `agents.write` | `agents` | `write` |
+| `apiKeys.read` | `apiKeys` | `read` |
+| `apiKeys.write` | `apiKeys` | `write` |
+| `audit.export` | `audit` | `export` |
+| `audit.read` | `audit` | `read` |
+| `audit.verify` | `audit` | `verify` |
+| `config.read` | `config` | `read` |
+| `config.write` | `config` | `write` |
+| `delegation.impersonate` | `delegation` | `impersonate` |
+| `delegation.read` | `delegation` | `read` |
+| `dlq.read` | `dlq` | `read` |
+| `dlq.write` | `dlq` | `write` |
+| `edge.runtime.ingest` | `edge.runtime` | `ingest` |
+| `evals.datasets.delete` | `evals.datasets` | `delete` |
+| `evals.datasets.read` | `evals.datasets` | `read` |
+| `evals.datasets.write` | `evals.datasets` | `write` |
+| `evals.runs.delete` | `evals.runs` | `delete` |
+| `evals.runs.execute` | `evals.runs` | `execute` |
+| `evals.runs.read` | `evals.runs` | `read` |
+| `governance.read` | `governance` | `read` |
+| `jobs.approve` | `jobs` | `approve` |
+| `jobs.read` | `jobs` | `read` |
+| `jobs.write` | `jobs` | `write` |
+| `legalHold.read` | `legalHold` | `read` |
+| `legalHold.write` | `legalHold` | `write` |
+| `license.read` | `license` | `read` |
+| `locks.read` | `locks` | `read` |
+| `mcp.read` | `mcp` | `read` |
+| `mcp.verify` | `mcp` | `verify` |
+| `memory.read` | `memory` | `read` |
+| `packs.install` | `packs` | `install` |
+| `packs.read` | `packs` | `read` |
+| `packs.uninstall` | `packs` | `uninstall` |
+| `packs.verify` | `packs` | `verify` |
+| `policy.read` | `policy` | `read` |
+| `policy.write` | `policy` | `write` |
+| `pools.write` | `pools` | `write` |
+| `roles.read` | `roles` | `read` |
+| `roles.write` | `roles` | `write` |
+| `schemas.read` | `schemas` | `read` |
+| `schemas.write` | `schemas` | `write` |
+| `shadow.exception.high_risk` | `shadow.exception` | `high_risk` |
+| `telemetry.export` | `telemetry` | `export` |
+| `telemetry.read` | `telemetry` | `read` |
+| `telemetry.write` | `telemetry` | `write` |
+| `topics.read` | `topics` | `read` |
+| `topics.write` | `topics` | `write` |
+| `users.read` | `users` | `read` |
+| `users.write` | `users` | `write` |
+| `workerCredentials.read` | `workerCredentials` | `read` |
+| `workerCredentials.write` | `workerCredentials` | `write` |
+| `workers.read` | `workers` | `read` |
+| `workers.write` | `workers` | `write` |
+| `workflows.read` | `workflows` | `read` |
+| `workflows.write` | `workflows` | `write` |
+
+<!-- END:rbac-permissions -->
 
 ---
 
@@ -2988,17 +3032,18 @@ curl -X POST https://gateway:8081/api/v1/pools/gpu-batch/drain \
 
 ## Endpoint Index (Registered Routes)
 
-The following routes are registered in gateway route setup.
+The following routes are registered in the gateway (`registerRoute` calls). Generated from code.
+
+<!-- BEGIN:rest-routes -->
+
+_Generated from `core/controlplane/gateway/gateway.go`, `core/controlplane/gateway/handlers_mcp.go` (registration order) — do not edit by hand; run `make docs-tables`. 226 routes._
 
 | Method | Path |
-|---|---|
+|--------|------|
 | GET | `/health` |
+| GET | `/api/v1/health` |
 | GET | `/api/v1/auth/config` |
-| GET | `/api/v1/auth/sso/oidc/login` |
-| GET | `/api/v1/auth/sso/oidc/callback` |
-| GET | `/api/v1/auth/sso/saml/metadata` |
-| GET | `/api/v1/auth/sso/saml/login` |
-| POST | `/api/v1/auth/sso/saml/acs` |
+| PUT | `/api/v1/auth/oidc/group-role-mapping` |
 | POST | `/api/v1/auth/login` |
 | GET | `/api/v1/auth/session` |
 | POST | `/api/v1/auth/logout` |
@@ -3011,23 +3056,111 @@ The following routes are registered in gateway route setup.
 | GET | `/api/v1/auth/keys` |
 | POST | `/api/v1/auth/keys` |
 | DELETE | `/api/v1/auth/keys/{id}` |
+| GET | `/api/v1/auth/roles` |
+| GET | `/api/v1/auth/roles/{name}` |
+| PUT | `/api/v1/auth/roles/{name}` |
+| DELETE | `/api/v1/auth/roles/{name}` |
 | GET | `/api/v1/workers` |
 | GET | `/api/v1/workers/{id}` |
 | GET | `/api/v1/workers/{id}/jobs` |
+| POST | `/api/v1/workers/{id}/revoke-session` |
 | GET | `/api/v1/workers/credentials` |
 | POST | `/api/v1/workers/credentials` |
 | DELETE | `/api/v1/workers/credentials/{worker_id}` |
+| GET | `/api/v1/agents` |
+| POST | `/api/v1/agents` |
+| GET | `/api/v1/agents/{id}` |
+| PUT | `/api/v1/agents/{id}` |
+| DELETE | `/api/v1/agents/{id}` |
+| GET | `/api/v1/agents/{id}/stats` |
+| GET | `/api/v1/agents/{id}/delegations` |
+| POST | `/api/v1/agents/{id}/delegate` |
+| GET | `/api/v1/delegations` |
+| POST | `/api/v1/agents/verify-delegation` |
+| POST | `/api/v1/agents/revoke-delegation` |
+| GET | `/api/v1/pools` |
+| GET | `/api/v1/pools/{name}` |
+| GET | `/api/v1/topics` |
+| POST | `/api/v1/topics` |
+| DELETE | `/api/v1/topics/{name}` |
+| PUT | `/api/v1/pools/{name}` |
+| PATCH | `/api/v1/pools/{name}` |
+| DELETE | `/api/v1/pools/{name}` |
+| POST | `/api/v1/pools/{name}/drain` |
+| PUT | `/api/v1/pools/{name}/topics/{topic}` |
+| DELETE | `/api/v1/pools/{name}/topics/{topic}` |
 | GET | `/api/v1/status` |
+| GET | `/api/v1/license` |
+| GET | `/api/v1/license/usage` |
+| POST | `/api/v1/license/reload` |
+| GET | `/api/v1/telemetry/status` |
+| GET | `/api/v1/telemetry/inspect` |
+| GET | `/api/v1/telemetry/export` |
+| GET | `/api/v1/telemetry/usage` |
+| POST | `/api/v1/telemetry/consent` |
+| GET | `/api/v1/admin/locks` |
+| GET | `/api/v1/audit/export` |
+| GET | `/api/v1/audit/export/health` |
+| GET | `/api/v1/audit/export/config` |
+| POST | `/api/v1/audit/export/test` |
+| GET | `/api/v1/audit/verify` |
+| GET | `/api/v1/audit/events` |
+| GET | `/api/v1/governance/health` |
+| POST | `/api/v1/audit/legal-hold` |
+| GET | `/api/v1/audit/legal-holds` |
+| DELETE | `/api/v1/audit/legal-hold/{id}` |
 | GET | `/api/v1/jobs` |
-| POST | `/api/v1/jobs` |
+| GET | `/api/v1/copilot/sessions/{sessionId}` |
 | GET | `/api/v1/jobs/{id}` |
 | GET | `/api/v1/jobs/{id}/stream` |
 | GET | `/api/v1/jobs/{id}/decisions` |
 | POST | `/api/v1/jobs/{id}/cancel` |
 | POST | `/api/v1/jobs/{id}/remediate` |
+| POST | `/api/v1/edge/sessions` |
+| GET | `/api/v1/edge/sessions` |
+| GET | `/api/v1/edge/sessions/{session_id}` |
+| POST | `/api/v1/edge/sessions/{session_id}/heartbeat` |
+| POST | `/api/v1/edge/sessions/{session_id}/end` |
+| POST | `/api/v1/edge/executions` |
+| GET | `/api/v1/edge/executions` |
+| GET | `/api/v1/edge/executions/{execution_id}` |
+| POST | `/api/v1/edge/executions/{execution_id}/end` |
+| GET | `/api/v1/edge/approvals` |
+| GET | `/api/v1/edge/approvals/{approval_ref}` |
+| POST | `/api/v1/edge/approvals/{approval_ref}/approve` |
+| POST | `/api/v1/edge/approvals/{approval_ref}/reject` |
+| POST | `/api/v1/edge/approvals/{approval_ref}/wait` |
+| POST | `/api/v1/edge/evaluate` |
+| POST | `/api/v1/edge/binary-integrity/events` |
+| GET | `/api/v1/edge/binary-integrity/events` |
+| POST | `/api/v1/edge/shadow-agents` |
+| GET | `/api/v1/edge/shadow-agents` |
+| GET | `/api/v1/edge/shadow-agents/{finding_id}` |
+| POST | `/api/v1/edge/shadow-agents/{finding_id}/resolve` |
+| POST | `/api/v1/edge/shadow-agents/{finding_id}/suppress` |
+| POST | `/api/v1/edge/shadow-agents/{finding_id}/ignore` |
+| POST | `/api/v1/edge/shadow-agents/{finding_id}/remediation` |
+| POST | `/api/v1/edge/shadow/exception` |
+| GET | `/api/v1/edge/shadow/exception/{exception_id}` |
+| DELETE | `/api/v1/edge/shadow/exception/{exception_id}` |
+| GET | `/api/v1/edge/shadow/exceptions` |
+| GET | `/api/v1/edge/mcp/upstreams` |
+| GET | `/api/v1/edge/mcp/upstreams/list` |
+| POST | `/api/v1/edge/mcp/upstreams` |
+| GET | `/api/v1/edge/mcp/upstreams/{name}` |
+| PUT | `/api/v1/edge/mcp/upstreams/{name}` |
+| POST | `/api/v1/edge/mcp/upstreams/{name}/disable` |
+| POST | `/api/v1/edge/mcp/upstreams/{name}/enable` |
+| POST | `/api/v1/edge/events` |
+| POST | `/api/v1/edge/events/batch` |
+| GET | `/api/v1/edge/sessions/{session_id}/events` |
+| GET | `/api/v1/edge/executions/{execution_id}/events` |
+| POST | `/api/v1/edge/sessions/{session_id}/export` |
+| POST | `/api/v1/edge/runtime/events` |
 | GET | `/api/v1/memory` |
 | POST | `/api/v1/artifacts` |
 | GET | `/api/v1/artifacts/{ptr}` |
+| POST | `/api/v1/jobs` |
 | GET | `/api/v1/traces/{id}` |
 | GET | `/api/v1/workflows` |
 | POST | `/api/v1/workflows` |
@@ -3035,7 +3168,6 @@ The following routes are registered in gateway route setup.
 | DELETE | `/api/v1/workflows/{id}` |
 | POST | `/api/v1/workflows/{id}/runs` |
 | GET | `/api/v1/workflows/{id}/runs` |
-| POST | `/api/v1/workflows/{id}/dry-run` |
 | GET | `/api/v1/workflow-runs` |
 | GET | `/api/v1/workflow-runs/{id}` |
 | GET | `/api/v1/workflow-runs/{id}/timeline` |
@@ -3043,12 +3175,11 @@ The following routes are registered in gateway route setup.
 | POST | `/api/v1/workflow-runs/{id}/chat` |
 | DELETE | `/api/v1/workflow-runs/{id}` |
 | POST | `/api/v1/workflow-runs/{id}/rerun` |
+| POST | `/api/v1/workflows/{id}/dry-run` |
 | GET | `/api/v1/config` |
 | GET | `/api/v1/config/effective` |
+| PUT | `/api/v1/config` |
 | POST | `/api/v1/config` |
-| GET | `/api/v1/topics` |
-| POST | `/api/v1/topics` |
-| DELETE | `/api/v1/topics/{name}` |
 | GET | `/api/v1/packs` |
 | GET | `/api/v1/packs/{id}` |
 | POST | `/api/v1/packs/install` |
@@ -3073,40 +3204,67 @@ The following routes are registered in gateway route setup.
 | POST | `/api/v1/approvals/{job_id}/approve` |
 | POST | `/api/v1/approvals/{job_id}/reject` |
 | POST | `/api/v1/approvals/{job_id}/repair` |
+| GET | `/api/v1/approvals/{job_id}/context` |
+| GET | `/api/v1/governance/decisions` |
+| GET | `/api/v1/governance/approvals/analytics` |
+| GET | `/api/v1/mcp/approvals` |
+| GET | `/api/v1/mcp/approvals/{id}` |
+| POST | `/api/v1/mcp/approvals/{id}/approve` |
+| POST | `/api/v1/mcp/approvals/{id}/reject` |
+| POST | `/api/v1/mcp/verify-signature` |
+| GET | `/api/v1/mcp/outbound` |
+| GET | `/api/v1/mcp/usage` |
+| GET | `/api/v1/mcp/tools` |
+| GET | `/api/v1/agents/{id}/tools` |
+| GET | `/api/v1/agents/{id}/denied-events` |
+| GET | `/api/v1/mcp/gateway/health` |
+| GET | `/api/v1/mcp/gateway/config` |
+| POST | `/api/v1/mcp/gateway/upstream` |
+|  | `/api/v1/mcp/gateway/upstream/` |
+| POST | `/api/v1/mcp/gateway/clients/connect` |
 | POST | `/api/v1/policy/evaluate` |
 | POST | `/api/v1/policy/simulate` |
 | POST | `/api/v1/policy/explain` |
 | GET | `/api/v1/policy/snapshots` |
 | GET | `/api/v1/policy/rules` |
+| GET | `/api/v1/policy/output/rules` |
+| GET | `/api/v1/policy/output/stats` |
+| PUT | `/api/v1/policy/output/rules/{id}` |
 | GET | `/api/v1/policy/velocity-rules` |
-| POST | `/api/v1/policy/velocity-rules` |
 | GET | `/api/v1/policy/velocity-rules/stats` |
+| POST | `/api/v1/policy/velocity-rules` |
 | PUT | `/api/v1/policy/velocity-rules/{id}` |
 | DELETE | `/api/v1/policy/velocity-rules/{id}` |
+| GET | `/api/v1/policy/global` |
+| PUT | `/api/v1/policy/global` |
 | GET | `/api/v1/policy/bundles` |
 | GET | `/api/v1/policy/bundles/{id}` |
 | PUT | `/api/v1/policy/bundles/{id}` |
 | DELETE | `/api/v1/policy/bundles/{id}` |
 | POST | `/api/v1/policy/bundles/{id}/simulate` |
+| PUT | `/api/v1/policy/shadows/{id}` |
+| GET | `/api/v1/policy/shadows/{id}` |
+| DELETE | `/api/v1/policy/shadows/{id}` |
+| GET | `/api/v1/policy/shadows/{id}/results/summary` |
+| GET | `/api/v1/policy/shadows/{id}/results/comparisons` |
+| GET | `/api/v1/policy/shadows/{id}/results/timeseries` |
 | GET | `/api/v1/policy/bundles/snapshots` |
 | POST | `/api/v1/policy/bundles/snapshots` |
 | GET | `/api/v1/policy/bundles/snapshots/{id}` |
 | POST | `/api/v1/policy/publish` |
 | POST | `/api/v1/policy/rollback` |
 | GET | `/api/v1/policy/audit` |
-| GET | `/api/v1/policy/output/rules` |
-| GET | `/api/v1/policy/output/stats` |
-| PUT | `/api/v1/policy/output/rules/{id}` |
-| GET | `/api/v1/pools` |
-| GET | `/api/v1/pools/{name}` |
-| PUT | `/api/v1/pools/{name}` |
-| PATCH | `/api/v1/pools/{name}` |
-| DELETE | `/api/v1/pools/{name}` |
-| POST | `/api/v1/pools/{name}/drain` |
-| PUT | `/api/v1/pools/{name}/topics/{topic}` |
-| DELETE | `/api/v1/pools/{name}/topics/{topic}` |
-| GET | `/api/v1/admin/locks` |
-| GET | `/api/v1/stream` (websocket upgrade) |
+| POST | `/api/v1/policy/replay` |
+| POST | `/api/v1/policy/analytics` |
+| POST | `/api/v1/evals/datasets/from-incidents` |
+| POST | `/api/v1/evals/datasets` |
+| GET | `/api/v1/evals/datasets` |
+|  | `/api/v1/evals/datasets/` |
+| GET | `/api/v1/evals/runs/{run_id}` |
+| DELETE | `/api/v1/evals/runs/{run_id}` |
+|  | `/api/v1/stream` |
 | GET | `/mcp/sse` |
 | POST | `/mcp/message` |
 | GET | `/mcp/status` |
+
+<!-- END:rest-routes -->

--- a/docs/backend_feature_matrix.md
+++ b/docs/backend_feature_matrix.md
@@ -17,7 +17,7 @@ This table tracks key backend features, their implementation status, and test co
 | Artifact store | Yes | None | Redis-backed store (`core/infra/artifacts`). |
 | Gateway HTTP/WS endpoints | Yes | Unit (`core/controlplane/gateway/gateway_test.go`) | Jobs, workflows, approvals, policy (bundles/publish/rollback/audit), schemas, locks, artifacts, DLQ. |
 | Auth (OSS) | Yes | Unit (gateway tests) | API key allowlist (`CORDUM_API_KEYS`/`CORDUM_API_KEY`) with single-tenant default; `X-Tenant-ID` required on HTTP. |
-| Auth (enterprise) | Yes | Unit (enterprise repo) | Multi-tenant API keys and RBAC enforced by the enterprise auth provider. |
+| Auth (enterprise) | Yes | Unit (gateway tests) | Multi-tenant API keys and RBAC enforced in core (`core/controlplane/gateway/auth/`) behind license entitlements. The standalone `cordum-enterprise` repo was retired 2026-04-23; these features are unified in core, license-gated. |
 | Worker runtime SDK | Yes | None | `sdk/runtime` wraps CAP runtime (typed handlers + pointer hydration). |
 | CLI (cordumctl) | Yes | None | `cmd/cordumctl` + smoke script; ships as `cordumctl`. |
 | Topic Registry | Yes | Unit + integration | `GET/POST/DELETE /api/v1/topics`; submit-time topic validation at gateway and scheduler boundaries; pack manifest `inputSchema`/`outputSchema` registered at install. |
@@ -27,7 +27,7 @@ This table tracks key backend features, their implementation status, and test co
 | Approvals + Delegations | Yes | Unit + integration (`handlers_approvals.go`, `handlers_delegation*.go`) | A2A delegation tokens, cascade revocation, scheduler dispatch-time re-verify, nonce/replay protection, `auth.PermDelegationImpersonate`. |
 | Audit verification pipeline | Yes | Unit + integration (`core/audit/`, `core/audit/exporter*`) | Chain verification + consumer + legal-hold + multi-backend exporter (webhook HMAC-SHA256, syslog RFC 5424, Datadog v2, CloudWatch Logs SigV4). |
 | Governance Timeline + analytics | Yes | Unit (`handlers_governance_*.go`, `useGovernanceHealth`, `useApprovalAnalytics`) | `/api/v1/governance/decisions`, `/api/v1/governance/health`, `/api/v1/governance/approvals/analytics`. |
-| MCP Server | Yes | Unit + integration (`cmd/cordum-mcp`, `gateway_mcp.go`) | stdio + HTTP/SSE transport; tool registry; tool-approval flow; `cordum://` resource resolution; audit hook. |
+| MCP Server | Yes | Unit + integration (`cmd/cordum-mcp`, `handlers_mcp.go`) | stdio + HTTP/SSE transport; tool registry; tool-approval flow; `cordum://` resource resolution; audit hook. |
 | Evals | Yes | Unit + dashboard hooks (`useEvals`) | Evaluations CRUD + run; `EvalsPage` + `EvalDatasetDetailPage` + `EvalRunDetailPage` dashboard surfaces. |
 | Enterprise (consolidated into core) | Yes | Unit (gateway + auth) | SSO/SAML/OIDC, SCIM provisioning, RBAC, SIEM export (4 backends), legal hold — all behind license entitlements; cordum-enterprise repo retired 2026-04-23. |
 | Workflow new step types | Yes | Unit (`core/workflow/*_test.go`) | Switch, parallel, loop, transform, storage, sub-workflow. |

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -791,17 +791,16 @@ Invalid values (non-numeric, zero, negative) are silently replaced with defaults
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GATEWAY_GRPC_ADDR` | `:50051` | gRPC listen address |
-| `GATEWAY_HTTP_ADDR` | `:8080` | HTTP listen address |
-| `GATEWAY_METRICS_ADDR` | `:9090` | Metrics listen address |
+| `GATEWAY_GRPC_ADDR` | `:8080` | gRPC listen address (the dev `docker-compose.yml` host-maps this to `9080`; the release compose maps `8080:8080`) |
+| `GATEWAY_HTTP_ADDR` | `:8081` | HTTP/REST listen address (TLS by default) |
+| `GATEWAY_METRICS_ADDR` | `:9092` | Metrics listen address |
 | `GATEWAY_METRICS_PUBLIC` | — | Set to `1` for non-loopback metrics in production |
 | `GATEWAY_HTTP_TLS_CERT` | — | HTTP TLS certificate path |
 | `GATEWAY_HTTP_TLS_KEY` | — | HTTP TLS private key path |
 | `GRPC_TLS_CERT` | — | gRPC TLS certificate path |
 | `GRPC_TLS_KEY` | — | gRPC TLS private key path |
-| `GATEWAY_MAX_JOB_PAYLOAD_BYTES` | `2097152` (2 MB) | Max job submission payload size in bytes |
-| `GATEWAY_MAX_BODY_BYTES` | `1048576` (1 MB) | Max HTTP request body size in bytes |
-| `GATEWAY_MAX_JSON_BODY_BYTES` | — | Max JSON request body size |
+| `GATEWAY_MAX_JOB_PAYLOAD_BYTES` | `2097152` (2 MiB) | Max job submission payload size in bytes |
+| `GATEWAY_MAX_JSON_BODY_BYTES` | `2097152` (2 MiB) | Max JSON request body size in bytes |
 | `TENANT_ID` | — | Single-tenant default ID |
 | `ARTIFACT_MAX_BYTES` | — | Max artifact upload/download size |
 | `WORKFLOW_FOREACH_MAX_ITEMS` | — | Max items in workflow for-each expansion |
@@ -822,8 +821,8 @@ Invalid values (non-numeric, zero, negative) are silently replaced with defaults
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `API_RATE_LIMIT_RPS` | `2000` | Per-tenant rate limit (requests/sec) |
-| `API_RATE_LIMIT_BURST` | `4000` | Per-tenant burst size |
+| `API_RATE_LIMIT_RPS` | `30` | Per-tenant rate limit (requests/sec) |
+| `API_RATE_LIMIT_BURST` | `50` | Per-tenant burst size |
 | `API_PUBLIC_RATE_LIMIT_RPS` | `20` | Public (unauthenticated) rate limit |
 | `API_PUBLIC_RATE_LIMIT_BURST` | `40` | Public burst size |
 | `REDIS_RATE_LIMIT` | `true` | Enable Redis-backed distributed rate limiting. When `true`, rate limits are enforced globally across all gateway replicas via Redis sliding-window counters (key format: `cordum:rl:{key}:{unix_second}`). When `false` or Redis unavailable, falls back to per-process in-memory token buckets (effective limit = N × configured limit with N replicas). |

--- a/docs/cordumctl.md
+++ b/docs/cordumctl.md
@@ -78,8 +78,8 @@ cordumctl run start --dry-run <workflow_id>
 cordumctl run timeline <run_id>
 cordumctl run delete <run_id>
 cordumctl approval step --approve <workflow_id> <run_id> <step_id>
-cordumctl approval job --approve <job_id>
-cordumctl approval job --reject <job_id>
+cordumctl approval job <job_id> --approve
+cordumctl approval job <job_id> --reject
 ```
 
 ## Jobs

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -68,8 +68,9 @@ For full TLS details, see [TLS Setup Guide](guides/tls-setup.md).
 
 ## Enterprise gateway
 
-Enterprise setup and licensing live in the enterprise repo. See `docs/enterprise.md`
-for details.
+Enterprise features (SSO/SAML, SCIM, advanced RBAC, SIEM export, legal hold) are
+built into core behind license entitlements — the standalone `cordum-enterprise`
+repo was retired 2026-04-23. See `docs/enterprise.md` for setup and licensing.
 
 ## Run a workflow smoke test
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -30,7 +30,7 @@ Primary code paths:
 - `core/mcp/server.go`
 - `core/mcp/transport_stdio.go`
 - `core/mcp/transport_http.go`
-- `core/controlplane/gateway/gateway_mcp.go`
+- `core/controlplane/gateway/handlers_mcp.go`
 
 ## Transport Modes
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -5,105 +5,41 @@ All tool calls are JSON-RPC `tools/call` requests and require gateway auth.
 
 ## Tool Catalog
 
-### `cordum_submit_job`
+<!-- BEGIN:mcp-tools -->
 
-- Purpose: Submit a new job into Cordum's scheduler pipeline.
-- Input:
-  - `prompt` (string, required)
-  - `topic` (string, default `job.default`)
-  - `priority` (`low|normal|high|critical`, default `normal`)
-  - `capability` (string, optional)
-  - `risk_tags` (string[], optional)
-  - `labels` (object<string,string>, optional)
-  - `memory_id` (string, optional)
-  - `pack_id` (string, optional)
-- Output:
-  - `job_id` (string)
-  - `trace_id` (string)
-  - `status` (`pending`)
-- Error codes:
-  - `idempotency_conflict`
-  - `system_at_capacity`
-  - `submit_failed`
+_Generated from `core/mcp` via `RegisterAllTools` — do not edit by hand; run `make docs-tables`. 27 tools._
 
-### `cordum_cancel_job`
+| Tool | Approval | Scope | Description |
+|------|----------|-------|-------------|
+| `cordum_approve_job` | — | `—` | Approve a job that requires human approval before execution. |
+| `cordum_audit_query` | — | `—` | Search the audit chain for SIEMEvents matching filters like tenant, event_type, and time window. Use this when the operator asks 'who changed policy X?', 'what happened around time T?', or 'did tool Y get called?'. Returns chain-verified events (seq + event_hash + prev_hash) so callers can prove integrity downstream. |
+| `cordum_audit_verify` | — | `—` | Walk the tenant's audit Merkle chain and report integrity: ok / compromised / partial. Use this when the operator asks 'is our audit log clean?' or before handing a compliance auditor evidence. Response includes any gaps with sequence numbers. |
+| `cordum_cancel_job` | — | `—` | Cancel a running or pending job. |
+| `cordum_create_workflow` | required | `mcp_write` | Create a new workflow definition from a spec. Use this when: the operator describes a multi-step automation and wants it registered so it can be triggered by `cordum_trigger_workflow` later. Returns the new workflow_id. This tool requires human approval by default. On first call, expect a JSON-RPC -32099 error with an approval_id in the data — surface the dashboard link (/approvals?mcp=<id>) to the operator and retry the call after they approve. |
+| `cordum_get_job` | — | `—` | Fetch the full record for a single job by id, including prompt, topic, policy decision, retry history, and final state. Use this when the operator says 'show me job X' or 'why did job X fail?' — the response includes the safety decision and any denial reason. |
+| `cordum_get_run` | — | `—` | Fetch a workflow run by id with its graph state, pending steps, and outputs. Use this when the operator says 'what is run X doing now?' or 'did run X finish?'. |
+| `cordum_install_pack` | required | `mcp_write` | Install a marketplace pack so its capabilities become available to agents. Use this when: the operator asks to 'install X' or 'add the X integration'. Returns {pack_id, version, installed}. This tool requires human approval by default. On first call, expect a JSON-RPC -32099 error with an approval_id in the data — surface the dashboard link (/approvals?mcp=<id>) to the operator and retry the call after they approve. |
+| `cordum_list_agents` | — | `—` | List agent identities configured in Cordum — their allowed tools, risk tier, and data classifications. Use this when the operator asks 'which agents can call tool X?' or is reviewing an agent before granting a new scope. |
+| `cordum_list_jobs` | — | `—` | List jobs the caller's tenant has submitted to Cordum, newest first. Returns job id, topic, state, submitter, and timestamps. Use this when the operator asks 'what jobs ran today?', 'any failures in the last hour?', or needs to find a job id before cancelling or inspecting it. |
+| `cordum_list_packs` | — | `—` | List installed integration packs (Slack, GitHub, AWS, etc.) and their status. Use this when the operator asks 'what integrations are live?' or 'is the Slack pack installed?'. Returns pack id, version, enabled, and install timestamp. |
+| `cordum_list_pending_approvals` | — | `—` | List approval requests currently waiting for a human decision across both job approvals and MCP tool-call approvals. Use this when the operator says 'what needs my approval?' or before batch-approving with cordumctl. |
+| `cordum_list_runs` | — | `—` | List workflow runs the tenant has initiated, newest first. Includes run id, workflow id, state, start/end timestamps. Use this when the operator asks 'which workflows are running now?' or wants to page through recent runs before opening one. |
+| `cordum_list_topics` | — | `—` | List job topics registered on the platform — the allow-listed channels jobs can be published to. Use this when the operator asks 'what topics can I submit to?' or is authoring a policy and needs the topic catalogue. |
+| `cordum_list_workers` | — | `—` | List workers currently registered (both in-cluster and external). Each entry has worker id, pool, capabilities, last-seen, status. Use this when the operator asks 'which agents are online?' or 'is worker X reachable?'. |
+| `cordum_list_workflows` | — | `—` | List workflow definitions available to the tenant. Each entry has workflow id, version, human title, and step count. Use this when the operator asks 'what workflows do I have?' or needs a workflow id before triggering a run. |
+| `cordum_query_policy` | — | `—` | Simulate policy evaluation without submitting a job. |
+| `cordum_register_agent` | required | `mcp_write_admin` | Register a new AI agent identity so it can authenticate against the MCP gateway. Use this when: the operator wants to bring a new CI bot, agent framework, or LLM client onto the platform. Returns the stable agent ID. This tool requires human approval by default. On first call, expect a JSON-RPC -32099 error with an approval_id in the data — surface the dashboard link (/approvals?mcp=<id>) to the operator and retry the call after they approve. |
+| `cordum_reject_job` | — | `—` | Reject a job that requires human approval before execution. |
+| `cordum_revoke_worker_session` | required | `mcp_write_admin` | Revoke a worker's active session credential, forcing it to re-authenticate. Use this when: a credential has been compromised, rotated, or the worker is being decommissioned. This tool requires human approval by default. On first call, expect a JSON-RPC -32099 error with an approval_id in the data — surface the dashboard link (/approvals?mcp=<id>) to the operator and retry the call after they approve. |
+| `cordum_run_timeline` | — | `—` | Return the ordered timeline of state transitions and step events for a workflow run. Use this when debugging — the operator asks 'what happened in run X?' or 'where did run X get stuck?'. Output is a list of {timestamp, event_type, step_id, details}. |
+| `cordum_set_agent_scope` | required | `mcp_write_admin` | Update an agent's authorized tool list and mutating-tool preapproval allowlist. Use this when: the operator wants to grant / revoke capabilities for an existing identity. The `preapproved_mutating_tools` field is high-privilege — agents on that list bypass human approval for the listed mutating calls. Reserve for CI bots. This tool requires human approval by default. On first call, expect a JSON-RPC -32099 error with an approval_id in the data — surface the dashboard link (/approvals?mcp=<id>) to the operator and retry the call after they approve. |
+| `cordum_status` | — | `—` | Report platform health at a glance: queue depth, per-component readiness, last policy snapshot, active worker count. Use this when the operator asks 'is Cordum healthy?' or 'how far behind is the scheduler?'. |
+| `cordum_submit_job` | — | `—` | Submit a new job to Cordum for agent execution. |
+| `cordum_trigger_workflow` | — | `—` | Start a workflow run with input parameters. |
+| `cordum_uninstall_pack` | required | `mcp_write_admin` | Uninstall a previously installed pack, revoking its capabilities. Use this when: the operator asks to 'remove' or 'uninstall' a pack or flags one as compromised. This tool requires human approval by default. On first call, expect a JSON-RPC -32099 error with an approval_id in the data — surface the dashboard link (/approvals?mcp=<id>) to the operator and retry the call after they approve. |
+| `cordum_update_policy_bundle` | required | `mcp_write_admin` | Save a new version of a policy bundle. The gateway signs the content with the tenant's policy-signing key before persisting — the MCP client never holds the private key. Use this when: the operator wants to tighten / loosen a rule set or deploy a drafted bundle. This tool requires human approval by default. On first call, expect a JSON-RPC -32099 error with an approval_id in the data — surface the dashboard link (/approvals?mcp=<id>) to the operator and retry the call after they approve. |
 
-- Purpose: Cancel a pending/running job.
-- Input:
-  - `job_id` (string, required)
-  - `reason` (string, optional)
-- Output:
-  - `cancelled` (boolean)
-  - `job_id` (string)
-- Error codes:
-  - `job_not_found`
-  - `job_already_completed`
-  - `cancel_failed`
-
-### `cordum_trigger_workflow`
-
-- Purpose: Start a workflow run.
-- Input:
-  - `workflow_id` (string, required)
-  - `input` (object, optional)
-  - `dry_run` (boolean, default `false`)
-  - `idempotency_key` (string, optional)
-- Output:
-  - `run_id` (string)
-  - `workflow_id` (string)
-  - `status` (`pending`)
-- Error codes:
-  - `workflow_not_found`
-  - `input_validation_failed`
-  - `trigger_failed`
-
-### `cordum_approve_job`
-
-- Purpose: Approve a job waiting in approval state.
-- Input:
-  - `job_id` (string, required)
-  - `note` (string, optional)
-- Output:
-  - `approved` (boolean)
-  - `job_id` (string)
-- Error codes:
-  - `job_not_found`
-  - `job_not_in_approval_state`
-  - `policy_changed_since_request`
-  - `approve_failed`
-
-### `cordum_reject_job`
-
-- Purpose: Reject a job waiting in approval state.
-- Input:
-  - `job_id` (string, required)
-  - `reason` (string, required)
-- Output:
-  - `rejected` (boolean)
-  - `job_id` (string)
-- Error codes:
-  - `job_not_found`
-  - `job_not_in_approval_state`
-  - `policy_changed_since_request`
-  - `reject_failed`
-
-### `cordum_query_policy`
-
-- Purpose: Simulate policy decision before submitting a job.
-- Input:
-  - `topic` (string, required)
-  - `priority` (`low|normal|high|critical`, default `normal`)
-  - `capability` (string, optional)
-  - `risk_tags` (string[], optional)
-  - `labels` (object<string,string>, optional)
-- Output:
-  - `decision` (`allow|deny|require_approval|throttle`)
-  - `reason` (string)
-  - `rule_id` (string)
-  - `constraints` (object)
-  - `remediations` (array<object>)
-- Error codes:
-  - `policy_query_failed`
+<!-- END:mcp-tools -->
 
 ## JSON-RPC Examples
 

--- a/docs/output-safety.md
+++ b/docs/output-safety.md
@@ -72,14 +72,17 @@ For succeeded jobs, scheduler output safety handling is:
 - `REDACT`: keep success state but prefer `redacted_ptr` when returned.
 - `ALLOW`: release result as normal.
 
-Output safety failures default to **fail-closed** (quarantine on error). The behavior is configurable:
+Output safety runs in two phases with **different** failure semantics:
+
+- **Sync metadata check** (`CheckOutputMeta`, hot path): always **fail-open** on checker error or timeout. The record stays at `ALLOW`, `cordum_output_policy_skipped_total` is incremented, and the job stays `SUCCEEDED`. This phase has no configurable fail mode — it is always fail-open so a degraded checker cannot block the result pipeline (`engine.go`, `CheckOutputMeta` error branch).
+- **Async content check** (background): **fail-closed by default** (quarantine on error). This phase is configurable:
 
 | Mode | Behavior | When to use |
 |------|----------|-------------|
 | `closed` (default) | Quarantine job on checker error/timeout | Production, regulated, high-risk tenants |
 | `open` | Allow result through, count as skipped | Development, low-risk tenants |
 
-Configure via environment variable `OUTPUT_POLICY_FAIL_MODE` at scheduler startup, or at runtime through the config service (`PUT /api/v1/config` with `{"scheduler":{"output_fail_mode":"open"}}`). Runtime changes are hot-reloaded every 30 seconds.
+Configure the async fail mode via environment variable `OUTPUT_POLICY_FAIL_MODE` at scheduler startup, or at runtime through the config service (`PUT /api/v1/config` with `{"scheduler":{"output_fail_mode":"open"}}`). Runtime changes are hot-reloaded every 30 seconds.
 
 A Redis-backed circuit breaker (3 failures → open for 30s → half-open probe) protects against cascading failures when the output safety checker is persistently unavailable.
 

--- a/docs/pack.md
+++ b/docs/pack.md
@@ -503,8 +503,8 @@ docker compose up -d
 # Start your pack worker (joins the Cordum network)
 docker compose -f my-pack/deploy/docker-compose.yaml up -d
 
-# Submit a test job
-curl -s -X POST http://localhost:8080/api/v1/jobs \
+# Submit a test job (gateway is TLS by default)
+curl -s --cacert ./certs/ca/ca.crt -X POST https://localhost:8081/api/v1/jobs \
   -H "X-API-Key: $CORDUM_API_KEY" \
   -H "X-Tenant-ID: default" \
   -H "Content-Type: application/json" \
@@ -521,7 +521,7 @@ set -euo pipefail
 cordumctl pack install ./my-pack
 
 # Submit job and capture ID
-JOB_ID=$(curl -s -X POST http://localhost:8080/api/v1/jobs \
+JOB_ID=$(curl -s --cacert ./certs/ca/ca.crt -X POST https://localhost:8081/api/v1/jobs \
   -H "X-API-Key: $CORDUM_API_KEY" \
   -H "X-Tenant-ID: default" \
   -H "Content-Type: application/json" \
@@ -529,7 +529,7 @@ JOB_ID=$(curl -s -X POST http://localhost:8080/api/v1/jobs \
 
 # Poll for completion (max 30s)
 for i in $(seq 1 30); do
-  STATUS=$(curl -s http://localhost:8080/api/v1/jobs/$JOB_ID \
+  STATUS=$(curl -s --cacert ./certs/ca/ca.crt https://localhost:8081/api/v1/jobs/$JOB_ID \
     -H "X-API-Key: $CORDUM_API_KEY" \
     -H "X-Tenant-ID: default" | jq -r '.status')
   [ "$STATUS" = "succeeded" ] && echo "PASS" && exit 0

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -9,8 +9,8 @@ Recommendations for optimizing Cordum gateway throughput in production deploymen
 The gateway rate limiter uses a **single Redis Lua script** per request (atomic INCR + conditional EXPIRE in a 1-second sliding window). This is already optimal — no WATCH/MULTI serialization.
 
 **Tuning:**
-- `API_RATE_LIMIT_RPS` — requests per second per API key (default: 2000, or tier limit)
-- `API_RATE_LIMIT_BURST` — burst capacity (default: 2× RPS)
+- `API_RATE_LIMIT_RPS` — requests per second per API key (default: 30, raised by license tier)
+- `API_RATE_LIMIT_BURST` — burst capacity (default: 50)
 - Use `REDIS_RATE_LIMIT=false` to fall back to in-memory token bucket (lower latency, not distributed)
 
 ## Status Endpoint Cache
@@ -82,8 +82,8 @@ go tool pprof http://localhost:6060/debug/pprof/heap
 | Setting | Default | Recommended |
 |---------|---------|-------------|
 | `GOMAXPROCS` | auto (host CPUs) | Match CPU limit |
-| `API_RATE_LIMIT_RPS` | 2000 | Tier limit or higher |
-| `API_RATE_LIMIT_BURST` | 2× RPS | 2× RPS |
+| `API_RATE_LIMIT_RPS` | 30 | Tier limit or higher |
+| `API_RATE_LIMIT_BURST` | 50 | Tier limit or higher |
 | `REDIS_RATE_LIMIT` | true (Redis) | true for distributed |
 | Gateway replicas | 1 | 3-5 for production |
 | Redis `maxclients` | 10000 | Monitor connected_clients |

--- a/docs/production.md
+++ b/docs/production.md
@@ -807,7 +807,7 @@ Complete list of production-relevant environment variables:
 | `CORDUM_DASHBOARD_EMBED_API_KEY` | Gateway | Embed API key in dashboard JS (DO NOT use in production) |
 | `CORDUM_ALLOW_HEADER_PRINCIPAL` | Gateway | Allow `X-Principal` header override (disabled in production) |
 | `GATEWAY_HTTP_ADDR` | Gateway | HTTP listen address (default `:8081`) |
-| `GATEWAY_GRPC_ADDR` | Gateway | gRPC listen address (default `:50051`) |
+| `GATEWAY_GRPC_ADDR` | Gateway | gRPC listen address (default `:8080`) |
 | `GATEWAY_METRICS_ADDR` | Gateway | Metrics listen address (default `:9092`) |
 | `GATEWAY_METRICS_PUBLIC` | Gateway | Allow public metrics bind (`1` to allow) |
 | `GATEWAY_HTTP_TLS_CERT` | Gateway | Path to HTTP TLS certificate |

--- a/docs/quickstart-edge.md
+++ b/docs/quickstart-edge.md
@@ -69,7 +69,7 @@ rm -f .env.bak
 export CORDUM_TENANT_ID=default
 # Gateway uses self-issued TLS in dev (cert minted into ./certs by the stack).
 export CORDUM_GATEWAY=https://localhost:8081
-export CORDUM_GATEWAY_TLS_CA="$(pwd)/certs/ca/ca.crt"  # consumed by cordum-agentd
+export CORDUM_TLS_CA="$(pwd)/certs/ca/ca.crt"  # consumed by cordum-agentd
 
 # 3. Bring up the full stack (~2-3 minutes first time)
 make dev-up

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -679,9 +679,9 @@ func TestFullPipeline(t *testing.T) {
 
 ---
 
-## 8. CAP v2.5.3 Re-exported Types
+## 8. CAP v2.13.1 Re-exported Types
 
-The `sdk/runtime` package re-exports several types from the CAP v2.5.3 SDK for convenience. These are available under the `runtime` package without importing CAP directly.
+The `sdk/runtime` package re-exports several types from the CAP v2.13.1 SDK for convenience. These are available under the `runtime` package without importing CAP directly.
 
 ### MetricsHook
 
@@ -751,7 +751,7 @@ func TestMyHandler(t *testing.T) {
 
 ### Updated Worker Config Fields
 
-The `Config` struct now accepts two additional fields from CAP v2.5.3:
+The `Config` struct now accepts two additional fields from CAP v2.13.1:
 
 ```go
 type Config struct {

--- a/docs/system_overview.md
+++ b/docs/system_overview.md
@@ -36,8 +36,8 @@ NATS bus (sys.* + job.* + worker.<id>.jobs)
   - Streams `BusPacket` events over `/api/v1/stream` (protojson).
   - Enforces API key + tenant headers and CORS allowlist if configured (HTTP `X-API-Key` + `X-Tenant-ID`, gRPC metadata `x-api-key`, WS `Sec-WebSocket-Protocol: cordum-api-key, <base64url>` + `?tenant_id=<tenant>`).
   - OSS auth uses an API key allowlist (`CORDUM_API_KEYS`, `CORDUM_API_KEY`, or `CORDUM_API_KEYS_PATH`) with optional role/tenant metadata and a single-tenant default (`TENANT_ID`, default `default`). HTTP requests must supply `X-Tenant-ID`.
-  - Multi-tenant API keys and RBAC enforcement are provided by the enterprise auth provider (enterprise repo).
-  - Enterprise add-ons are delivered from the enterprise repo; this repo stays platform-only.
+  - Multi-tenant API keys and RBAC enforcement are provided in core (`core/controlplane/gateway/auth/`) behind license entitlements.
+  - All enterprise features are consolidated into core behind license entitlements; the standalone `cordum-enterprise` repo was retired 2026-04-23.
 
 - Dashboard (`dashboard/`)
   - React UI served via Nginx; connects to `/api/v1` and `/api/v1/stream`.

--- a/tools/scripts/gen_docs_tables/main.go
+++ b/tools/scripts/gen_docs_tables/main.go
@@ -1,0 +1,317 @@
+// Command gen_docs_tables generates the doc enumeration tables that
+// otherwise drift away from the code: the RBAC permission table, the REST
+// route index, and the MCP tool catalog. Each table is written between a
+// pair of stable HTML-comment markers in the target docs so the rest of
+// the page is left untouched.
+//
+// The three sources of truth are read directly from code:
+//   - RBAC permissions: auth.AllPermissions (compiled in).
+//   - MCP tool catalog: mcp.RegisterAllTools into a fresh registry (compiled in).
+//   - REST routes: the static registerRoute(mux, "METHOD /path", ...) string
+//     literals in gateway.go, read via go/parser (no server construction).
+//
+// Usage:
+//
+//	go run ./tools/scripts/gen_docs_tables            # rewrite cordum/docs tables
+//	go run ./tools/scripts/gen_docs_tables -check     # fail (exit 1) if out of date
+//	go run ./tools/scripts/gen_docs_tables -site DIR  # also rewrite the Cordum-site tree at DIR
+//
+// The -check mode is wired to `make docs-tables-check` so CI fails when the
+// committed tables no longer match the code.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/mcp"
+)
+
+// section identifies one generated region. Name is used in the marker pair
+// (<!-- BEGIN:name --> ... <!-- END:name -->); source documents where the
+// data comes from and is printed in the BEGIN marker for human readers.
+type section struct {
+	name   string
+	render func() (string, error)
+}
+
+// target is a doc file plus the ordered list of sections it embeds.
+type target struct {
+	path     string
+	sections []string
+}
+
+// routeSourceFiles holds the gateway source files whose registerRoute calls
+// make up the registered-route surface, in the order their routes are listed.
+// gateway.go carries the /api + /health REST surface; handlers_mcp.go adds the
+// three /mcp/* transport routes (registered via registerMCPRoutes).
+var routeSourceFiles = []string{
+	"core/controlplane/gateway/gateway.go",
+	"core/controlplane/gateway/handlers_mcp.go",
+}
+
+func main() {
+	check := flag.Bool("check", false, "verify the committed tables match the code; exit 1 on drift")
+	site := flag.String("site", "", "also (re)write the Cordum-site docs-site tree rooted at this directory")
+	repoRoot := flag.String("root", ".", "cordum repo root (where docs/ and core/ live)")
+	flag.Parse()
+
+	sections := map[string]section{
+		"rbac-permissions": {
+			name:   "rbac-permissions",
+			render: renderRBACTable,
+		},
+		"rest-routes": {
+			name:   "rest-routes",
+			render: func() (string, error) { return renderRouteTable(*repoRoot) },
+		},
+		"mcp-tools": {
+			name:   "mcp-tools",
+			render: renderMCPTable,
+		},
+	}
+
+	// cordum/docs targets (in-repo, CI-gated).
+	targets := []target{
+		{path: filepath.Join(*repoRoot, "docs", "api-reference.md"), sections: []string{"rbac-permissions", "rest-routes"}},
+		{path: filepath.Join(*repoRoot, "docs", "mcp-tools-reference.md"), sections: []string{"mcp-tools"}},
+	}
+
+	// Cordum-site mirror targets (manual, opt-in via -site; not present in cordum CI).
+	if *site != "" {
+		targets = append(targets,
+			target{path: filepath.Join(*site, "docs", "api-reference", "api-overview.md"), sections: []string{"rbac-permissions", "rest-routes"}},
+			target{path: filepath.Join(*site, "docs", "api-reference", "mcp-tools.md"), sections: []string{"mcp-tools"}},
+		)
+	}
+
+	// Render every section once (the inputs are process-global).
+	rendered := make(map[string]string, len(sections))
+	for name, sec := range sections {
+		body, err := sec.render()
+		if err != nil {
+			fatalf("render %s: %v", name, err)
+		}
+		rendered[name] = body
+	}
+
+	drift := false
+	for _, t := range targets {
+		changed, err := applyTarget(t, sections, rendered, *check)
+		if err != nil {
+			fatalf("%s: %v", t.path, err)
+		}
+		if changed {
+			drift = true
+			if *check {
+				fmt.Fprintf(os.Stderr, "DRIFT: %s is out of date\n", t.path)
+			} else {
+				fmt.Printf("updated %s\n", t.path)
+			}
+		}
+	}
+
+	if *check && drift {
+		fmt.Fprintln(os.Stderr, "docs tables are out of date — run `make docs-tables` and commit the result")
+		os.Exit(1)
+	}
+	if *check {
+		fmt.Println("docs tables are in sync with code")
+	}
+}
+
+// applyTarget rewrites (or, in check mode, compares) every section region in
+// one file. It returns true when the file's content would change.
+func applyTarget(t target, sections map[string]section, rendered map[string]string, check bool) (bool, error) {
+	raw, err := os.ReadFile(t.path)
+	if err != nil {
+		return false, err
+	}
+	content := string(raw)
+	// Preserve the file's line-ending style: the generated region must use
+	// the same EOL as the rest of the document or git sees spurious churn.
+	nl := "\n"
+	if strings.Contains(content, "\r\n") {
+		nl = "\r\n"
+	}
+	updated := content
+	for _, name := range t.sections {
+		sec, ok := sections[name]
+		if !ok {
+			return false, fmt.Errorf("unknown section %q", name)
+		}
+		next, err := replaceSection(updated, sec, rendered[name], nl)
+		if err != nil {
+			return false, err
+		}
+		updated = next
+	}
+	if updated == content {
+		return false, nil
+	}
+	if !check {
+		if err := os.WriteFile(t.path, []byte(updated), 0o644); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// replaceSection swaps the text between the BEGIN/END markers for the freshly
+// rendered table, leaving the markers (and everything outside them) intact.
+// nl is the document's line ending; the rendered body (built with "\n") is
+// re-encoded to nl, and content outside the region is left byte-for-byte.
+func replaceSection(content string, sec section, body, nl string) (string, error) {
+	begin := fmt.Sprintf("<!-- BEGIN:%s -->", sec.name)
+	end := fmt.Sprintf("<!-- END:%s -->", sec.name)
+
+	bi := strings.Index(content, begin)
+	if bi < 0 {
+		return "", fmt.Errorf("begin marker for section %q not found (expected exact line: %s)", sec.name, begin)
+	}
+	ei := strings.Index(content, end)
+	if ei < 0 {
+		return "", fmt.Errorf("end marker for section %q not found (expected: %s)", sec.name, end)
+	}
+	if ei < bi {
+		return "", fmt.Errorf("end marker precedes begin marker for section %q", sec.name)
+	}
+	bodyNL := strings.ReplaceAll(body, "\n", nl)
+	return content[:bi+len(begin)] + nl + nl + bodyNL + nl + nl + content[ei:], nil
+}
+
+// renderRBACTable emits one row per canonical permission, split into the
+// resource (everything before the final dot) and action (after it).
+func renderRBACTable() (string, error) {
+	perms := append([]string(nil), auth.AllPermissions...)
+	sort.Strings(perms)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "_Generated from `core/controlplane/gateway/auth/rbac.go` (`auth.AllPermissions`) — do not edit by hand; run `make docs-tables`. %d permissions._\n\n", len(perms))
+	b.WriteString("| Permission | Resource | Action |\n")
+	b.WriteString("|------------|----------|--------|\n")
+	for _, p := range perms {
+		resource, action := p, ""
+		if i := strings.LastIndex(p, "."); i >= 0 {
+			resource, action = p[:i], p[i+1:]
+		}
+		fmt.Fprintf(&b, "| `%s` | `%s` | `%s` |\n", p, resource, action)
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+// renderMCPTable enumerates the full tool catalog by registering every tool
+// into a fresh registry and listing it back (names, descriptions, and the
+// approval gate are all carried on the Tool definition).
+func renderMCPTable() (string, error) {
+	registry := mcp.NewToolRegistry()
+	if err := mcp.RegisterAllTools(registry, stubBridge{}); err != nil {
+		return "", fmt.Errorf("register tools: %w", err)
+	}
+	tools := registry.ListToolsUnfiltered()
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "_Generated from `core/mcp` via `RegisterAllTools` — do not edit by hand; run `make docs-tables`. %d tools._\n\n", len(tools))
+	b.WriteString("| Tool | Approval | Scope | Description |\n")
+	b.WriteString("|------|----------|-------|-------------|\n")
+	for _, t := range tools {
+		approval := "—"
+		if t.RequiresApproval {
+			approval = "required"
+		}
+		scope := t.ApprovalScope
+		if scope == "" {
+			scope = "—"
+		}
+		fmt.Fprintf(&b, "| `%s` | %s | `%s` | %s |\n", t.Name, approval, scope, escapePipes(t.Description))
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+type route struct{ method, path string }
+
+// renderRouteTable parses each gateway source file and lists every route
+// registered through registerRoute(mux, "METHOD /path", ...). Routes are
+// listed per file in source order, files in routeSourceFiles order, so the
+// /api surface (gateway.go) comes first and the /mcp/* transport routes
+// (handlers_mcp.go) come last.
+func renderRouteTable(repoRoot string) (string, error) {
+	var routes []route
+	for _, rel := range routeSourceFiles {
+		fileRoutes, err := parseRoutes(filepath.Join(repoRoot, rel))
+		if err != nil {
+			return "", err
+		}
+		routes = append(routes, fileRoutes...)
+	}
+	if len(routes) == 0 {
+		return "", fmt.Errorf("no registerRoute calls found in %v", routeSourceFiles)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "_Generated from `%s` (registration order) — do not edit by hand; run `make docs-tables`. %d routes._\n\n", strings.Join(routeSourceFiles, "`, `"), len(routes))
+	b.WriteString("| Method | Path |\n")
+	b.WriteString("|--------|------|\n")
+	for _, r := range routes {
+		fmt.Fprintf(&b, "| %s | `%s` |\n", r.method, r.path)
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+// parseRoutes extracts the registerRoute(mux, "METHOD /path", ...) string
+// literals from one Go source file, in source order.
+func parseRoutes(path string) ([]route, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	var routes []route
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "registerRoute" || len(call.Args) < 2 {
+			return true
+		}
+		lit, ok := call.Args[1].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		pattern, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		method, p, found := strings.Cut(pattern, " ")
+		if !found {
+			// A bare path with no method (rare) — record it verbatim.
+			method, p = "", pattern
+		}
+		routes = append(routes, route{method: method, path: p})
+		return true
+	})
+	return routes, nil
+}
+
+// escapePipes keeps a single-line description from breaking the table.
+func escapePipes(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.ReplaceAll(s, "|", "\\|")
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/tools/scripts/gen_docs_tables/stub_bridge.go
+++ b/tools/scripts/gen_docs_tables/stub_bridge.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cordum/cordum/core/mcp"
+)
+
+// stubBridge is a no-op implementation of mcp.ServiceBridge. RegisterAllTools
+// requires a non-nil bridge to bind handlers, but this generator only reads
+// the static tool metadata (name, description, approval gate) back out of the
+// registry, so the handlers are never invoked.
+type stubBridge struct{}
+
+var _ mcp.ServiceBridge = stubBridge{}
+
+// Core action surface.
+func (stubBridge) SubmitJob(context.Context, mcp.SubmitJobInput) (*mcp.SubmitJobOutput, error) {
+	return nil, nil
+}
+func (stubBridge) CancelJob(context.Context, string, string) error { return nil }
+func (stubBridge) TriggerWorkflow(context.Context, mcp.TriggerWorkflowInput) (*mcp.TriggerOutput, error) {
+	return nil, nil
+}
+func (stubBridge) ApproveJob(context.Context, string, string) error { return nil }
+func (stubBridge) RejectJob(context.Context, string, string) error  { return nil }
+func (stubBridge) SimulatePolicy(context.Context, mcp.PolicySimInput) (*mcp.PolicySimOutput, error) {
+	return nil, nil
+}
+
+// Read-only discovery surface.
+func (stubBridge) ListJobs(context.Context, mcp.ListInput) (*mcp.ListPage, error) { return nil, nil }
+func (stubBridge) GetJob(context.Context, string) (*mcp.ResourceItem, error)      { return nil, nil }
+func (stubBridge) ListRuns(context.Context, mcp.ListInput) (*mcp.ListPage, error) { return nil, nil }
+func (stubBridge) GetRun(context.Context, string) (*mcp.ResourceItem, error)      { return nil, nil }
+func (stubBridge) GetRunTimeline(context.Context, string) (*mcp.ResourceItem, error) {
+	return nil, nil
+}
+func (stubBridge) ListWorkflows(context.Context, mcp.ListInput) (*mcp.ListPage, error) {
+	return nil, nil
+}
+func (stubBridge) ListPacks(context.Context, mcp.ListInput) (*mcp.ListPage, error)   { return nil, nil }
+func (stubBridge) ListTopics(context.Context, mcp.ListInput) (*mcp.ListPage, error)  { return nil, nil }
+func (stubBridge) ListWorkers(context.Context, mcp.ListInput) (*mcp.ListPage, error) { return nil, nil }
+func (stubBridge) ListAgents(context.Context, mcp.ListInput) (*mcp.ListPage, error)  { return nil, nil }
+func (stubBridge) ListPendingApprovals(context.Context, mcp.ListInput) (*mcp.ListPage, error) {
+	return nil, nil
+}
+func (stubBridge) QueryAudit(context.Context, mcp.AuditQueryInput) (*mcp.ListPage, error) {
+	return nil, nil
+}
+func (stubBridge) VerifyAudit(context.Context, string) (*mcp.ResourceItem, error) { return nil, nil }
+func (stubBridge) GetStatus(context.Context) (*mcp.ResourceItem, error)           { return nil, nil }
+
+// Mutating administrative surface.
+func (stubBridge) CreateWorkflow(context.Context, mcp.CreateWorkflowInput) (*mcp.CreateWorkflowOutput, error) {
+	return nil, nil
+}
+func (stubBridge) InstallPack(context.Context, mcp.InstallPackInput) (*mcp.InstallPackOutput, error) {
+	return nil, nil
+}
+func (stubBridge) UninstallPack(context.Context, mcp.UninstallPackInput) error { return nil }
+func (stubBridge) RegisterAgent(context.Context, mcp.RegisterAgentInput) (*mcp.RegisterAgentOutput, error) {
+	return nil, nil
+}
+func (stubBridge) UpdatePolicyBundle(context.Context, mcp.UpdatePolicyBundleInput) (*mcp.UpdatePolicyBundleOutput, error) {
+	return nil, nil
+}
+func (stubBridge) RevokeWorkerSession(context.Context, mcp.RevokeWorkerSessionInput) error {
+	return nil
+}
+func (stubBridge) SetAgentScope(context.Context, mcp.SetAgentScopeInput) (*mcp.SetAgentScopeOutput, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
- Mirror docs-to-code accuracy corrections into cordum/docs and update CAP SDK comment
- Add generated docs-table tooling/check target for RBAC permissions, REST routes, and MCP tools
- Regenerate cordum/docs RBAC/route/MCP tables from source code

## Verification
- `bash -lc "make docs-tables-check"`
- `go run ./tools/scripts/gen_docs_tables -check -site D:/Cordum/Cordum-site/docs-site`
- `go vet ./tools/scripts/gen_docs_tables/...`
- `go build ./tools/...`
- Cordum-site docs-site: `npm run typecheck`; `npm run build`

Moe task: task-8e555500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major API reference refresh: expanded endpoint and WebSocket route index, full RBAC permissions table, and consolidated MCP tool catalog
  * Multiple docs updated to reference CAP v2.13.1 and note enterprise features merged into core; TLS-first examples updated

* **Configuration Changes**
  * Gateway defaults adjusted: TLS-first endpoints, listener ports, and reduced API rate-limiting defaults

* **Chores**
  * Added doc-table regeneration and CI check targets to simplify keeping generated documentation in sync

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->