### PR TITLE
ci(binaries-pr-validation): resilient GnuPG step (apt mirror flake)

### DIFF
--- a/.github/workflows/binaries-pr-validation.yml
+++ b/.github/workflows/binaries-pr-validation.yml
@@ -65,8 +65,18 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Install GnuPG
-        run: sudo apt-get update && sudo apt-get install -y gnupg
+      - name: Ensure GnuPG
+        # gnupg is preinstalled on ubuntu-latest, so this is normally a no-op.
+        # When it isn't, retry the apt mirror — `apt-get update` against
+        # azure.archive.ubuntu.com has hung the job past timeout when the
+        # mirror is unreachable (e.g. cancelled run 26538443323 on #301).
+        run: |
+          if command -v gpg >/dev/null 2>&1; then
+            echo "gpg already on PATH ($(gpg --version | head -n1)); skipping apt"
+            exit 0
+          fi
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get install -y gnupg
       - name: make release-local
         run: make release-local
       - name: install_test.sh — tamper + unsigned synthetics must FAIL install


### PR DESCRIPTION
## Why
`install_test.sh synthetic-tampered` was **cancelled** on PR #301 (run [26538443323](https://github.com/cordum-io/cordum/actions/runs/26538443323/job/78174374763)) because `apt-get update` hung for ~15 minutes hitting an unreachable Azure Ubuntu mirror (`azure.archive.ubuntu.com`) before the 15-min job timeout fired. Every other check on the run was green; the Windows counterpart (`install_test.ps1`) passed in the same run, so the verifier itself is fine — only the Linux Install GnuPG step flaked.

## What
- Skip `apt-get` entirely when `gpg` is already on PATH (it is, by default, on `ubuntu-latest`).
- When it isn't, retry the mirror up to 3 times instead of bailing on the first network failure.

Keeps the **EDGE-151 Tier 1 supply-chain verification gate** intact — `install_test.sh` still runs and still asserts `install.sh` refuses tampered + unsigned synthetic releases. Only the brittle apt step changes.

## Tested
This file is in the workflow's own `paths:` trigger, so this PR runs the gate against itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build validation pipeline reliability by making GnuPG installation conditional and adding retry logic for package fetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->