### PR TITLE
Fix new-user install: loginable dashboard out of the box + correct docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,9 +96,12 @@ CORDUM_USER_AUTH_ENABLED=true
 
 # Default admin user (created on first start if password is set)
 CORDUM_ADMIN_USERNAME=admin
-# Required when CORDUM_USER_AUTH_ENABLED=true. Must be >= 8 characters.
-# Gateway refuses to start if user auth is enabled and this is empty.
-CORDUM_ADMIN_PASSWORD=admin123
+# Required when CORDUM_USER_AUTH_ENABLED=true. Policy: >= 12 characters, with at
+# least one uppercase letter, one digit, and one special character. The gateway
+# refuses to start (and silently fails to seed the admin) if user auth is
+# enabled and this is empty or non-compliant. CHANGE THIS before any real use.
+# (tools/scripts/quickstart.sh seeds this same default into a fresh .env.)
+CORDUM_ADMIN_PASSWORD=ChangeMe123!
 CORDUM_ADMIN_EMAIL=admin@cordum.local
 
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ curl -sS --cacert ./certs/ca/ca.crt \
   -X POST https://localhost:8081/api/v1/jobs \
   -H "X-API-Key: $CORDUM_API_KEY" -H "X-Tenant-ID: default" \
   -H "Content-Type: application/json" \
-  -d '{"topic":"job.default","context":{"prompt":"hello"}}'
+  -d '{"topic":"job.default","prompt":"hello"}'
 
 # Stop the stack
 docker compose down

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ cd cordum
 `curl`. On Windows use MSYS2 / Git Bash / WSL.
 
 **What you get at the end:**
-- Dashboard at http://localhost:8082 (admin / admin123).
+- Dashboard at http://localhost:8082 — log in as `admin` / `ChangeMe123!`
+  (the default dev password, also saved to `.env` as `CORDUM_ADMIN_PASSWORD`;
+  change it before exposing the stack).
 - Gateway at http://localhost:8081 with a generated `CORDUM_API_KEY` in
   `.env`.
 - TLS CA, server, and client keypairs under `./certs/`.
