### PR TITLE
fix(dashboard): live stream connects in session-cookie mode (not just apikey)

### DIFF
--- a/dashboard/src/hooks/useEventStream.test.ts
+++ b/dashboard/src/hooks/useEventStream.test.ts
@@ -62,11 +62,24 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 // Mock config store
+type MockConfigState = {
+  apiKey: string;
+  apiBaseUrl: string;
+  authMode: "apikey" | "session" | "anonymous";
+  isAuthenticated: boolean;
+};
 let mockApiKey = "test-key";
 let mockApiBaseUrl = "";
+let mockAuthMode: MockConfigState["authMode"] = "apikey";
+let mockIsAuthenticated = true;
 vi.mock("../state/config", () => ({
-  useConfigStore: (selector: (s: { apiKey: string; apiBaseUrl: string }) => unknown) =>
-    selector({ apiKey: mockApiKey, apiBaseUrl: mockApiBaseUrl }),
+  useConfigStore: (selector: (s: MockConfigState) => unknown) =>
+    selector({
+      apiKey: mockApiKey,
+      apiBaseUrl: mockApiBaseUrl,
+      authMode: mockAuthMode,
+      isAuthenticated: mockIsAuthenticated,
+    }),
 }));
 
 // Import after mocks
@@ -89,6 +102,8 @@ describe("useEventStream", () => {
     MockWebSocket.instances = [];
     mockInvalidateQueries.mockClear();
     mockApiKey = "test-key";
+    mockAuthMode = "apikey";
+    mockIsAuthenticated = true;
     useEventStore.setState({
       status: "disconnected",
       events: [],
@@ -114,6 +129,38 @@ describe("useEventStream", () => {
     expect(ws.protocols).toHaveLength(2);
     expect(ws.protocols[0]).toBe("cordum-api-key");
     expect(ws.protocols[1]).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("connects WITHOUT subprotocol in session mode (cookie auth)", () => {
+    // Session-mode login (e.g. password / SSO) keeps apiKey empty on purpose
+    // — auth flows via the httpOnly cordum_session cookie the gateway set.
+    // Previously the hook bailed on `!apiKey` and the status badge stuck on
+    // "disconnected". The fix: connect anyway, just without the subprotocol,
+    // and let the cookie carry the credential.
+    mockAuthMode = "session";
+    mockApiKey = "";
+    useEventStream();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].protocols).toHaveLength(0);
+  });
+
+  it("does not connect when not authenticated", () => {
+    mockIsAuthenticated = false;
+    mockAuthMode = "anonymous";
+    mockApiKey = "";
+    useEventStream();
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
+  it("does not connect in apikey mode when apiKey is empty", () => {
+    // Defensive: if authMode says apikey but the key is missing (transient
+    // state during update), don't open a connection that would immediately
+    // 401 — the gateway requires the subprotocol credential in this mode.
+    mockAuthMode = "apikey";
+    mockApiKey = "";
+    mockIsAuthenticated = true;
+    useEventStream();
+    expect(MockWebSocket.instances).toHaveLength(0);
   });
 
   it("sets status to connected on open", () => {

--- a/dashboard/src/hooks/useEventStream.ts
+++ b/dashboard/src/hooks/useEventStream.ts
@@ -337,6 +337,8 @@ export function useEventStream(): void {
   const queryClient = useQueryClient();
   const apiKey = useConfigStore((s) => s.apiKey);
   const apiBaseUrl = useConfigStore((s) => s.apiBaseUrl);
+  const authMode = useConfigStore((s) => s.authMode);
+  const isAuthenticated = useConfigStore((s) => s.isAuthenticated);
   const wsRef = useRef<WebSocket | null>(null);
   const backoffRef = useRef(MIN_BACKOFF_MS);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -346,7 +348,16 @@ export function useEventStream(): void {
   useEffect(() => {
     unmountedRef.current = false;
 
-    if (!apiKey) return;
+    // Connect when authenticated by EITHER credential mode:
+    //   - apikey mode  → auth via WS subprotocol `cordum-api-key.<base64(key)>`
+    //   - session mode → no subprotocol; the browser sends the httpOnly
+    //                    `cordum_session` cookie automatically, and the
+    //                    gateway's standard auth middleware
+    //                    (handlers_stream.go: auth.FromRequest) accepts it.
+    // Previously this gated on `apiKey` alone, so password-logged-in users
+    // never connected and the status badge stayed stuck on "disconnected".
+    if (!isAuthenticated) return;
+    if (authMode === "apikey" && !apiKey) return;
 
     const { setStatus, addEvent, pushSafetyDecision } =
       useEventStore.getState();
@@ -354,15 +365,23 @@ export function useEventStream(): void {
     function connect() {
       if (unmountedRef.current) return;
 
-      // Auth via subprotocol — send identifier and credential as separate list
-      // entries so the server echoes only "cordum-api-key" (never the key itself).
-      const encoded = btoa(apiKey).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-
       setStatus("connecting");
       const url = wsUrl(apiBaseUrl);
-      logger.info("ws", "Connecting", { url });
+      logger.info("ws", "Connecting", { url, authMode });
 
-      const ws = new WebSocket(url, ["cordum-api-key", encoded]);
+      let ws: WebSocket;
+      if (authMode === "apikey" && apiKey) {
+        // Auth via subprotocol — send identifier and credential as separate list
+        // entries so the server echoes only "cordum-api-key" (never the key itself).
+        const encoded = btoa(apiKey)
+          .replace(/\+/g, "-")
+          .replace(/\//g, "_")
+          .replace(/=+$/, "");
+        ws = new WebSocket(url, ["cordum-api-key", encoded]);
+      } else {
+        // Session mode: cookie carries auth; no subprotocol.
+        ws = new WebSocket(url);
+      }
       wsRef.current = ws;
 
       ws.onopen = () => {
@@ -506,6 +525,7 @@ export function useEventStream(): void {
       }
       useEventStore.getState().setStatus("disconnected");
     };
-    // Re-connect when apiKey changes (login/logout)
-  }, [apiKey, apiBaseUrl, queryClient]);
+    // Re-connect when auth state changes (login/logout) or when the API key
+    // is set/cleared (embedded-config path can flip apikey mode at runtime).
+  }, [apiKey, apiBaseUrl, authMode, isAuthenticated, queryClient]);
 }


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved WebSocket connection reliability by properly handling session-based and API key authentication modes
  * Event streaming now correctly connects and disconnects when authentication state or mode changes
  * Prevents unnecessary connection attempts when not authenticated or API key is empty

* **Tests**
  * Added comprehensive test coverage for WebSocket authentication and connection behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->