### PR TITLE
fix(gateway): deflake copilot-session decision tests (30-day retention time-bomb)

### DIFF
--- a/core/controlplane/gateway/handlers_copilot_sessions_test.go
+++ b/core/controlplane/gateway/handlers_copilot_sessions_test.go
@@ -34,7 +34,11 @@ func (s *stubCopilotSessionStore) GetSession(_ context.Context, sessionID, userI
 func TestHandleGetCopilotSession_HappyPathAggregatesSessionJobsAndDecisions(t *testing.T) {
 	s, _, _ := newTestGateway(t)
 	s.auth = governanceAuth{}
-	now := time.Date(2026, time.April, 26, 8, 0, 0, 0, time.UTC)
+	// Wall-clock, not a fixed date: AppendDecision prunes decision-log entries
+	// older than the 30-day retention window on insert (decision_log_store.go),
+	// so a hardcoded past timestamp silently ages out and the query returns
+	// nothing once the test runs >30 days later.
+	now := time.Now().UTC()
 	store := &stubCopilotSessionStore{
 		session: &copilot.CopilotSession{
 			ID:        "sess-abc123",
@@ -291,7 +295,11 @@ func TestHandleGetCopilotSession_JobsReadOnlyRoleSeesNoDecisions(t *testing.T) {
 		t.Fatalf("PutRole() error = %v", err)
 	}
 
-	now := time.Date(2026, time.April, 26, 8, 0, 0, 0, time.UTC)
+	// Wall-clock, not a fixed date: AppendDecision prunes decision-log entries
+	// older than the 30-day retention window on insert (decision_log_store.go),
+	// so a hardcoded past timestamp silently ages out and the query returns
+	// nothing once the test runs >30 days later.
+	now := time.Now().UTC()
 	s.copilotStore = &stubCopilotSessionStore{
 		session: &copilot.CopilotSession{
 			ID:        "sess-rbac",
@@ -376,7 +384,11 @@ func TestHandleGetCopilotSession_GovernanceReadRoleSeesDecisions(t *testing.T) {
 		t.Fatalf("PutRole() error = %v", err)
 	}
 
-	now := time.Date(2026, time.April, 26, 8, 0, 0, 0, time.UTC)
+	// Wall-clock, not a fixed date: AppendDecision prunes decision-log entries
+	// older than the 30-day retention window on insert (decision_log_store.go),
+	// so a hardcoded past timestamp silently ages out and the query returns
+	// nothing once the test runs >30 days later.
+	now := time.Now().UTC()
 	s.copilotStore = &stubCopilotSessionStore{
 		session: &copilot.CopilotSession{
 			ID:        "sess-rbac-pos",


### PR DESCRIPTION
## Why

`Test (1.25)` and `Integration Tests` are red on **every** open PR branched from `main` (e.g. all five Dependabot Actions bumps #302–#306), even though those PRs only change workflow YAML. The failure is on `main`:

```
--- FAIL: TestHandleGetCopilotSession_HappyPathAggregatesSessionJobsAndDecisions
--- FAIL: TestHandleGetCopilotSession_GovernanceReadRoleSeesDecisions
FAIL	github.com/cordum/cordum/core/controlplane/gateway
```

## Root cause — a time-bomb test

`RedisDecisionLogStore.AppendDecision` enforces the 30-day decision-log retention window **on insert**:

```go
cutoff := time.Now().UTC().Add(-s.ttl).UnixMilli() // ttl = 30 days
pipe.ZRemRangeByScore(ctx, primaryIndex, "-inf", cutoff)
```

These tests seeded decision records at a **hardcoded `2026-04-26`** timestamp. Once the suite runs more than 30 days later (it is now 2026-05-27), the seeded record's score is below the cutoff, so it is pruned the instant it is appended → `collectCopilotSessionDecisions` returns an empty list → assertions fail. The sibling test `TestCollectCopilotSessionDecisionsPaginatesPastUnrelatedTenantDecisions` already documents this exact trap and uses wall-clock `now`.

## Fix

Seed the three affected tests with wall-clock `time.Now().UTC()` instead of a fixed past date. The negative-RBAC case (`jobs-only` role) keeps asserting `decisions == 0` and now exercises the governance-permission gate rather than relying on the retention prune. **No production code changes.**

## Test plan

- `go test ./core/controlplane/gateway -run 'TestHandleGetCopilotSession|TestCollectCopilotSession' -count=1` → `ok`.
- Unblocks the failing `Test (1.25)` / `Integration Tests` checks on PRs branched from `main` (#302–#306, #307, #301) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Copilot session handler test stability to ensure consistent results over extended periods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->