@@ -233,7 +235,11 @@ docker compose up -d        # starts the stack — no source build needed
 ```
 
 **Dashboard:** http://localhost:8082
-**Login:** `admin` / `admin123` (change in `.env` → `CORDUM_ADMIN_PASSWORD`)
+**Login:** this path leaves user auth off by default — sign in on the dashboard
+with your `CORDUM_API_KEY`. To enable `admin` password login instead, set
+`CORDUM_USER_AUTH_ENABLED=true` and a policy-compliant `CORDUM_ADMIN_PASSWORD`
+(≥ 12 chars, with an uppercase letter, a digit, and a special character) in
+`.env`, then `docker compose up -d`. (The quickstart script does this for you.)
 
 Pin a specific release by exporting `CORDUM_VERSION=1.2.3` before
 `docker compose pull`. Defaults to `:latest`, which only moves on stable
@@ -341,7 +347,7 @@ docker compose logs -f api-gateway
 |-------|-----|
 | Port already in use | `docker compose down` then retry, or check `lsof -i :8082` |
 | Docker out of memory | Allocate at least 4 GB RAM to Docker Desktop |
-| Can't login to dashboard | Default credentials: admin / admin123 |
+| Can't login to dashboard | Default is `admin` / `ChangeMe123!` (in `.env` as `CORDUM_ADMIN_PASSWORD`); ensure `CORDUM_USER_AUTH_ENABLED=true`. Custom passwords must be ≥12 chars + uppercase + digit + special |
 | TLS/SSL cert errors | Remove `./certs/` and re-run — certs auto-regenerate |
 | `openssl` not found | Not needed — quickstart.sh auto-generates keys without it |
 | Go build fails | Requires Go 1.24+ — check with `go version` |

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useConfigStore } from "@/state/config";
+import { useAuthConfig } from "@/hooks/useAuthConfig";
 import { Button } from "@/components/ui/Button";
 import type { User } from "@/api/types";
 import { toast } from "sonner";
@@ -246,12 +247,20 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const login = useConfigStore((s) => s.login);
+  const configuredApiBase = useConfigStore((s) => s.apiBaseUrl);
+  const { data: authConfig } = useAuthConfig();
   const returnUrl = isSafeReturnUrl(searchParams.get("returnUrl"));
   const [authMode, setAuthMode] = useState<AuthMode>("api_key");
   const [showModeSelector, setShowModeSelector] = useState(false);
+  // Default-tab resolution runs once when auth-config arrives; tracked so a
+  // user's later manual tab choice is never overridden by a refetch.
+  const [defaultModeApplied, setDefaultModeApplied] = useState(false);
 
-  // API Key fields
-  const [apiUrl, setApiUrl] = useState("");
+  // API Key fields. Pre-fill the endpoint with the runtime-configured base
+  // (from public/config.json) when present, otherwise the relative `/api/v1`
+  // nginx-proxy default — so a fresh install shows a working value instead of
+  // a blank box. isSafeApiUrl() still treats empty as the same default.
+  const [apiUrl, setApiUrl] = useState(configuredApiBase || "/api/v1");
   const [apiKey, setApiKey] = useState("");
 
   // Password fields
@@ -298,6 +307,20 @@ export default function LoginPage() {
     showErrorToast(message);
     window.history.replaceState(null, "", window.location.pathname + window.location.search);
   }, []);
+
+  // Pick the most useful default tab once the gateway's auth-config loads:
+  // when password auth is enabled (the common self-hosted setup), open the
+  // Password tab with `admin` pre-filled so the documented default login is
+  // one field away. SSO-only or API-key-only deployments keep the API Key
+  // default. Applied once; manual tab switches afterward are preserved.
+  useEffect(() => {
+    if (defaultModeApplied || !authConfig) return;
+    if (authConfig.password_enabled) {
+      setAuthMode("password");
+      setUsername((current) => current || "admin");
+    }
+    setDefaultModeApplied(true);
+  }, [authConfig, defaultModeApplied]);
 
   const handleApiKeyLogin = async () => {
     if (!apiKey.trim()) {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,9 +49,11 @@ That's it. The script:
 | NATS | localhost:4222 |
 | Redis (TLS) | localhost:6379 |
 
-**Dashboard login:** `admin / admin123`. Change it before exposing the
-stack to anything beyond localhost by setting `CORDUM_ADMIN_PASSWORD`
-in `.env`.
+**Dashboard login:** user `admin`, default password `ChangeMe123!` (also in
+`.env` as `CORDUM_ADMIN_PASSWORD`). Rotate it before exposing the stack beyond
+localhost by setting a new `CORDUM_ADMIN_PASSWORD` in `.env` (policy: ≥12
+chars, with an uppercase letter, a digit, and a special character) and
+restarting the gateway.
 
 **API key:** in `.env` as `CORDUM_API_KEY`. Attach to every request:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,10 +92,23 @@ go test -count=3 ./core/...
 
 **Symptoms**: Dashboard login page rejects credentials.
 
-**Fix**: Default credentials are `admin` / `admin123`. These are set via `CORDUM_ADMIN_USERNAME` and `CORDUM_ADMIN_PASSWORD` in `.env`. If you changed the password and forgot it, update `.env` and restart:
+**Fix**: The admin user is `CORDUM_ADMIN_USERNAME` (default `admin`) with the
+password in `CORDUM_ADMIN_PASSWORD` — quickstart auto-generates a compliant one
+and prints it (it's also in `.env`). Two common causes of login failure:
+
+1. **User auth is disabled.** Password login only works when
+   `CORDUM_USER_AUTH_ENABLED=true`. The published-images path (`docker compose
+   up -d` without quickstart) defaults it to `false` — sign in with your
+   `CORDUM_API_KEY` instead, or enable it.
+2. **The password violates the policy**, so the gateway silently failed to seed
+   the admin (look for `seed admin user failed` in `docker compose logs
+   api-gateway`). Policy: **≥ 12 characters, with at least one uppercase letter,
+   one digit, and one special character.** `admin123` does NOT satisfy it.
+
+To set/rotate the password, edit `.env` and restart:
 
 ```bash
