### PR TITLE
feat(dashboard): empty-state "Create identity" affordance for heartbeating workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ dashboard/lh-*.json
 production_gate_results.json
 *.go.[0-9]*
 certs/
+tools/dev-keys/
+docker-compose.local.yml

--- a/core/controlplane/gateway/handlers_agents.go
+++ b/core/controlplane/gateway/handlers_agents.go
@@ -18,7 +18,12 @@ import (
 const agentIdentityFeature = "agent_identity"
 
 type createAgentRequest struct {
-	Name                     string   `json:"name"`
+	Name string `json:"name"`
+	// AgentID, when set, registers this identity for an existing worker. The
+	// server links worker_id -> identity (LinkWorker) so audit/scheduler
+	// resolution via GetByWorkerID surfaces the human label instead of the raw
+	// agent_id (#314). Empty preserves the prior behaviour (unlinked identity).
+	AgentID                  string   `json:"agent_id,omitempty"`
 	Description              string   `json:"description,omitempty"`
 	Owner                    string   `json:"owner"`
 	Team                     string   `json:"team,omitempty"`
@@ -125,6 +130,17 @@ func (s *server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// When registering an identity for an existing worker, refuse if that
+	// worker is already linked — otherwise LinkWorker below would overwrite
+	// the global worker->identity mapping and orphan the prior identity.
+	workerID := strings.TrimSpace(req.AgentID)
+	if workerID != "" {
+		if existing, lookupErr := s.agentIdentityStore.GetByWorkerID(r.Context(), workerID); lookupErr == nil && existing != nil {
+			writeJSONError(w, http.StatusConflict, errorCodeAgentWorkerConflict, "worker is already linked to an agent identity")
+			return
+		}
+	}
+
 	identity := store.AgentIdentity{
 		TenantID:                 tenant,
 		Name:                     strings.TrimSpace(req.Name),
@@ -146,6 +162,19 @@ func (s *server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, errorCodeAgentRequestInvalid, err.Error())
 		return
+	}
+
+	// Link the worker so GetByWorkerID-based resolution (audit enrichment,
+	// scheduler, MCP/job principals) maps this worker's agent_id to the new
+	// identity. Without this the identity exists but audit rows still fall
+	// back to the raw agent_id — the exact bug #314 set out to fix. The
+	// identity is already persisted, so surface a link failure rather than
+	// reporting a misleading success.
+	if workerID != "" {
+		if linkErr := s.agentIdentityStore.LinkWorker(r.Context(), created.ID, workerID); linkErr != nil {
+			writeInternalError(w, r, "link worker to agent identity", linkErr)
+			return
+		}
 	}
 
 	slog.Info("agent identity created",
@@ -311,6 +340,18 @@ func (s *server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeInternalError(w, r, "get agent identity", err)
 		return
+	}
+	if identity == nil {
+		// Fallback: `id` may be a worker id linked to an identity (e.g. a
+		// heartbeating worker registered via the dashboard empty-state flow,
+		// #314). Resolve through the worker link, then re-apply the tenant
+		// scope that GetByWorkerID does not enforce — preserving the
+		// existence-oracle hardening of the direct lookup above.
+		if linked, linkErr := s.agentIdentityStore.GetByWorkerID(r.Context(), id); linkErr == nil && linked != nil {
+			if tenant == "" || strings.TrimSpace(linked.TenantID) == tenant {
+				identity = linked
+			}
+		}
 	}
 	if identity == nil {
 		writeJSONError(w, http.StatusNotFound, errorCodeAgentNotFound, "agent identity not found")

--- a/core/controlplane/gateway/handlers_agents_test.go
+++ b/core/controlplane/gateway/handlers_agents_test.go
@@ -77,6 +77,78 @@ func TestCreateAgent(t *testing.T) {
 	}
 }
 
+// TestCreateAgent_LinksWorkerForHeartbeatRegistration covers the #314 flow:
+// creating an identity for a heartbeating worker (agent_id set) must link the
+// worker so GetByWorkerID-based resolution (audit/scheduler) works AND the
+// detail panel — which looks the identity up by the worker id — resolves it.
+// Before the fix, the created identity got an unrelated UUID with no link, so
+// both the panel (404) and audit attribution (raw agent_id) stayed broken.
+func TestCreateAgent_LinksWorkerForHeartbeatRegistration(t *testing.T) {
+	s, _, _ := newTestGateway(t)
+	enableAgentIdentityEntitlement(t, s)
+	ctx := context.Background()
+	const workerID = "support-triage-bot"
+
+	body := bytes.NewBufferString(`{"agent_id":"support-triage-bot","name":"Support Triage Bot","owner":"alice","risk_tier":"low"}`)
+	req := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/agents", body), &auth.AuthContext{
+		Tenant: "default", Role: "admin", PrincipalID: "admin-user",
+	})
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.handleCreateAgent(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var created agentResponse
+	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	// The identity keeps its own server-assigned id, distinct from the worker id.
+	if created.ID == "" || created.ID == workerID {
+		t.Fatalf("expected a server-generated id distinct from worker id, got %q", created.ID)
+	}
+
+	// Core of #314: the worker is linked, so GetByWorkerID resolves the identity.
+	linked, err := s.agentIdentityStore.GetByWorkerID(ctx, workerID)
+	if err != nil {
+		t.Fatalf("GetByWorkerID: %v", err)
+	}
+	if linked == nil || linked.ID != created.ID {
+		t.Fatalf("worker %q not linked to created identity %q (got %+v)", workerID, created.ID, linked)
+	}
+
+	// The panel looks the identity up by the worker id; the GET fallback must
+	// resolve it. This assertion fails on the pre-fix code (404).
+	getReq := withAuth(httptest.NewRequest(http.MethodGet, "/api/v1/agents/"+workerID, nil), &auth.AuthContext{
+		Tenant: "default", Role: "admin",
+	})
+	getReq.SetPathValue("id", workerID)
+	getRR := httptest.NewRecorder()
+	s.handleGetAgent(getRR, getReq)
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("get-by-worker-id: expected 200, got %d: %s", getRR.Code, getRR.Body.String())
+	}
+	var got agentResponse
+	if err := json.NewDecoder(getRR.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if got.ID != created.ID || got.Name != "Support Triage Bot" {
+		t.Fatalf("resolved wrong identity: %+v", got)
+	}
+
+	// Re-registering the same worker must conflict, not silently overwrite the link.
+	dupReq := withAuth(httptest.NewRequest(http.MethodPost, "/api/v1/agents",
+		bytes.NewBufferString(`{"agent_id":"support-triage-bot","name":"Dup","owner":"bob","risk_tier":"low"}`)),
+		&auth.AuthContext{Tenant: "default", Role: "admin"})
+	dupReq.Header.Set("Content-Type", "application/json")
+	dupRR := httptest.NewRecorder()
+	s.handleCreateAgent(dupRR, dupReq)
+	if dupRR.Code != http.StatusConflict {
+		t.Fatalf("duplicate worker register: expected 409, got %d: %s", dupRR.Code, dupRR.Body.String())
+	}
+	requireStableErrorCode(t, dupRR, http.StatusConflict, "AGENT_WORKER_CONFLICT")
+}
+
 func TestAgentIdentityAPISurfacesMCPAllowlists(t *testing.T) {
 	s, _, _ := newTestGateway(t)
 	enableAgentIdentityEntitlement(t, s)

--- a/core/controlplane/gateway/handlers_identity_admin_error_codes.go
+++ b/core/controlplane/gateway/handlers_identity_admin_error_codes.go
@@ -13,6 +13,7 @@ const (
 
 	errorCodeAgentRequestInvalid = "AGENT_REQUEST_INVALID"
 	errorCodeAgentNotFound       = "AGENT_NOT_FOUND"
+	errorCodeAgentWorkerConflict = "AGENT_WORKER_CONFLICT"
 
 	errorCodeConfigRequestInvalid  = "CONFIG_REQUEST_INVALID"
 	errorCodeConfigKeyForbidden    = "CONFIG_KEY_FORBIDDEN"

--- a/core/infra/maputil/clone.go
+++ b/core/infra/maputil/clone.go
@@ -30,9 +30,11 @@ func CloneAnyMap(m map[string]any) map[string]any {
 }
 
 // DeepCloneAnyMap returns a deep copy of the map, recursively cloning
-// nested map[string]any values and []any slices. Primitive types (int,
-// float64, string, bool) are copied by value. Unlike JSON round-trip,
-// this preserves Go types — int stays int, not float64.
+// nested containers so no reference is shared with the original:
+// map[string]any, map[any]any (from yaml.v2), []any, []string, and
+// []map[string]any. Primitive types (int, float64, string, bool) are
+// copied by value. Unlike JSON round-trip, this preserves Go types —
+// int stays int, not float64.
 func DeepCloneAnyMap(m map[string]any) map[string]any {
 	if m == nil {
 		return nil
@@ -52,6 +54,22 @@ func deepCloneValue(v any) any {
 		cp := make([]any, len(val))
 		for i, elem := range val {
 			cp[i] = deepCloneValue(elem)
+		}
+		return cp
+	case map[any]any:
+		// yaml.v2 unmarshals nested objects as map[any]any. Keys are scalars
+		// (copied by value); values are cloned recursively.
+		cp := make(map[any]any, len(val))
+		for mk, mv := range val {
+			cp[mk] = deepCloneValue(mv)
+		}
+		return cp
+	case []string:
+		return append([]string(nil), val...)
+	case []map[string]any:
+		cp := make([]map[string]any, len(val))
+		for i, m := range val {
+			cp[i] = DeepCloneAnyMap(m)
 		}
 		return cp
 	default:

--- a/core/infra/maputil/clone_test.go
+++ b/core/infra/maputil/clone_test.go
@@ -127,6 +127,49 @@ func TestDeepCloneAnyMap_PreservesIntType(t *testing.T) {
 	}
 }
 
+func TestDeepCloneAnyMap_StringSliceIsolated(t *testing.T) {
+	orig := map[string]any{"tags": []string{"a", "b"}}
+	got := DeepCloneAnyMap(orig)
+
+	gotSlice, ok := got["tags"].([]string)
+	if !ok || len(gotSlice) != 2 {
+		t.Fatalf("expected []string of len 2, got %T %v", got["tags"], got["tags"])
+	}
+	gotSlice[0] = "changed"
+	if orig["tags"].([]string)[0] != "a" {
+		t.Fatal("[]string mutation leaked to original")
+	}
+}
+
+func TestDeepCloneAnyMap_MapAnyAnyIsolated(t *testing.T) {
+	inner := map[any]any{"nested": true}
+	orig := map[string]any{"yaml": inner}
+	got := DeepCloneAnyMap(orig)
+
+	gotInner, ok := got["yaml"].(map[any]any)
+	if !ok {
+		t.Fatalf("expected map[any]any, got %T", got["yaml"])
+	}
+	gotInner["nested"] = false
+	if inner["nested"] != true {
+		t.Fatal("map[any]any mutation leaked to original")
+	}
+}
+
+func TestDeepCloneAnyMap_MapSliceIsolated(t *testing.T) {
+	orig := map[string]any{"items": []map[string]any{{"k": 1}}}
+	got := DeepCloneAnyMap(orig)
+
+	gotSlice, ok := got["items"].([]map[string]any)
+	if !ok || len(gotSlice) != 1 {
+		t.Fatalf("expected []map[string]any len 1, got %T %v", got["items"], got["items"])
+	}
+	gotSlice[0]["k"] = 999
+	if orig["items"].([]map[string]any)[0]["k"] != 1 {
+		t.Fatal("[]map[string]any mutation leaked to original")
+	}
+}
+
 func TestDeepCloneAnyMap_SliceCloned(t *testing.T) {
 	orig := map[string]any{
 		"tags": []any{"a", "b", map[string]any{"nested": true}},

--- a/dashboard/src/components/agents/AgentIdentityCreateForm.test.tsx
+++ b/dashboard/src/components/agents/AgentIdentityCreateForm.test.tsx
@@ -1,0 +1,188 @@
+/*
+ * Focused tests for the empty-state Create-Identity form added for issue
+ * #314. Covers:
+ *   - heartbeat-based pre-fill (display name, pool, description hint)
+ *   - fallback prettifier when no heartbeat is available
+ *   - mutation invocation with the operator-edited body
+ *   - error surface from the mutation hook
+ */
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Worker } from "@/api/types";
+import AgentIdentityCreateForm from "./AgentIdentityCreateForm";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const { mutationState } = vi.hoisted(() => ({
+  mutationState: {
+    mutate: vi.fn(),
+    isPending: false as boolean,
+    isError: false as boolean,
+    error: null as Error | null,
+  },
+}));
+
+vi.mock("@/hooks/useAgentIdentities", () => ({
+  useCreateAgentIdentity: () => mutationState,
+}));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function render(ui: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  act(() => {
+    root.render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  });
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function getInput(container: HTMLElement, label: string): HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {
+  const labels = Array.from(container.querySelectorAll("label"));
+  for (const lbl of labels) {
+    if (lbl.textContent?.includes(label)) {
+      const input = lbl.querySelector("input, textarea, select");
+      if (input) return input as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+    }
+  }
+  throw new Error(`No input found under label containing "${label}"`);
+}
+
+function makeHeartbeat(over: Partial<Worker> = {}): Worker {
+  return {
+    id: "support-triage-bot",
+    name: "Support Triage Bot",
+    pool: "support-llm",
+    capabilities: [],
+    status: "online",
+    activeJobs: 0,
+    capacity: 4,
+    type: "llm",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mutationState.mutate = vi.fn();
+  mutationState.isPending = false;
+  mutationState.isError = false;
+  mutationState.error = null;
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("AgentIdentityCreateForm", () => {
+  it("pre-fills name and pool from the worker heartbeat", () => {
+    const { container, cleanup } = render(
+      <AgentIdentityCreateForm
+        agentId="support-triage-bot"
+        heartbeat={makeHeartbeat()}
+        defaultOwner="alice"
+      />,
+    );
+    try {
+      const name = getInput(container, "Display name") as HTMLInputElement;
+      const owner = getInput(container, "Owner") as HTMLInputElement;
+      expect(name.value).toBe("Support Triage Bot");
+      expect(owner.value).toBe("alice");
+      // Pool surfaced as a pre-fill hint so the operator knows what's
+      // being attached to the identity.
+      expect(container.textContent).toContain("allowed_pools=[support-llm]");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("falls back to a deterministic prettifier when no heartbeat is available", () => {
+    const { container, cleanup } = render(
+      <AgentIdentityCreateForm agentId="support-triage-bot" />,
+    );
+    try {
+      const name = getInput(container, "Display name") as HTMLInputElement;
+      // "support-triage-bot" -> "Support Triage Bot"
+      expect(name.value).toBe("Support Triage Bot");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("submits the mutation with the edited body", () => {
+    const { container, cleanup } = render(
+      <AgentIdentityCreateForm
+        agentId="bot"
+        // heartbeat WITHOUT a display name forces the prettify(agentId)
+        // fallback — useful so the test asserts the prettifier output too.
+        heartbeat={makeHeartbeat({ id: "bot", name: "", pool: "p" })}
+        defaultOwner="alice"
+      />,
+    );
+    try {
+      // Operator edits the risk tier before saving.
+      const tier = getInput(container, "Risk tier") as unknown as HTMLSelectElement;
+      act(() => {
+        tier.value = "high";
+        tier.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      const form = container.querySelector("form")!;
+      act(() => {
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      });
+      expect(mutationState.mutate).toHaveBeenCalledTimes(1);
+      const [body] = mutationState.mutate.mock.calls[0];
+      expect(body.name).toBe("Bot");
+      expect(body.owner).toBe("alice");
+      expect(body.risk_tier).toBe("high");
+      expect(body.allowed_pools).toEqual(["p"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("surfaces mutation errors above the submit button", () => {
+    mutationState.isError = true;
+    mutationState.error = new Error("agent identity already exists");
+    const { container, cleanup } = render(
+      <AgentIdentityCreateForm agentId="bot" defaultOwner="alice" />,
+    );
+    try {
+      expect(container.textContent).toContain("agent identity already exists");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("disables the submit button while the mutation is in flight", () => {
+    mutationState.isPending = true;
+    const { container, cleanup } = render(
+      <AgentIdentityCreateForm agentId="bot" defaultOwner="alice" />,
+    );
+    try {
+      const submit = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.getAttribute("type") === "submit",
+      );
+      expect(submit).not.toBeNull();
+      expect(submit?.disabled).toBe(true);
+      expect(submit?.textContent).toContain("Creating");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/dashboard/src/components/agents/AgentIdentityCreateForm.test.tsx
+++ b/dashboard/src/components/agents/AgentIdentityCreateForm.test.tsx
@@ -147,6 +147,9 @@ describe("AgentIdentityCreateForm", () => {
       });
       expect(mutationState.mutate).toHaveBeenCalledTimes(1);
       const [body] = mutationState.mutate.mock.calls[0];
+      // agent_id must link the identity to this worker, else the panel never
+      // resolves and audit attribution stays on the raw id (#314 regression).
+      expect(body.agent_id).toBe("bot");
       expect(body.name).toBe("Bot");
       expect(body.owner).toBe("alice");
       expect(body.risk_tier).toBe("high");

--- a/dashboard/src/components/agents/AgentIdentityCreateForm.test.tsx
+++ b/dashboard/src/components/agents/AgentIdentityCreateForm.test.tsx
@@ -11,6 +11,7 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Worker } from "@/api/types";
+import { renderWithProviders } from "@/test-utils/render";
 import AgentIdentityCreateForm from "./AgentIdentityCreateForm";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -90,6 +91,20 @@ beforeEach(() => {
 /* ------------------------------------------------------------------ */
 
 describe("AgentIdentityCreateForm", () => {
+  // Accessibility gate for this new customer-visible surface: zero WCAG 2
+  // A/AA violations. Uses the shared renderWithProviders + runAxe per the
+  // dashboard testing guidelines (CodeRabbit #314 review).
+  it("has no WCAG 2 A/AA violations", async () => {
+    await renderWithProviders(
+      <AgentIdentityCreateForm
+        agentId="support-triage-bot"
+        heartbeat={makeHeartbeat()}
+        defaultOwner="alice"
+      />,
+      { runAxe: true },
+    );
+  });
+
   it("pre-fills name and pool from the worker heartbeat", () => {
     const { container, cleanup } = render(
       <AgentIdentityCreateForm

--- a/dashboard/src/components/agents/AgentIdentityCreateForm.tsx
+++ b/dashboard/src/components/agents/AgentIdentityCreateForm.tsx
@@ -1,0 +1,175 @@
+/*
+ * AgentIdentityCreateForm — inline form rendered inside the AgentIdentityPanel's
+ * empty state for a worker that's heartbeating but has no Agent Identity yet.
+ *
+ * Context (GitHub #314): the panel used to show "no identity" with no call to
+ * action. Operators had to leave the page, find the /agents catalog, and create
+ * one manually — meanwhile every audit row for the worker fell back to the raw
+ * agent_id instead of a human-readable agent_label. This form pre-fills from
+ * the worker's latest heartbeat so the common case is one button + Save.
+ */
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/Button";
+import type { Worker } from "@/api/types";
+import { useCreateAgentIdentity, type CreateAgentIdentityBody } from "@/hooks/useAgentIdentities";
+
+interface AgentIdentityCreateFormProps {
+  /** The agent_id we're registering — comes from the URL / heartbeat record. */
+  agentId: string;
+  /** Latest heartbeat snapshot if the worker is online; used for pre-fill. */
+  heartbeat?: Worker;
+  /** Default owner for the form — usually the logged-in operator's principalId. */
+  defaultOwner?: string;
+  /** Called when the create succeeds; the panel reacts by re-fetching. */
+  onCreated?: () => void;
+  /** Optional cancel handler to collapse the form back to the empty-state CTA. */
+  onCancel?: () => void;
+}
+
+/** Build a sensible initial body from heartbeat data. Falls back gracefully
+ *  when fields are missing — the user can edit anything before submit. */
+function initialBody(
+  agentId: string,
+  heartbeat: Worker | undefined,
+  defaultOwner: string | undefined,
+): CreateAgentIdentityBody {
+  const name = heartbeat?.name?.trim() || prettify(agentId);
+  return {
+    name,
+    owner: defaultOwner?.trim() || "",
+    risk_tier: "low",
+    description: heartbeat?.type
+      ? `Auto-registered from worker heartbeat (type=${heartbeat.type}, pool=${heartbeat.pool || "?"})`
+      : "Auto-registered from worker heartbeat.",
+    allowed_topics: [], // server-side: rules govern routing; leave empty by default
+    allowed_pools: heartbeat?.pool ? [heartbeat.pool] : [],
+    data_classifications: ["internal"],
+  };
+}
+
+/** "support-triage-bot" → "Support Triage Bot" — a stable, deterministic prettifier
+ *  for the common case where worker_id is the only thing we have. */
+function prettify(id: string): string {
+  return id
+    .split(/[-_.]/g)
+    .filter(Boolean)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join(" ");
+}
+
+export default function AgentIdentityCreateForm({
+  agentId,
+  heartbeat,
+  defaultOwner,
+  onCreated,
+  onCancel,
+}: AgentIdentityCreateFormProps) {
+  const [body, setBody] = useState<CreateAgentIdentityBody>(
+    () => initialBody(agentId, heartbeat, defaultOwner),
+  );
+  const mutation = useCreateAgentIdentity();
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (mutation.isPending) return;
+    mutation.mutate(body, {
+      onSuccess: () => onCreated?.(),
+    });
+  }
+
+  function update<K extends keyof CreateAgentIdentityBody>(
+    key: K,
+    value: CreateAgentIdentityBody[K],
+  ) {
+    setBody((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 text-left max-w-xl mx-auto">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="block">
+          <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+            Display name
+          </span>
+          <input
+            required
+            value={body.name}
+            onChange={(e) => update("name", e.target.value)}
+            placeholder="e.g. Support Triage Bot"
+            className="mt-1 w-full rounded-lg border border-border bg-surface-0 px-3 py-2 text-sm font-mono text-foreground focus:outline-none focus:ring-2 focus:ring-cordum"
+          />
+        </label>
+        <label className="block">
+          <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+            Owner
+          </span>
+          <input
+            required
+            value={body.owner}
+            onChange={(e) => update("owner", e.target.value)}
+            placeholder="operator id"
+            className="mt-1 w-full rounded-lg border border-border bg-surface-0 px-3 py-2 text-sm font-mono text-foreground focus:outline-none focus:ring-2 focus:ring-cordum"
+          />
+        </label>
+        <label className="block">
+          <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+            Risk tier
+          </span>
+          <select
+            value={body.risk_tier}
+            onChange={(e) => update("risk_tier", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-border bg-surface-0 px-3 py-2 text-sm font-mono text-foreground focus:outline-none focus:ring-2 focus:ring-cordum"
+          >
+            <option value="low">low</option>
+            <option value="medium">medium</option>
+            <option value="high">high</option>
+            <option value="critical">critical</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+            Team (optional)
+          </span>
+          <input
+            value={body.team ?? ""}
+            onChange={(e) => update("team", e.target.value || undefined)}
+            placeholder="e.g. platform-ops"
+            className="mt-1 w-full rounded-lg border border-border bg-surface-0 px-3 py-2 text-sm font-mono text-foreground focus:outline-none focus:ring-2 focus:ring-cordum"
+          />
+        </label>
+      </div>
+      <label className="block">
+        <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+          Description
+        </span>
+        <textarea
+          rows={2}
+          value={body.description ?? ""}
+          onChange={(e) => update("description", e.target.value || undefined)}
+          className="mt-1 w-full rounded-lg border border-border bg-surface-0 px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-cordum"
+        />
+      </label>
+      {heartbeat?.pool && (
+        <div className="text-xs text-muted-foreground">
+          Pre-filled <span className="font-mono">allowed_pools=[{heartbeat.pool}]</span> from heartbeat.
+          Edit via the catalog after creation if you need finer scope.
+        </div>
+      )}
+      {mutation.isError && (
+        <div className="text-xs text-destructive border border-destructive/30 bg-destructive/10 rounded-lg px-3 py-2">
+          {mutation.error?.message ?? "Failed to create agent identity."}
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <Button type="submit" variant="default" size="sm" disabled={mutation.isPending}>
+          {mutation.isPending ? "Creating…" : "Create identity"}
+        </Button>
+        {onCancel && (
+          <Button type="button" variant="ghost" size="sm" onClick={onCancel} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/dashboard/src/components/agents/AgentIdentityCreateForm.tsx
+++ b/dashboard/src/components/agents/AgentIdentityCreateForm.tsx
@@ -35,6 +35,9 @@ function initialBody(
 ): CreateAgentIdentityBody {
   const name = heartbeat?.name?.trim() || prettify(agentId);
   return {
+    // agent_id links the new identity to this heartbeating worker so the
+    // panel resolves it and audit rows stop falling back to the raw id (#314).
+    agent_id: agentId,
     name,
     owner: defaultOwner?.trim() || "",
     risk_tier: "low",

--- a/dashboard/src/components/agents/AgentIdentityPanel.tsx
+++ b/dashboard/src/components/agents/AgentIdentityPanel.tsx
@@ -4,17 +4,22 @@
  * Was a standalone route at /agents/identity/:id until the v2.5 IA cut
  * folded it into the agent detail surface.
  */
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { SkeletonCard } from "@/components/ui/Skeleton";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Button } from "@/components/ui/Button";
 import {
   Shield, Fingerprint, Tag, Clock, AlertTriangle, Activity, FileQuestion,
 } from "lucide-react";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import { ApiError } from "@/api/client";
 import { useAgentIdentity, useAgentStats } from "@/hooks/useAgentIdentities";
+import { useWorker } from "@/hooks/useWorkers";
+import { useConfigStore } from "@/state/config";
+import AgentIdentityCreateForm from "./AgentIdentityCreateForm";
 
 const riskTierConfig: Record<string, { color: string; bg: string; border: string }> = {
   low:      { color: "text-emerald-400", bg: "bg-emerald-500/10", border: "border-emerald-500/30" },
@@ -53,15 +58,52 @@ interface AgentIdentityPanelProps {
 export default function AgentIdentityPanel({ agentId }: AgentIdentityPanelProps) {
   const { data: agent, isLoading, isError, error } = useAgentIdentity(agentId);
   const { data: stats, isLoading: statsLoading, isError: statsError } = useAgentStats(agentId);
+  // Heartbeat data for the empty-state pre-fill. Loaded eagerly so the form
+  // can pop instantly when the operator clicks "Create identity" — no extra
+  // round trip. Falls back gracefully if the worker isn't heartbeating.
+  const { data: heartbeat } = useWorker(agentId);
+  const defaultOwner = useConfigStore((s) => s.principalId);
+  const [showCreateForm, setShowCreateForm] = useState(false);
 
   if (isError) {
     if (error instanceof ApiError && error.status === 404) {
+      // Empty state with an actionable CTA. Previously this was a text-only
+      // placeholder pointing operators at "the /agents catalog or cordumctl"
+      // — they'd leave the page, lose context, and meanwhile every audit
+      // row for this worker fell back to the raw agent_id (issue #314).
+      // Now: explanation + a button that pre-fills from the worker's
+      // heartbeat (when available) and POSTs in place.
       return (
-        <EmptyState
-          icon={<FileQuestion className="w-6 h-6" />}
-          title="No identity profile"
-          description="This worker is online but does not have a registered Agent Identity. Identities are created via the /agents catalog or the cordumctl agents identity create CLI."
-        />
+        <div className="space-y-4">
+          <EmptyState
+            icon={<FileQuestion className="w-6 h-6" />}
+            title="No identity registered for this agent"
+            description="This worker is reporting heartbeats but has no Agent Identity record. Audit rows for its jobs will show the raw agent_id as the label instead of a human-readable agent name. Register an identity below to fix the attribution surface."
+            action={
+              !showCreateForm ? (
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={() => setShowCreateForm(true)}
+                  data-testid="agent-identity-create-button"
+                >
+                  Create identity
+                </Button>
+              ) : undefined
+            }
+          />
+          {showCreateForm && (
+            <div className="instrument-card">
+              <AgentIdentityCreateForm
+                agentId={agentId}
+                heartbeat={heartbeat ?? undefined}
+                defaultOwner={defaultOwner || undefined}
+                onCreated={() => setShowCreateForm(false)}
+                onCancel={() => setShowCreateForm(false)}
+              />
+            </div>
+          )}
+        </div>
       );
     }
     return <ErrorBanner message={error instanceof Error ? error.message : "Failed to load agent identity"} />;

--- a/dashboard/src/hooks/useAgentIdentities.ts
+++ b/dashboard/src/hooks/useAgentIdentities.ts
@@ -13,6 +13,12 @@ export interface CreateAgentIdentityBody {
   name: string;
   owner: string;
   risk_tier: string;
+  /**
+   * The worker/agent id this identity represents. When set, the server links
+   * worker_id -> identity so audit + the detail panel resolve the new record
+   * by the worker's id (GitHub issue #314). Omitted for catalog-only creates.
+   */
+  agent_id?: string;
   description?: string;
   team?: string;
   allowed_topics?: string[];
@@ -76,17 +82,22 @@ export function useAgentStats(id: string | undefined) {
  * worker so its audit rows surface `agent_label` instead of falling back
  * to the raw `agent_id` (GitHub issue #314).
  *
- * On success, invalidates the per-id `agent-identity` query so the panel
- * re-fetches and renders the populated identity; also invalidates the
- * list so the /agents catalog reflects the new record.
+ * On success, invalidates the whole `agent-identity` query family so the
+ * panel re-fetches and renders the populated identity. We invalidate the
+ * family (not just `["agent-identity", created.id]`) because the server
+ * assigns the identity its own id while the panel is keyed by the worker's
+ * id — the two differ, so a key-specific invalidation would miss the panel
+ * (the worker->identity link is what makes the panel's worker-id lookup
+ * resolve, see #314). Also invalidates the list so the /agents catalog
+ * reflects the new record.
  */
 export function useCreateAgentIdentity() {
   const qc = useQueryClient();
   return useMutation<AgentIdentity, Error, CreateAgentIdentityBody>({
     mutationFn: (body) => post<AgentIdentity>("/agents", body),
-    onSuccess: (created) => {
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agent-identities"] });
-      qc.invalidateQueries({ queryKey: ["agent-identity", created.id] });
+      qc.invalidateQueries({ queryKey: ["agent-identity"] });
     },
   });
 }

--- a/dashboard/src/hooks/useAgentIdentities.ts
+++ b/dashboard/src/hooks/useAgentIdentities.ts
@@ -1,6 +1,29 @@
-import { useQuery } from "@tanstack/react-query";
-import { get } from "../api/client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { get, post } from "../api/client";
 import type { AgentIdentity, AgentStats } from "../api/types";
+
+/**
+ * Body for POST /api/v1/agents — mirrors `createAgentRequest` in
+ * core/controlplane/gateway/handlers_agents.go. `name`, `owner`, and
+ * `risk_tier` are required by the server; the rest are optional and may
+ * be pre-populated from the worker's heartbeat when registering an
+ * identity for an already-online worker (see GitHub issue #314).
+ */
+export interface CreateAgentIdentityBody {
+  name: string;
+  owner: string;
+  risk_tier: string;
+  description?: string;
+  team?: string;
+  allowed_topics?: string[];
+  allowed_pools?: string[];
+  allowed_servers?: string[];
+  allowed_tools?: string[];
+  allowed_resources?: string[];
+  entitlements?: string[];
+  preapproved_mutating_tools?: string[];
+  data_classifications?: string[];
+}
 
 interface AgentIdentitiesResponse {
   items: AgentIdentity[];
@@ -44,5 +67,26 @@ export function useAgentStats(id: string | undefined) {
     queryFn: () => get<AgentStats>(`/agents/${id}/stats`),
     enabled: !!id,
     refetchInterval: 60_000,
+  });
+}
+
+/**
+ * Create an Agent Identity record. Used by the AgentIdentityPanel's
+ * empty-state "Create identity" affordance to register a heartbeating
+ * worker so its audit rows surface `agent_label` instead of falling back
+ * to the raw `agent_id` (GitHub issue #314).
+ *
+ * On success, invalidates the per-id `agent-identity` query so the panel
+ * re-fetches and renders the populated identity; also invalidates the
+ * list so the /agents catalog reflects the new record.
+ */
+export function useCreateAgentIdentity() {
+  const qc = useQueryClient();
+  return useMutation<AgentIdentity, Error, CreateAgentIdentityBody>({
+    mutationFn: (body) => post<AgentIdentity>("/agents", body),
+    onSuccess: (created) => {
+      qc.invalidateQueries({ queryKey: ["agent-identities"] });
+      qc.invalidateQueries({ queryKey: ["agent-identity", created.id] });
+    },
   });
 }

--- a/dashboard/src/pages/AgentIdentityTab.test.tsx
+++ b/dashboard/src/pages/AgentIdentityTab.test.tsx
@@ -48,11 +48,25 @@ const { hookState } = vi.hoisted(() => ({
 /* Mocks                                                               */
 /* ------------------------------------------------------------------ */
 
-vi.mock("@/hooks/useAgentIdentities", () => ({
-  useAgentIdentities: () => hookState.identities,
-  useAgentIdentity: () => hookState.identity,
-  useAgentStats: () => hookState.stats,
-}));
+vi.mock("@/hooks/useAgentIdentities", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/useAgentIdentities")>(
+    "@/hooks/useAgentIdentities",
+  );
+  return {
+    ...actual,
+    useAgentIdentities: () => hookState.identities,
+    useAgentIdentity: () => hookState.identity,
+    useAgentStats: () => hookState.stats,
+    // useCreateAgentIdentity (added for issue #314 empty-state CTA) is mocked
+    // as a no-op success so the form can render without a real network call.
+    useCreateAgentIdentity: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+    }),
+  };
+});
 
 vi.mock("@/hooks/useLicense", () => ({
   useLicense: () => hookState.license,
@@ -61,6 +75,16 @@ vi.mock("@/hooks/useLicense", () => ({
 
 vi.mock("@/hooks/useWorkers", () => ({
   useWorkers: () => ({ data: [], isLoading: false }),
+  // useWorker is the heartbeat fetch the AgentIdentityPanel uses to pre-fill
+  // the empty-state create form (issue #314). Default to undefined so the
+  // panel falls back to deterministic prettify(agent_id) for the name.
+  useWorker: () => ({ data: undefined, isLoading: false }),
+  useWorkerJobs: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@/state/config", () => ({
+  useConfigStore: (selector: (s: { principalId: string }) => unknown) =>
+    selector({ principalId: "test-operator" }),
 }));
 
 vi.mock("@/components/agents/WorkerDetailDrawer", () => ({
@@ -382,7 +406,12 @@ describe("AgentIdentityPanel rendered", () => {
     }
   });
 
-  it("renders EmptyState (not ErrorBanner) when useAgentIdentity returns 404", () => {
+  it("renders EmptyState with create-identity CTA (not ErrorBanner) when useAgentIdentity returns 404", () => {
+    // Issue #314 — previously this rendered a text-only placeholder pointing
+    // operators at the catalog / CLI. It now renders an actionable empty
+    // state with a "Create identity" button that pre-fills from the
+    // worker's heartbeat (the form pops inline on click; not asserted here
+    // — its behavior is covered by a focused test below).
     hookState.identity = {
       data: undefined,
       isLoading: false,
@@ -391,8 +420,14 @@ describe("AgentIdentityPanel rendered", () => {
     };
     const { container, cleanup } = renderIdentityPanel();
     try {
-      expect(container.textContent).toContain("No identity profile");
-      expect(container.textContent).toContain("cordumctl agents identity create");
+      expect(container.textContent).toContain("No identity registered for this agent");
+      // Must explain the operational consequence (raw agent_id in audit).
+      expect(container.textContent).toContain("agent_id");
+      // Must offer the in-place CTA.
+      const cta = container.querySelector('[data-testid="agent-identity-create-button"]');
+      expect(cta).not.toBeNull();
+      expect(cta?.textContent).toContain("Create identity");
+      // Must NOT degrade into the generic error banner.
       expect(container.textContent).not.toContain("Failed to load agent identity");
     } finally {
       cleanup();


### PR DESCRIPTION
Fixes #314.

## Before / After

**Before** — the Identity tab for `/agents/<id>` showed a text-only placeholder when no `AgentIdentity` was registered for a heartbeating worker. The recommended path was "use the catalog or cordumctl agents identity create" — most operators wouldn't find it, and meanwhile every audit row for the worker fell back to the raw `agent_id` (e.g. `support-triage-bot`) instead of the human-readable `agent_label` that #301's humanization layer is designed to populate.

**After** — same tab, same 404 path, but the empty state is actionable:

1. **Explanation** that names the operational consequence (raw `agent_id` in audit rows), not just "no profile."
2. **`Create identity`** button → expands an inline form pre-filled from the worker's heartbeat (`useWorker(agentId)`): display name (heartbeat `.name` or `prettify(agent_id)` fallback), allowed pools, description.
3. Operator can edit any field; submit triggers `useCreateAgentIdentity` → `POST /api/v1/agents`.
4. On success the `agent-identity` query is invalidated and the panel re-fetches, so the form is replaced by the populated identity profile in the same tab.

## What's in this PR

| File | Purpose |
|---|---|
| `dashboard/src/hooks/useAgentIdentities.ts` | New `useCreateAgentIdentity` React Query mutation hook + typed `CreateAgentIdentityBody` matching the Go `createAgentRequest` struct. |
| `dashboard/src/components/agents/AgentIdentityCreateForm.tsx` | Self-contained inline form (no modal infrastructure). Pre-fills from heartbeat; surfaces mutation errors above the submit; disables submit while pending. |
| `dashboard/src/components/agents/AgentIdentityPanel.tsx` | Replaces the placeholder `<EmptyState>` with the actionable variant + toggle into the form. Pulls `useWorker(agentId)` for heartbeat data and `useConfigStore` for `principalId` (default owner). |
| `dashboard/src/components/agents/AgentIdentityCreateForm.test.tsx` | 5 focused tests: pre-fill, prettifier fallback, mutation invocation with edited body, error surface, disabled-while-pending. |
| `dashboard/src/pages/AgentIdentityTab.test.tsx` | Existing 404-case test updated to assert the new title, the `agent_id`-consequence text, and the `[data-testid="agent-identity-create-button"]` CTA. Mock setup gains `useWorker`, `useConfigStore`, `useCreateAgentIdentity` so the panel can render in test isolation. |

## Tests

`pnpm exec vitest run src/components/agents/AgentIdentityCreateForm.test.tsx src/pages/AgentIdentityTab.test.tsx src/hooks/useAgentIdentities.test.ts` — **33 passed / 33 total**.
`pnpm exec tsc -p tsconfig.json --noEmit` — clean.

## Out of scope (deferred)

- Per-tenant identity-creation defaults (would need a settings page).
- Workflow that auto-creates an identity record on first heartbeat (server-side, separate from this dashboard fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline "Create identity" form when no identity exists; pre-fills name, owner, risk tier and pools from worker heartbeat.
  * Server accepts registering an identity for an existing worker and can resolve identities by worker ID.

* **Bug Fixes**
  * Empty-state updated to an actionable view with a Create button.
  * Creation conflicts surface a clear client-facing error code.

* **Tests**
  * Added tests for create flow, pre-fill/pending/error UI, and worker-linking behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->