### PR TITLE
docs: fix 5 broken relative links + drop lychee baseline suppression (recovers #298)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -787,7 +787,7 @@ cordumctl delegation-keygen --rotate         # rotate; preserves prior public ke
 ```
 
 Companion to the delegation system documented in
-[delegation.md](delegation.md). Tokens are re-verified at
+[delegation.md](auth/delegation.md). Tokens are re-verified at
 dispatch time per the boundary-hardening described in
 [CORE.md § 3](CORE.md#3-scheduler-that-is-purely-config‑driven-no-hardcoded-core-topics).
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1147,5 +1147,5 @@ The consumer calls the configured SIEM exporter (`CORDUM_AUDIT_EXPORT_TYPE`) for
 - [adr/009-control-plane-boundary-hardening.md](adr/009-control-plane-boundary-hardening.md) — Topic Registry, Worker Credentials, schema enforcement design
 - [AGENT_PROTOCOL.md](AGENT_PROTOCOL.md) — CAP v2.9.0 handshake, ready_topics, auth_token wire details
 - [audit.md](audit.md) — Output Policy + Governance Timeline audit event types
-- [delegation.md](delegation.md) — A2A delegation tokens; rides on top of worker credentials
+- [delegation.md](auth/delegation.md) — A2A delegation tokens; rides on top of worker credentials
 - [horizontal-scaling.md](horizontal-scaling.md) — Multi-replica deployment, Redis lock keys, NATS subject matrix

--- a/docs/mcp/resources.md
+++ b/docs/mcp/resources.md
@@ -75,7 +75,7 @@ The embedded `text` decodes to:
 **`id` and `kind` are stable.** **`data`** passes through the gateway's
 JSON body verbatim — individual fields track the gateway's existing
 REST-API contract; see the
-[OpenAPI spec](../../api/openapi.yaml) for per-field stability.
+[OpenAPI spec](../api/openapi/cordum-api.yaml) for per-field stability.
 
 ---
 

--- a/docs/troubleshooting/install.md
+++ b/docs/troubleshooting/install.md
@@ -62,7 +62,7 @@ cordumctl doctor
   you want to run first).
 - If pack is installed but still zero → check the worker container
   logs: `docker compose logs <pack-worker>`. Worker tokens may have
-  expired; see [worker-credentials.md](../deployment/worker-credentials.md).
+  expired; see [Worker credentials API reference](../api-reference.md#worker-credentials).
 
 ### `build_info`
 
@@ -128,7 +128,7 @@ cordumctl doctor
 
 - `warn: CA cert expires in Nd` (N < 7) → regenerate soon. Rotation
   is backwards-compatible if you stage it (see
-  [deployment/certs.md](../deployment/certs.md)).
+  [TLS setup](../guides/tls-setup.md)).
 - `fail: CA cert expires in Xh` (X < 24) → regenerate now:
   `cordumctl generate-certs --force --days 365`, then restart all
   services so the new cert is picked up.
@@ -193,6 +193,6 @@ stack: baseline → stop NATS → assert recovery. Invoke via
   and check.
 - [docs/troubleshooting.md](../troubleshooting.md) — post-install
   runtime issues (flaky workers, job-timeouts, DLQ pile-up).
-- [docs/deployment/certs.md](../deployment/certs.md) — cert rotation.
+- [docs/guides/tls-setup.md](../guides/tls-setup.md) — cert rotation.
 - [tools/scripts/quickstart.sh](../../tools/scripts/quickstart.sh) —
   doctor runs as the final verification step.

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,18 +20,7 @@ exclude_path = [
   "docs/static",
 ]
 
-# --- Individual links excluded (pre-existing baseline breaks) ----------------
-# These relative links were already broken when this gate was introduced
-# (lychee --offline baseline, 2026-05-24). The content fixes are owned by the
-# docs-accuracy task (task-8e555500); excluding them here snapshots the known
-# baseline so the gate fails only on NEW breakage, not pre-existing debt.
-exclude = [
-  # docs/cli-reference.md, docs/configuration-reference.md:
-  #   link "(delegation.md)" resolves to docs/delegation.md; file lives at docs/auth/delegation.md
-  "docs/delegation\\.md$",
-  # docs/mcp/resources.md: "(../../api/openapi.yaml)" — spec file not present in repo
-  "/api/openapi\\.yaml$",
-  # docs/troubleshooting/install.md: targets were never created under docs/deployment/
-  "docs/deployment/certs\\.md$",
-  "docs/deployment/worker-credentials\\.md$",
-]
+# --- Individual links excluded ------------------------------------------------
+# No individual baseline excludes remain; keep this array explicit so future
+# debt snapshots are visible in review.
+exclude = []


### PR DESCRIPTION
## What
Recovers the net change from #298, which GitHub auto-closed when its stacked base branch (#296) was squash-merged into `main` — its fix never landed.

Fixes 5 relative links that point to files moved during the docs-consolidation epic, and removes #296's `lychee.toml` baseline excludes that were *suppressing* these same broken links:

| File | was | now |
|---|---|---|
| cli-reference.md, configuration-reference.md | `(delegation.md)` | `(auth/delegation.md)` |
| mcp/resources.md | `(../../api/openapi.yaml)` | `(../api/openapi/cordum-api.yaml)` |
| troubleshooting/install.md | `(../deployment/worker-credentials.md)` | `(../api-reference.md#worker-credentials)` |
| troubleshooting/install.md x2 | `(../deployment/certs.md)` | `(../guides/tls-setup.md)` |

All new targets verified present on `main`; all old targets verified absent. `lychee.toml` `exclude` is now `[]` so the docs-linkcheck gate catches new breakage instead of carrying suppressed debt. Built on current `main` (preserves #297's other edits to configuration-reference.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)