-# Edit .env: set CORDUM_ADMIN_PASSWORD=your-new-password
+# Edit .env: set a compliant CORDUM_ADMIN_PASSWORD (>=12 chars, upper+digit+special)
 docker compose restart api-gateway
 ```
 

--- a/tools/scripts/quickstart.sh
+++ b/tools/scripts/quickstart.sh
@@ -62,6 +62,15 @@ gen_hex() {
   fi
 }
 
+# --- Default dashboard admin password ---
+# Seeded by the login bootstrap below when CORDUM_ADMIN_PASSWORD is unset. Must
+# satisfy the gateway policy (>=12 chars, with an uppercase letter, a digit, and
+# a special character — see core/controlplane/gateway/auth.ValidatePassword).
+# This is a well-known DEV default for frictionless first login — CHANGE it
+# before exposing the stack beyond localhost. Override via the environment with
+# CORDUM_DEFAULT_ADMIN_PASSWORD.
+DEFAULT_ADMIN_PASSWORD="${CORDUM_DEFAULT_ADMIN_PASSWORD:-ChangeMe123!}"
+
 # --- Pre-flight checks ---
 require docker
 require curl
@@ -449,7 +458,34 @@ ORG_ID=${CORDUM_ORG_ID:-${CORDUM_TENANT_ID:-default}}
 TENANT_ID=${CORDUM_TENANT_ID:-${ORG_ID}}
 COMPOSE_FILES=${CORDUM_COMPOSE_FILES:-docker-compose.yml}
 ALLOW_ENTERPRISE=${CORDUM_ALLOW_ENTERPRISE:-0}
+# Dashboard login bootstrap — enable password auth by default and seed a known
+# default, policy-compliant admin password (>=12 chars, with an uppercase
+# letter, a digit, and a special character) when none is supplied, so the
+# dashboard is loginable out of the box. Explicit env / .env values always win;
+# the default is persisted to .env. CHANGE it before exposing the stack.
+if [[ -z "${CORDUM_USER_AUTH_ENABLED:-}" ]]; then
+  export CORDUM_USER_AUTH_ENABLED=true
+  persist_env_var CORDUM_USER_AUTH_ENABLED true
+  mark_env_source CORDUM_USER_AUTH_ENABLED "auto-generated" ".env"
+fi
 AUTH_ENABLED=${CORDUM_USER_AUTH_ENABLED:-false}
+AUTH_FLAG_LC="$(printf '%s' "${AUTH_ENABLED}" | tr '[:upper:]' '[:lower:]')"
+if [[ "${AUTH_FLAG_LC}" == "true" || "${AUTH_FLAG_LC}" == "1" || "${AUTH_FLAG_LC}" == "yes" ]]; then
+  if [[ -z "${CORDUM_ADMIN_USERNAME:-}" ]]; then
+    export CORDUM_ADMIN_USERNAME=admin
+    persist_env_var CORDUM_ADMIN_USERNAME admin
+  fi
+  if [[ -z "${CORDUM_ADMIN_EMAIL:-}" ]]; then
+    export CORDUM_ADMIN_EMAIL=admin@cordum.local
+    persist_env_var CORDUM_ADMIN_EMAIL admin@cordum.local
+  fi
+  if [[ -z "${CORDUM_ADMIN_PASSWORD:-}" ]]; then
+    export CORDUM_ADMIN_PASSWORD="${DEFAULT_ADMIN_PASSWORD}"
+    persist_env_var CORDUM_ADMIN_PASSWORD "${CORDUM_ADMIN_PASSWORD}"
+    mark_env_source CORDUM_ADMIN_PASSWORD "default" ".env"
+    log "CORDUM_ADMIN_PASSWORD: set to the default dev password (CHANGE before exposing publicly); persisted to .env"
+  fi
+fi
 ADMIN_PASSWORD=${CORDUM_ADMIN_PASSWORD:-}
 ADMIN_EMAIL=${CORDUM_ADMIN_EMAIL:-}
 export COMPOSE_HTTP_TIMEOUT=${COMPOSE_HTTP_TIMEOUT:-1800}
@@ -543,6 +579,22 @@ else
   log "warning: config endpoint returned ${config_status} — settings page may show empty state"
 fi
 
+# Credential summary for the banner — show the admin login when password auth
+# is enabled (password masked; the full value lives in .env), otherwise point
+# operators at the API key.
+BANNER_AUTH_LC="$(printf '%s' "${AUTH_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')"
+if [[ "${BANNER_AUTH_LC}" == "true" || "${BANNER_AUTH_LC}" == "1" || "${BANNER_AUTH_LC}" == "yes" ]]; then
+  if [[ "${ADMIN_PASSWORD}" == "${DEFAULT_ADMIN_PASSWORD}" ]]; then
+    # Known dev default — safe to show in full so first login is frictionless.
+    CREDS_SUMMARY="${CORDUM_ADMIN_USERNAME:-admin} / ${ADMIN_PASSWORD}  (default — CHANGE before prod)"
+  else
+    # Operator-supplied secret — mask it; the full value lives in .env.
+    CREDS_SUMMARY="${CORDUM_ADMIN_USERNAME:-admin} / ${ADMIN_PASSWORD:0:8}... (full value in .env)"
+  fi
+else
+  CREDS_SUMMARY="use your CORDUM_API_KEY (see .env)"
+fi
+
 echo ""
 echo "  ┌─────────────────────────────────────────────────────────┐"
 echo "  │  Cordum is running!                                     │"
@@ -551,8 +603,8 @@ echo "  │  Dashboard:      http://localhost:8082                  │"
 echo "  │  API Gateway:    ${API_BASE}                            │"
 echo "  │  API Key:        ${API_KEY:0:8}... (see .env)           │"
 echo "  ├─────────────────────────────────────────────────────────┤"
-echo "  │  Login:          admin / admin123                       │"
-echo "  │  (change via CORDUM_ADMIN_PASSWORD in .env)             │"
+echo "  │  Login:          ${CREDS_SUMMARY}"
+echo "  │  (auto-generated — rotate before exposing publicly)     │"
 echo "  ├─────────────────────────────────────────────────────────┤"
 echo "  │  Ports:                                                 │"
 echo "  │    8082  Dashboard                                      │"

--- a/tools/scripts/quickstart.sh
+++ b/tools/scripts/quickstart.sh
@@ -591,7 +591,7 @@ if [[ "${BANNER_AUTH_LC}" == "true" || "${BANNER_AUTH_LC}" == "1" || "${BANNER_A
     # Operator-supplied secret — mask it. It came from CORDUM_ADMIN_PASSWORD
     # (shell env or .env) and is NOT necessarily persisted to .env, so point
     # back at the source the operator set rather than promising it's in .env.
-    CREDS_SUMMARY="${CORDUM_ADMIN_USERNAME:-admin} / ${ADMIN_PASSWORD:0:8}... (the value you set in CORDUM_ADMIN_PASSWORD)"
+    CREDS_SUMMARY="${CORDUM_ADMIN_USERNAME:-admin} / •••••••• (the value you set in CORDUM_ADMIN_PASSWORD)"
   fi
 else
   CREDS_SUMMARY="use your CORDUM_API_KEY (see .env)"

--- a/tools/scripts/quickstart.sh
+++ b/tools/scripts/quickstart.sh
@@ -588,8 +588,10 @@ if [[ "${BANNER_AUTH_LC}" == "true" || "${BANNER_AUTH_LC}" == "1" || "${BANNER_A
     # Known dev default — safe to show in full so first login is frictionless.
     CREDS_SUMMARY="${CORDUM_ADMIN_USERNAME:-admin} / ${ADMIN_PASSWORD}  (default — CHANGE before prod)"
   else
-    # Operator-supplied secret — mask it; the full value lives in .env.
-    CREDS_SUMMARY="${CORDUM_ADMIN_USERNAME:-admin} / ${ADMIN_PASSWORD:0:8}... (full value in .env)"
+    # Operator-supplied secret — mask it. It came from CORDUM_ADMIN_PASSWORD
+    # (shell env or .env) and is NOT necessarily persisted to .env, so point
+    # back at the source the operator set rather than promising it's in .env.
+    CREDS_SUMMARY="${CORDUM_ADMIN_USERNAME:-admin} / ${ADMIN_PASSWORD:0:8}... (the value you set in CORDUM_ADMIN_PASSWORD)"
   fi
 else
   CREDS_SUMMARY="use your CORDUM_API_KEY (see .env)"


### PR DESCRIPTION
## Why

A brand-new user who followed the README + quickstart hit two blockers:

1. **Documented job-submit payload was wrong.** The README's "After Setup" example posted the prompt under `context.prompt`, but the gateway requires a top-level `prompt` field (`core/controlplane/gateway/helpers.go`). As written it returns `400 prompt_is_required`.
2. **Dashboard login was impossible out of the box.** quickstart left `CORDUM_USER_AUTH_ENABLED` unset (compose defaults it to `false`), so password login was off; and the documented `admin123` violates the gateway password policy (≥12 chars + uppercase + digit + special — `auth.ValidatePassword`), so admin seeding silently failed (`seed admin user failed` in gateway logs) even when auth was enabled. The advertised `admin / admin123` could never work.

## What

- **`quickstart.sh`**: enable password auth by default and seed a known, policy-compliant default admin password (`ChangeMe123!`) into `.env`; print it in the success banner (operator-supplied passwords are masked).
- **`.env.example`**: correct the password-policy comment (was "≥ 8 characters") and ship a compliant default.
- **`LoginPage.tsx`**: pre-fill the API Endpoint with `/api/v1` (was blank); default to the Password tab with `admin` pre-filled when the gateway reports password auth is enabled (via the existing `useAuthConfig` hook).
- **README / docs/quickstart / docs/troubleshooting**: replace the false `admin / admin123` references with the real default + policy, and document the two real login-failure modes; fix the job-submit example payload.

## Test plan

- Fresh `quickstart.sh --clean` run: stack healthy; `.env` seeded with `CORDUM_USER_AUTH_ENABLED=true` + compliant password; `POST /api/v1/auth/login` with `admin` / `ChangeMe123!` returns `200`.
- `POST /api/v1/jobs` with top-level `prompt` returns a `job_id`; Safety Kernel returns `ALLOW`.
- Dashboard: `tsc --noEmit` clean, `eslint` clean, `vitest` 30/30 on `LoginPage.test.ts`.
- `bash -n quickstart.sh` and `tools/scripts/lint_no_secret_log.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login page auto-detects available auth methods, defaults to Password when enabled, and pre-fills the admin username and API endpoint.
  * Quickstart now bootstraps password auth and seeds admin credentials when unset; startup banner shows a login summary and masks operator-set passwords.

* **Documentation**
  * README, Quickstart, and Troubleshooting updated with default dev credentials (admin / ChangeMe123!), requirement to enable user-auth for password login, stricter password policy (≥12 chars, uppercase, digit, special), and adjusted API example (prompt as top-level field).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->