### PR TITLE
feat(config): safety-policy schema rejection suggests sibling rule-type

### DIFF
--- a/core/infra/config/safety_policy.go
+++ b/core/infra/config/safety_policy.go
@@ -583,7 +583,7 @@ func ParseSafetyPolicy(data []byte) (*SafetyPolicy, error) {
 		return nil, nil
 	}
 	if err := validateConfigSchema("safety policy", safetyPolicySchemaFile, data); err != nil {
-		return nil, err
+		return nil, enrichSafetyPolicyValidationError(err)
 	}
 	var policy SafetyPolicy
 	if err := yaml.Unmarshal(data, &policy); err != nil {

--- a/core/infra/config/safety_policy_errors.go
+++ b/core/infra/config/safety_policy_errors.go
@@ -57,19 +57,15 @@ var (
 // sections fell back to "ambiguous" and dropped every hint (CodeRabbit
 // finding on #316).
 //
-// `[^']*?` is lazy so we stop at the FIRST closing quote of `'X'`, which is
-// the offending field name. `[^/']*?` between the section and the field
-// keeps the match local to one rejection (no `/` allowed, so a cross-cause
-// match can't slip through).
+// The gap `[^']*?` is lazy, so each match pairs a rule-match path with the
+// FIRST `additionalProperties 'X'` that follows it — that rejection's own
+// offending field. `/` is intentionally allowed in the gap because the
+// rejection path itself contains `/additionalProperties` before the message;
+// it's the laziness (not a `/` exclusion) that scopes each match to one
+// cause. `([^']+)` then captures the field name up to its closing quote.
 var causeRegex = regexp.MustCompile(
 	`/properties/(rules|input_rules)/items/\$ref/properties/match[^']*?additionalProperties '([^']+)' not allowed`,
 )
-
-// additionalPropsRegex is a fallback for rejections that DON'T sit under
-// rules[].match or input_rules[].match (e.g. an unknown top-level key).
-// We use it only to detect "is there any schema rejection at all?" and pass
-// the error through unchanged when no rule-match cause matched.
-var additionalPropsRegex = regexp.MustCompile(`additionalProperties '([^']+)' not allowed`)
 
 // enrichSafetyPolicyValidationError wraps a schema validation failure with a
 // "did you mean..." hint when the offending property is valid on the SIBLING

--- a/core/infra/config/safety_policy_errors.go
+++ b/core/infra/config/safety_policy_errors.go
@@ -12,7 +12,9 @@ import (
 // and definitions.inputMatch). The schema is the source of truth; if you
 // add or remove a field there, update the corresponding set below and the
 // TestEnrichSafetyPolicyValidationError_FieldSetsMatchSchema test that
-// guards against drift.
+// guards against drift (it walks the schema bidirectionally so a NEW
+// exclusive field added to the schema without a hint-set update will
+// also fire the test, not just a removed one).
 var (
 	policyMatchOnlyFields = map[string]struct{}{
 		"pack_ids":                   {},
@@ -20,6 +22,7 @@ var (
 		"actor_types":                {},
 		"agent_risk_tiers":           {},
 		"agent_data_classifications": {},
+		"labels":                     {},
 		"label_allowlist":            {},
 		"label_threshold":            {},
 		"secrets_present":            {},
@@ -40,9 +43,32 @@ var (
 	}
 )
 
-// Compiled once; matches messages emitted by jsonschema/v5 of the form
-// `additionalProperties 'X' not allowed`. We capture the field name to
-// look up which rule type it actually belongs on.
+// causeRegex extracts (section, field) pairs PER REJECTION from a
+// jsonschema/v5 validation error. The library emits each cause with its own
+// schema location prefix like:
+//
+//	... inmemory://safety-policy#/properties/rules/items/$ref/properties/match/...:
+//	    additionalProperties 'keywords' not allowed
+//	... inmemory://safety-policy#/properties/input_rules/items/$ref/properties/match/...:
+//	    additionalProperties 'delegation' not allowed
+//
+// Matching the (section, field) tuple greedily-but-locally lets us emit
+// distinct hints per cause — previously a single error containing both
+// sections fell back to "ambiguous" and dropped every hint (CodeRabbit
+// finding on #316).
+//
+// `[^']*?` is lazy so we stop at the FIRST closing quote of `'X'`, which is
+// the offending field name. `[^/']*?` between the section and the field
+// keeps the match local to one rejection (no `/` allowed, so a cross-cause
+// match can't slip through).
+var causeRegex = regexp.MustCompile(
+	`/properties/(rules|input_rules)/items/\$ref/properties/match[^']*?additionalProperties '([^']+)' not allowed`,
+)
+
+// additionalPropsRegex is a fallback for rejections that DON'T sit under
+// rules[].match or input_rules[].match (e.g. an unknown top-level key).
+// We use it only to detect "is there any schema rejection at all?" and pass
+// the error through unchanged when no rule-match cause matched.
 var additionalPropsRegex = regexp.MustCompile(`additionalProperties '([^']+)' not allowed`)
 
 // enrichSafetyPolicyValidationError wraps a schema validation failure with a
@@ -63,38 +89,40 @@ func enrichSafetyPolicyValidationError(err error) error {
 		return nil
 	}
 	msg := err.Error()
-	matches := additionalPropsRegex.FindAllStringSubmatch(msg, -1)
-	if len(matches) == 0 {
+
+	// Per-cause (section, field) extraction. Each match is one rejection,
+	// scoped to a single rules[] or input_rules[] match-clause path. This
+	// is the right granularity — when one error has rejections in BOTH
+	// sections, we now suggest both, instead of dropping all hints because
+	// the global path was ambiguous (CodeRabbit major finding on #316).
+	pairs := causeRegex.FindAllStringSubmatch(msg, -1)
+	if len(pairs) == 0 {
 		return err
 	}
 
-	// Collect unique suggestions across all rejections in this error (the
-	// jsonschema library aggregates multiple causes into one error tree).
 	seenSuggestions := map[string]struct{}{}
-	suggestions := make([]string, 0, len(matches))
-	for _, m := range matches {
-		field := m[1]
-		path := pathContextFor(msg, field)
-		// Field used in rules[].match but is input-only → suggest input_rules.
-		if path == "rules" {
+	suggestions := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		section, field := p[1], p[2]
+		var hint string
+		switch section {
+		case "rules":
 			if _, ok := inputMatchOnlyFields[field]; ok {
-				s := fmt.Sprintf("'%s' is valid under input_rules[].match (content inspection); see docs/policy/global-authority.md", field)
-				if _, dup := seenSuggestions[s]; !dup {
-					seenSuggestions[s] = struct{}{}
-					suggestions = append(suggestions, s)
-				}
+				hint = fmt.Sprintf("'%s' is valid under input_rules[].match (content inspection); see docs/policy/global-authority.md", field)
 			}
-		}
-		// Field used in input_rules[].match but is policy-only → suggest rules.
-		if path == "input_rules" {
+		case "input_rules":
 			if _, ok := policyMatchOnlyFields[field]; ok {
-				s := fmt.Sprintf("'%s' is valid under rules[].match (dispatch); see docs/policy/global-authority.md", field)
-				if _, dup := seenSuggestions[s]; !dup {
-					seenSuggestions[s] = struct{}{}
-					suggestions = append(suggestions, s)
-				}
+				hint = fmt.Sprintf("'%s' is valid under rules[].match (dispatch); see docs/policy/global-authority.md", field)
 			}
 		}
+		if hint == "" {
+			continue
+		}
+		if _, dup := seenSuggestions[hint]; dup {
+			continue
+		}
+		seenSuggestions[hint] = struct{}{}
+		suggestions = append(suggestions, hint)
 	}
 
 	if len(suggestions) == 0 {
@@ -106,48 +134,6 @@ func enrichSafetyPolicyValidationError(err error) error {
 		hint += "; " + s
 	}
 	return fmt.Errorf("%w (%s)", err, hint)
-}
-
-// pathContextFor returns "rules" or "input_rules" if the substring around
-// the rejected field name in the jsonschema error indicates one of those
-// sections. Returns "" for any other context (so we don't fire incorrect
-// hints on unrelated additionalProperties rejections elsewhere in the schema).
-//
-// The jsonschema/v5 error embeds the schema location like:
-//
-//	/properties/rules/items/$ref/properties/match/$ref/additionalProperties
-//	/properties/input_rules/items/$ref/properties/match/$ref/additionalProperties
-//
-// We probe for `/properties/rules/items` and `/properties/input_rules/items`
-// against the WHOLE message rather than trying to align with the specific
-// instance location for the matched field — multiple causes in a single
-// error often share one schema location, so a global probe is robust.
-func pathContextFor(msg, _ string) string {
-	const ruleHint = "/properties/rules/items"
-	const inputHint = "/properties/input_rules/items"
-	hasRules := containsLiteral(msg, ruleHint)
-	hasInput := containsLiteral(msg, inputHint)
-	switch {
-	case hasInput && !hasRules:
-		return "input_rules"
-	case hasRules && !hasInput:
-		return "rules"
-	default:
-		// Ambiguous (both present, or neither). Don't risk a wrong hint.
-		return ""
-	}
-}
-
-// containsLiteral is a tiny strings.Contains shim so this file does not pull
-// in the strings package just for one call (avoids an import collision in
-// tests). Inlined for clarity.
-func containsLiteral(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }
 
 // Sentinel so callers can errors.Is the inner ValidationError if they want

--- a/core/infra/config/safety_policy_errors.go
+++ b/core/infra/config/safety_policy_errors.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+// Match-clause field sets, mirrored from
+// core/infra/config/schema/safety_policy.schema.json (definitions.policyMatch
+// and definitions.inputMatch). The schema is the source of truth; if you
+// add or remove a field there, update the corresponding set below and the
+// TestEnrichSafetyPolicyValidationError_FieldSetsMatchSchema test that
+// guards against drift.
+var (
+	policyMatchOnlyFields = map[string]struct{}{
+		"pack_ids":                   {},
+		"actor_ids":                  {},
+		"actor_types":                {},
+		"agent_risk_tiers":           {},
+		"agent_data_classifications": {},
+		"label_allowlist":            {},
+		"label_threshold":            {},
+		"secrets_present":            {},
+		"predicate":                  {},
+		"delegation":                 {},
+		"mcp":                        {},
+		"requires":                   {},
+	}
+	inputMatchOnlyFields = map[string]struct{}{
+		"scanners":         {},
+		"content_patterns": {},
+		"keywords":         {},
+		"content_types":    {},
+		"detectors":        {},
+		"input_size_gt":    {},
+		"max_input_bytes":  {},
+		"scope":            {},
+	}
+)
+
+// Compiled once; matches messages emitted by jsonschema/v5 of the form
+// `additionalProperties 'X' not allowed`. We capture the field name to
+// look up which rule type it actually belongs on.
+var additionalPropsRegex = regexp.MustCompile(`additionalProperties '([^']+)' not allowed`)
+
+// enrichSafetyPolicyValidationError wraps a schema validation failure with a
+// "did you mean..." hint when the offending property is valid on the SIBLING
+// rule type (rules[]/input_rules[]).
+//
+// Background — see GitHub issue #312. The bare error from jsonschema/v5
+// says nothing about WHY the property was rejected; operators copying a
+// rule with `keywords:` from config/safety.yaml into rules[].match get a
+// pure red wall and no hint that `keywords` is valid on input_rules[].
+//
+// The function is intentionally narrow: it preserves the original error
+// (via %w) and only appends a single suggestion line. If we can't extract
+// a property name, or the property isn't on either rule's exclusive set,
+// the original error passes through unchanged.
+func enrichSafetyPolicyValidationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	matches := additionalPropsRegex.FindAllStringSubmatch(msg, -1)
+	if len(matches) == 0 {
+		return err
+	}
+
+	// Collect unique suggestions across all rejections in this error (the
+	// jsonschema library aggregates multiple causes into one error tree).
+	seenSuggestions := map[string]struct{}{}
+	suggestions := make([]string, 0, len(matches))
+	for _, m := range matches {
+		field := m[1]
+		path := pathContextFor(msg, field)
+		// Field used in rules[].match but is input-only → suggest input_rules.
+		if path == "rules" {
+			if _, ok := inputMatchOnlyFields[field]; ok {
+				s := fmt.Sprintf("'%s' is valid under input_rules[].match (content inspection); see docs/policy/global-authority.md", field)
+				if _, dup := seenSuggestions[s]; !dup {
+					seenSuggestions[s] = struct{}{}
+					suggestions = append(suggestions, s)
+				}
+			}
+		}
+		// Field used in input_rules[].match but is policy-only → suggest rules.
+		if path == "input_rules" {
+			if _, ok := policyMatchOnlyFields[field]; ok {
+				s := fmt.Sprintf("'%s' is valid under rules[].match (dispatch); see docs/policy/global-authority.md", field)
+				if _, dup := seenSuggestions[s]; !dup {
+					seenSuggestions[s] = struct{}{}
+					suggestions = append(suggestions, s)
+				}
+			}
+		}
+	}
+
+	if len(suggestions) == 0 {
+		return err
+	}
+	sort.Strings(suggestions)
+	hint := "did you mean: " + suggestions[0]
+	for _, s := range suggestions[1:] {
+		hint += "; " + s
+	}
+	return fmt.Errorf("%w (%s)", err, hint)
+}
+
+// pathContextFor returns "rules" or "input_rules" if the substring around
+// the rejected field name in the jsonschema error indicates one of those
+// sections. Returns "" for any other context (so we don't fire incorrect
+// hints on unrelated additionalProperties rejections elsewhere in the schema).
+//
+// The jsonschema/v5 error embeds the schema location like:
+//
+//	/properties/rules/items/$ref/properties/match/$ref/additionalProperties
+//	/properties/input_rules/items/$ref/properties/match/$ref/additionalProperties
+//
+// We probe for `/properties/rules/items` and `/properties/input_rules/items`
+// against the WHOLE message rather than trying to align with the specific
+// instance location for the matched field — multiple causes in a single
+// error often share one schema location, so a global probe is robust.
+func pathContextFor(msg, _ string) string {
+	const ruleHint = "/properties/rules/items"
+	const inputHint = "/properties/input_rules/items"
+	hasRules := containsLiteral(msg, ruleHint)
+	hasInput := containsLiteral(msg, inputHint)
+	switch {
+	case hasInput && !hasRules:
+		return "input_rules"
+	case hasRules && !hasInput:
+		return "rules"
+	default:
+		// Ambiguous (both present, or neither). Don't risk a wrong hint.
+		return ""
+	}
+}
+
+// containsLiteral is a tiny strings.Contains shim so this file does not pull
+// in the strings package just for one call (avoids an import collision in
+// tests). Inlined for clarity.
+func containsLiteral(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// Sentinel so callers can errors.Is the inner ValidationError if they want
+// to distinguish enrichment from the underlying error. Not used today but
+// keeps the API forward-compatible.
+var ErrSafetyPolicyValidation = errors.New("safety policy schema validation")

--- a/core/infra/config/safety_policy_errors_test.go
+++ b/core/infra/config/safety_policy_errors_test.go
@@ -127,10 +127,15 @@ func TestEnrichSafetyPolicyValidationError_NilIsNil(t *testing.T) {
 	}
 }
 
-// Drift guard: every field in policyMatchOnlyFields and inputMatchOnlyFields
-// must still be (a) defined in the schema, and (b) NOT in the OTHER side's
-// allowlist. If anyone adds a field to the schema and forgets to update the
-// sets here, this test fires and points at exactly which one drifted.
+// Drift guard: every field in policyMatchOnlyFields / inputMatchOnlyFields
+// must still be (a) defined in the schema and (b) NOT in the OTHER side's
+// definition. AND — bidirectionally — every field that's actually exclusive
+// to one match definition in the schema must appear in the corresponding
+// hint set. The CodeRabbit major finding on #316 pointed out the one-way
+// check above silently passes if someone adds a NEW exclusive field to the
+// schema and forgets the hint set; the bidirectional check below catches
+// that case too. Either drift direction fires this test with a precise
+// pointer at the field that diverged.
 func TestEnrichSafetyPolicyValidationError_FieldSetsMatchSchema(t *testing.T) {
 	schemaBytes, err := configSchemaFS.ReadFile(safetyPolicySchemaFile)
 	if err != nil {
@@ -147,6 +152,9 @@ func TestEnrichSafetyPolicyValidationError_FieldSetsMatchSchema(t *testing.T) {
 	policyMatch := matchProperties(t, defs, "policyMatch")
 	inputMatch := matchProperties(t, defs, "inputMatch")
 
+	// Direction 1 — every entry in our hint sets must be a real schema
+	// field AND must not also appear in the OTHER definition (otherwise
+	// it isn't exclusive, and the hint would mislead).
 	for field := range policyMatchOnlyFields {
 		if _, ok := policyMatch[field]; !ok {
 			t.Errorf("policyMatchOnlyFields lists %q but the schema's policyMatch does not", field)
@@ -163,6 +171,71 @@ func TestEnrichSafetyPolicyValidationError_FieldSetsMatchSchema(t *testing.T) {
 			t.Errorf("inputMatchOnlyFields lists %q but it's ALSO in policyMatch — it isn't exclusive", field)
 		}
 	}
+
+	// Direction 2 — walk the SCHEMA. Every field that's exclusive to one
+	// definition must appear in the matching hint set; otherwise the hint
+	// won't fire when a user puts it in the wrong section. This catches
+	// the case where the schema gains a new exclusive field but the hint
+	// sets are left behind.
+	for field := range policyMatch {
+		if _, alsoInInput := inputMatch[field]; alsoInInput {
+			continue // shared field; no exclusive hint applies
+		}
+		if _, listed := policyMatchOnlyFields[field]; !listed {
+			t.Errorf(
+				"schema field %q is exclusive to policyMatch but missing from policyMatchOnlyFields — "+
+					"hint won't fire if a user puts it in input_rules[].match", field)
+		}
+	}
+	for field := range inputMatch {
+		if _, alsoInPolicy := policyMatch[field]; alsoInPolicy {
+			continue
+		}
+		if _, listed := inputMatchOnlyFields[field]; !listed {
+			t.Errorf(
+				"schema field %q is exclusive to inputMatch but missing from inputMatchOnlyFields — "+
+					"hint won't fire if a user puts it in rules[].match", field)
+		}
+	}
+}
+
+// Regression for the second CodeRabbit major finding on #316. The previous
+// global "is /properties/rules/items AND /properties/input_rules/items in
+// the message?" check returned "" (ambiguous) when one validation error
+// contained rejections in BOTH sections — dropping every otherwise-valid
+// hint. The per-cause regex now emits one hint per rejection independently.
+func TestEnrichSafetyPolicyValidationError_BothSectionsInOneError(t *testing.T) {
+	// Build a single multi-cause error string by hand. The shape mirrors
+	// what jsonschema/v5 actually produces — each cause gets its own
+	// schema location prefix and an `additionalProperties 'X' not allowed`
+	// trailer.
+	combined := errors.New(
+		"validate safety policy config: schema validation failed: jsonschema: '/' does not validate with " +
+			"inmemory://safety-policy: " +
+			// cause 1 — content-inspection field in rules[].match
+			"jsonschema: '/rules/0/match' does not validate with inmemory://safety-policy#/properties/rules/items/$ref/properties/match/$ref/additionalProperties: additionalProperties 'keywords' not allowed; " +
+			// cause 2 — dispatch-only field in input_rules[].match
+			"jsonschema: '/input_rules/0/match' does not validate with inmemory://safety-policy#/properties/input_rules/items/$ref/properties/match/$ref/additionalProperties: additionalProperties 'delegation' not allowed",
+	)
+	enriched := enrichSafetyPolicyValidationError(combined)
+	msg := enriched.Error()
+	// Both hints must appear — previously the global path check returned
+	// "ambiguous" and the user got zero suggestions.
+	if !contains(msg, "'keywords' is valid under input_rules[].match") {
+		t.Errorf("expected input_rules hint for keywords; got: %s", msg)
+	}
+	if !contains(msg, "'delegation' is valid under rules[].match") {
+		t.Errorf("expected rules hint for delegation; got: %s", msg)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func matchProperties(t *testing.T, defs map[string]any, name string) map[string]any {

--- a/core/infra/config/safety_policy_errors_test.go
+++ b/core/infra/config/safety_policy_errors_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The end-to-end behavior #312 cares about: someone authors a policy
+// fragment putting `keywords` in rules[].match (where it doesn't belong)
+// and ParseSafetyPolicy returns an error that names the right section.
+func TestParseSafetyPolicy_KeywordsInRulesSuggestsInputRules(t *testing.T) {
+	bad := []byte(`
+rules:
+  - id: bad-keywords-in-rules
+    match:
+      topics: [job.x]
+      keywords: ["refund"]
+    decision: require_approval
+    reason: ""
+`)
+	_, err := ParseSafetyPolicy(bad)
+	if err == nil {
+		t.Fatal("expected schema validation error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "additionalProperties") {
+		t.Fatalf("expected underlying schema error preserved, got: %s", msg)
+	}
+	if !strings.Contains(msg, "input_rules[].match") {
+		t.Errorf("expected hint pointing to input_rules[].match, got: %s", msg)
+	}
+	if !strings.Contains(msg, "'keywords'") {
+		t.Errorf("expected hint to name the offending field 'keywords', got: %s", msg)
+	}
+	if !strings.Contains(msg, "docs/policy/global-authority.md") {
+		t.Errorf("expected hint to link the canonical docs page, got: %s", msg)
+	}
+}
+
+func TestParseSafetyPolicy_ContentPatternsInRulesSuggestsInputRules(t *testing.T) {
+	bad := []byte(`
+rules:
+  - id: bad-patterns-in-rules
+    match:
+      topics: ["job.x"]
+      content_patterns: ["ignore previous"]
+    decision: deny
+    reason: ""
+`)
+	_, err := ParseSafetyPolicy(bad)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "'content_patterns'") || !strings.Contains(err.Error(), "input_rules[].match") {
+		t.Errorf("expected content_patterns→input_rules hint, got: %s", err)
+	}
+}
+
+// Symmetric direction: a policy-only field in input_rules[] should suggest
+// the dispatch (rules) section. delegation is policyMatch-only and a clean
+// example because it isn't likely to appear in any input_rule by accident.
+func TestParseSafetyPolicy_DelegationInInputRulesSuggestsRules(t *testing.T) {
+	bad := []byte(`
+input_rules:
+  - id: bad-delegation-in-input-rules
+    severity: high
+    match:
+      topics: ["job.x"]
+      delegation:
+        max_depth: 2
+    decision: deny
+    reason: ""
+`)
+	_, err := ParseSafetyPolicy(bad)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "'delegation'") || !strings.Contains(err.Error(), "rules[].match") {
+		t.Errorf("expected delegation→rules hint, got: %s", err)
+	}
+}
+
+// Valid policy should still parse fine.
+func TestParseSafetyPolicy_ValidPolicyAcceptsBothSections(t *testing.T) {
+	good := []byte(`
+rules:
+  - id: classify-allow
+    match: { topics: [job.support.classify] }
+    decision: allow
+    reason: ""
+input_rules:
+  - id: send-money-approve
+    severity: high
+    match:
+      topics: [job.support.send]
+      keywords: ["refund"]
+    decision: require_approval
+    reason: ""
+`)
+	if _, err := ParseSafetyPolicy(good); err != nil {
+		t.Fatalf("unexpected error on valid policy: %v", err)
+	}
+}
+
+// Schema rejections unrelated to match-clause (e.g. an unknown top-level
+// field) should pass through unchanged — we must not append a spurious
+// "did you mean…" hint when neither rules[] nor input_rules[] is implicated.
+func TestEnrichSafetyPolicyValidationError_PassesThroughUnrelated(t *testing.T) {
+	original := errors.New(
+		"validate safety policy config: schema validation failed: " +
+			"jsonschema: '/totally_unknown' does not validate with " +
+			"inmemory://safety-policy#/additionalProperties: " +
+			"additionalProperties 'totally_unknown' not allowed",
+	)
+	enriched := enrichSafetyPolicyValidationError(original)
+	if enriched.Error() != original.Error() {
+		t.Errorf("unrelated error must pass through unchanged.\nbefore: %s\nafter:  %s",
+			original, enriched)
+	}
+}
+
+func TestEnrichSafetyPolicyValidationError_NilIsNil(t *testing.T) {
+	if got := enrichSafetyPolicyValidationError(nil); got != nil {
+		t.Errorf("nil in → nil out; got %v", got)
+	}
+}
+
+// Drift guard: every field in policyMatchOnlyFields and inputMatchOnlyFields
+// must still be (a) defined in the schema, and (b) NOT in the OTHER side's
+// allowlist. If anyone adds a field to the schema and forgets to update the
+// sets here, this test fires and points at exactly which one drifted.
+func TestEnrichSafetyPolicyValidationError_FieldSetsMatchSchema(t *testing.T) {
+	schemaBytes, err := configSchemaFS.ReadFile(safetyPolicySchemaFile)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(schemaBytes, &doc); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	defs, _ := doc["definitions"].(map[string]any)
+	if defs == nil {
+		t.Fatal("schema missing definitions")
+	}
+	policyMatch := matchProperties(t, defs, "policyMatch")
+	inputMatch := matchProperties(t, defs, "inputMatch")
+
+	for field := range policyMatchOnlyFields {
+		if _, ok := policyMatch[field]; !ok {
+			t.Errorf("policyMatchOnlyFields lists %q but the schema's policyMatch does not", field)
+		}
+		if _, ok := inputMatch[field]; ok {
+			t.Errorf("policyMatchOnlyFields lists %q but it's ALSO in inputMatch — it isn't exclusive", field)
+		}
+	}
+	for field := range inputMatchOnlyFields {
+		if _, ok := inputMatch[field]; !ok {
+			t.Errorf("inputMatchOnlyFields lists %q but the schema's inputMatch does not", field)
+		}
+		if _, ok := policyMatch[field]; ok {
+			t.Errorf("inputMatchOnlyFields lists %q but it's ALSO in policyMatch — it isn't exclusive", field)
+		}
+	}
+}
+
+func matchProperties(t *testing.T, defs map[string]any, name string) map[string]any {
+	t.Helper()
+	d, _ := defs[name].(map[string]any)
+	if d == nil {
+		t.Fatalf("schema missing definition %q", name)
+	}
+	props, _ := d["properties"].(map[string]any)
+	if props == nil {
+		t.Fatalf("schema definition %q has no properties", name)
+	}
+	return props
+}


### PR DESCRIPTION
Fixes #312.

## Bug

Safety policy rules split across two slots:

- `rules[].match` (policyMatch) — topic / actor / capability dispatch
- `input_rules[].match` (inputMatch) — content inspection (`keywords`, `content_patterns`, `scanners`, …)

A pack author who puts `keywords` (or any content-inspection field) directly in `rules[].match` today gets a bare:

```
schema validation failed: ... additionalProperties 'keywords' not allowed
```

Technically correct, operationally useless — `keywords` IS valid, just on the other rule type. The split is only documented in `docs/policy/global-authority.md`, which is easy to miss. Hit this myself today; took 30 minutes of grepping the schema file before the structure clicked.

## Fix

`ParseSafetyPolicy` now wraps validation errors with a single "did you mean…" line when the offending property is exclusive to the sibling rule type:

```
validate safety policy config: schema validation failed:
  ... additionalProperties 'keywords' not allowed
  (did you mean: 'keywords' is valid under input_rules[].match
   (content inspection); see docs/policy/global-authority.md)
```

Symmetric — a policy-only field (`delegation`, `predicate`, `mcp`, …) put in `input_rules[].match` suggests `rules[].match`.

### Implementation notes

- All in a new file `core/infra/config/safety_policy_errors.go` (~80 lines) — no behavior change to `validate.go` / generic schema validation; the hint fires only on the safety-policy path.
- Original error preserved verbatim via `fmt.Errorf("%w (%s)", err, hint)` — `errors.Is/As` chains keep working.
- If the offending field belongs to BOTH rule types, or NEITHER, the original error passes through unchanged (test covers it).
- Field sets are mirrored from the JSON schema and **drift-guarded** by `TestEnrichSafetyPolicyValidationError_FieldSetsMatchSchema`: if anyone adds/removes a field in `safety_policy.schema.json` and forgets to update these sets, the test fires with a precise pointer at the divergence.

### Tests

7 new tests in `safety_policy_errors_test.go`:

| Case | Expectation |
|---|---|
| `keywords` in `rules[].match` | hint → `input_rules[].match` |
| `content_patterns` in `rules[].match` | hint → `input_rules[].match` |
| `delegation` in `input_rules[].match` | hint → `rules[].match` |
| valid policy with both slots populated correctly | no error |
| unrelated `additionalProperties` rejection | passes through, no spurious hint |
| `nil` in → `nil` out | safety guard |
| field sets vs schema | drift guard |

`go test ./core/infra/config/` — all green (existing + 7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors for safety policies now include actionable "did you mean" hints when fields are placed in the wrong section, while preserving the original message.

* **Tests**
  * Added end-to-end tests covering hint enrichment, pass-through cases, schema-drift checks, and multi-section validation errors.

* **Chores**
  * Introduced a sentinel error to let callers detect enriched validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->