### PR TITLE
fix(edge): hook fail-closes on degraded PreToolUse under enforce mode

### DIFF
--- a/core/edge/agentd/evaluator.go
+++ b/core/edge/agentd/evaluator.go
@@ -268,7 +268,17 @@ func (e *Evaluator) degradedDecision(req claude.AgentdRequest, evalReq EvaluateR
 		GatewayErrorCategory: category,
 		ApprovalRef:          "",
 	})
-	decision := claude.AgentdDecision{Decision: outcome.Decision}
+	decision := claude.AgentdDecision{
+		Decision: outcome.Decision,
+		// Surface the degraded flag on the wire to the hook. Previously this
+		// field wasn't on the AgentdDecision struct at all — the hook lost
+		// the signal that a fail-mode response was synthesized (vs. a real
+		// gateway decision), and `hookOutputForRun` couldn't fail-close
+		// on the degraded path. With the struct now carrying Degraded
+		// (claude/agentd_client.go), the hook can synthesize a deny on
+		// PreToolUse under enforce / enterprise-strict modes.
+		Degraded: true,
+	}
 	if outcome.TerminalCopy != "" {
 		decision.Reason = boundDecisionText(outcome.TerminalCopy)
 	} else if outcome.Decision != claude.DecisionAllow {

--- a/core/edge/claude/agentd_client.go
+++ b/core/edge/claude/agentd_client.go
@@ -77,6 +77,15 @@ type AgentdDecision struct {
 	ApprovalRef       string         `json:"approval_ref,omitempty"`
 	AdditionalContext string         `json:"additional_context,omitempty"`
 	UpdatedInput      map[string]any `json:"updated_input,omitempty"`
+	// Degraded mirrors agentd's EvaluateResponse.Degraded (set when the
+	// gateway evaluation could not complete in time and the agentd had to
+	// answer the hook on degraded path). The hook used to drop this signal
+	// because the struct didn't declare the field — every degraded response
+	// looked like a regular allow/RECORDED at the output mapper, and risky
+	// PreToolUse actions slipped through under policy_mode=enforce. See
+	// GitHub issue (filed alongside this fix) and runner.hookOutputForRun
+	// for the fail-closed treatment.
+	Degraded bool `json:"degraded,omitempty"`
 }
 
 type HTTPAgentdClient struct {

--- a/core/edge/claude/agentd_client_test.go
+++ b/core/edge/claude/agentd_client_test.go
@@ -118,7 +118,7 @@ func TestRunLegacyNonceURLWithoutEnvFailsClosedClearly(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code=%d stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum Edge unavailable; blocking by fail-closed policy","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
 	if !strings.Contains(stderr, "CORDUM_AGENTD_HOOK_NONCE") || !strings.Contains(stderr, "not embedded in CORDUM_AGENTD_URL") {
 		t.Fatalf("stderr missing clear nonce migration error: %q", stderr)
 	}

--- a/core/edge/claude/fail_modes_test.go
+++ b/core/edge/claude/fail_modes_test.go
@@ -44,7 +44,7 @@ func TestRunLocalDevEnforceDeniesRiskyPreToolUseWhenAgentdUnavailable(t *testing
 	if code != 0 {
 		t.Fatalf("exit code=%d stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge local enforcer unavailable; blocking risky action"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum Edge local enforcer unavailable; blocking risky action","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge local enforcer unavailable; blocking risky action"}}`)
 	if strings.Contains(stderr, "rm -rf") {
 		t.Fatalf("stderr leaked raw command: %q", stderr)
 	}
@@ -67,7 +67,7 @@ func TestRunEnterpriseStrictDeniesMalformedAgentdResponse(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code=%d stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum Edge unavailable; blocking by fail-closed policy","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
 	if !strings.Contains(stderr, "agentd_unavailable") {
 		t.Fatalf("stderr missing malformed-response warning: %q", stderr)
 	}

--- a/core/edge/claude/fail_modes_test.go
+++ b/core/edge/claude/fail_modes_test.go
@@ -72,3 +72,120 @@ func TestRunEnterpriseStrictDeniesMalformedAgentdResponse(t *testing.T) {
 		t.Fatalf("stderr missing malformed-response warning: %q", stderr)
 	}
 }
+
+// =====================================================================
+// Regression: Edge end-to-end testing on 2026-05-28 uncovered that when
+// agentd returned a *degraded* PreToolUse response (the gateway couldn't
+// complete evaluation in the hook's 5s budget — agentd answered with
+// `decision=RECORDED, degraded=true`), the hook dropped the degraded
+// signal entirely (no field on AgentdDecision) and preToolUseOutput's
+// `default:` arm returned an empty output → Claude proceeded with the
+// risky action. Under `policy_mode=enforce` that's a silent fail-OPEN
+// on every risky tool call whenever the safety kernel is briefly slow.
+//
+// Fix:
+//   1. AgentdDecision now carries the Degraded field (matches the JSON
+//      payload agentd has been emitting all along).
+//   2. hookOutputForRun synthesizes a deny in enforce / enterprise-strict
+//      modes when the response is flagged degraded, naming the mode in
+//      the reason so the audit trail and the model both see why.
+// =====================================================================
+
+func TestRunEnforceDeniesDegradedPreToolUse(t *testing.T) {
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		// What real agentd sends when the gateway evaluation didn't
+		// complete in time. Decision is a placeholder; Degraded is true.
+		return AgentdDecision{
+			Decision: Decision("recorded"),
+			Reason:   "evaluation pending",
+			Degraded: true,
+		}, nil
+	}}
+	code, stdout, stderr := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/x.txt","new_string":"hi"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_POLICY_MODE": "enforce"},
+	})
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q", code, stderr)
+	}
+	// Must be a deny output that names the degraded condition AND the
+	// policy mode that caused fail-close. We assert substrings rather
+	// than exact JSON because the synthesized reason concatenates strings.
+	if stdout == "" {
+		t.Fatalf("expected non-empty hook output, got empty (would silently allow)")
+	}
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Errorf("output should deny, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "degraded") {
+		t.Errorf("reason should mention degraded state; got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "enforce") {
+		t.Errorf("reason should name the policy_mode that forced fail-close; got: %s", stdout)
+	}
+}
+
+func TestRunEnterpriseStrictDeniesDegradedPreToolUse(t *testing.T) {
+	// Same fail-closed treatment when CORDUM_EDGE_MODE=enterprise-strict.
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{Decision: Decision("recorded"), Degraded: true}, nil
+	}}
+	code, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/x.txt","new_string":"hi"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_MODE": "enterprise-strict"},
+	})
+	if code != 0 {
+		t.Fatalf("exit code=%d", code)
+	}
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Errorf("enterprise-strict must deny on degraded PreToolUse; got: %s", stdout)
+	}
+}
+
+func TestRunObserveModeAllowsDegradedPreToolUse(t *testing.T) {
+	// Observe mode is the explicit opposite: we record but never enforce.
+	// A degraded response must still pass through to Claude as a no-op
+	// — otherwise we'd be silently denying in a mode that's supposed to
+	// be observability-only.
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{Decision: Decision("recorded"), Degraded: true}, nil
+	}}
+	code, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/x.txt","new_string":"hi"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_POLICY_MODE": "observe"},
+	})
+	if code != 0 {
+		t.Fatalf("exit code=%d", code)
+	}
+	if stdout != "" {
+		t.Errorf("observe mode should NOT synthesize a deny on degraded; got: %s", stdout)
+	}
+}
+
+func TestRunEnforceAllowsNonDegradedRecordedResponses(t *testing.T) {
+	// Belt-and-braces: a RECORDED decision WITHOUT the degraded flag means
+	// the evaluation completed and the policy explicitly chose to record
+	// (e.g. user prompt submit). That must still pass through cleanly —
+	// the fail-close only triggers when degraded=true.
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{Decision: Decision("recorded"), Degraded: false}, nil
+	}}
+	code, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/x.txt","new_string":"hi"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_POLICY_MODE": "enforce"},
+	})
+	if code != 0 {
+		t.Fatalf("exit code=%d", code)
+	}
+	if stdout != "" {
+		t.Errorf("RECORDED without degraded should be a no-op pass-through; got: %s", stdout)
+	}
+}

--- a/core/edge/claude/fail_modes_test.go
+++ b/core/edge/claude/fail_modes_test.go
@@ -189,3 +189,129 @@ func TestRunEnforceAllowsNonDegradedRecordedResponses(t *testing.T) {
 		t.Errorf("RECORDED without degraded should be a no-op pass-through; got: %s", stdout)
 	}
 }
+
+// =====================================================================
+// Regression for the deeper enforce-mode gap end-to-end testing on
+// 2026-05-29 uncovered: when agentd was unreachable (Post EOF — agentd
+// took longer than the hook's postBudget waiting for an approval that
+// never came), the hook fell into handleAgentdError. failClosed(opts)
+// returned false because it only matched enterprise-strict, not enforce.
+// localDevEnforce(opts) returned false because mode was "enforce", not
+// "local-dev-enforce". So the hook hit the catch-all "return 0" with 0
+// bytes of stdout — a silent allow on every risky tool call in enforce
+// mode whenever agentd was briefly slow.
+//
+// The fix wires enforce into the same fail-closed-on-risky branch
+// local-dev-enforce already used, AND extends riskyPreToolUse to cover
+// the file-mutation tools (Write / Edit / MultiEdit / NotebookEdit) that
+// the demo policy pack's require-approval-for-edits rule was already
+// trying to gate.
+// =====================================================================
+
+func TestRunEnforceModeDeniesWritePreToolUseWhenAgentdUnavailable(t *testing.T) {
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{}, errors.New("agentd connection refused")
+	}}
+	code, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/x","content":"hi"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_MODE": "enforce"},
+	})
+	if code != 0 {
+		t.Fatalf("exit code=%d", code)
+	}
+	if stdout == "" {
+		t.Fatal("enforce mode + Write + agentd unavailable must NOT silently allow")
+	}
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Errorf("expected deny output; got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "blocking risky action") {
+		t.Errorf("Write is a file-mutation tool and must be classified risky; got: %s", stdout)
+	}
+}
+
+func TestRunEnforceModeDeniesEditPreToolUseWhenAgentdUnavailable(t *testing.T) {
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{}, errors.New("agentd stopped")
+	}}
+	_, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/tmp/x","old_string":"a","new_string":"b"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_POLICY_MODE": "enforce"},
+	})
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) || !strings.Contains(stdout, "risky action") {
+		t.Errorf("Edit under enforce + agentd-down must deny + classify risky; got: %s", stdout)
+	}
+}
+
+func TestRunEnforceModeDeniesMultiEditPreToolUseWhenAgentdUnavailable(t *testing.T) {
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{}, errors.New("agentd stopped")
+	}}
+	_, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"MultiEdit","tool_input":{"file_path":"/tmp/x"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_MODE": "enforce"},
+	})
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Errorf("MultiEdit must be denied under enforce + agentd-down; got: %s", stdout)
+	}
+}
+
+func TestRunEnforceModeDeniesNotebookEditPreToolUseWhenAgentdUnavailable(t *testing.T) {
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{}, errors.New("agentd stopped")
+	}}
+	_, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"NotebookEdit","tool_input":{"notebook_path":"/tmp/n.ipynb"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_MODE": "enforce"},
+	})
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Errorf("NotebookEdit must be denied under enforce + agentd-down; got: %s", stdout)
+	}
+}
+
+func TestRunObserveModeAllowsWritePreToolUseWhenAgentdUnavailable(t *testing.T) {
+	// Belt-and-braces: observe mode must NOT be wrapped into the new
+	// enforce branch — operators who chose observability-only deployments
+	// rely on it never synthesizing a deny.
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{}, errors.New("agentd connection refused")
+	}}
+	code, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/x","content":"hi"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_MODE": "observe"},
+	})
+	if code != 0 {
+		t.Fatalf("exit code=%d", code)
+	}
+	if stdout != "" {
+		t.Errorf("observe mode must continue passing through degraded; got: %s", stdout)
+	}
+}
+
+func TestRunEnforceModeDeniesUnclassifiedPreToolUseWhenAgentdUnavailable(t *testing.T) {
+	// Tool name unknown to riskyPreToolUse (not Bash, not in
+	// fileMutationTools) — must still deny under enforce because we
+	// can't classify, and enforce "degrades closed for unknown actions".
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{}, errors.New("agentd unavailable")
+	}}
+	_, stdout, _ := runHook(t, RunOptions{
+		Args:   []string{"claude", "pre-tool-use"},
+		Stdin:  hookInput(`{"hook_event_name":"PreToolUse","tool_name":"FutureExperimentalTool","tool_input":{"x":"y"}}`),
+		Agentd: agentd,
+		Env:    map[string]string{"CORDUM_EDGE_MODE": "enforce"},
+	})
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Errorf("unknown tool under enforce + agentd-down must deny; got: %s", stdout)
+	}
+}

--- a/core/edge/claude/fail_modes_test.go
+++ b/core/edge/claude/fail_modes_test.go
@@ -315,3 +315,89 @@ func TestRunEnforceModeDeniesUnclassifiedPreToolUseWhenAgentdUnavailable(t *test
 		t.Errorf("unknown tool under enforce + agentd-down must deny; got: %s", stdout)
 	}
 }
+
+// CodeRabbit on #319 caught that the observability recording fired
+// BEFORE the degraded+enforce synthesis path, so a fail-closed PreToolUse
+// showed up in metrics as the original (non-deny) decision and with
+// degraded/failClosed flags both false. This regression asserts that the
+// recorder now sees DecisionDeny + degraded=true + failClosed=true with
+// the canonical "degraded_policy_enforced" reason code, matching the
+// hook's actual emitted output.
+func TestRunEnforceDegradedRecordsDenyObservability(t *testing.T) {
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{
+			Decision: Decision("recorded"),
+			Reason:   "evaluation pending",
+			Degraded: true,
+		}, nil
+	}}
+	recorder := &hookRecordingRecorder{}
+	code, stdout, _ := runHook(t, RunOptions{
+		Args:     []string{"claude", "pre-tool-use"},
+		Stdin:    hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/x","content":"hi"}}`),
+		Agentd:   agentd,
+		Recorder: recorder,
+		Env:      map[string]string{"CORDUM_EDGE_POLICY_MODE": "enforce"},
+	})
+	if code != 0 {
+		t.Fatalf("exit=%d", code)
+	}
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Fatalf("expected deny output; got: %s", stdout)
+	}
+	// 1. RecordActionDecision must reflect the SYNTHESIZED deny, not the
+	//    original RECORDED decision.
+	if len(recorder.actionDecisions) != 1 {
+		t.Fatalf("want 1 RecordActionDecision call, got %d: %#v", len(recorder.actionDecisions), recorder.actionDecisions)
+	}
+	if got := recorder.actionDecisions[0].decision; got != string(DecisionDeny) {
+		t.Errorf("RecordActionDecision.decision = %q, want %q (synthesized deny)", got, DecisionDeny)
+	}
+	if got := recorder.actionDecisions[0].mode; got != "enforce" {
+		t.Errorf("RecordActionDecision.mode = %q, want %q", got, "enforce")
+	}
+	// 2. RecordActionDenied must fire — old code never reached this
+	//    branch because effectiveDecision was the original RECORDED.
+	if len(recorder.actionDenied) != 1 {
+		t.Fatalf("want 1 RecordActionDenied call, got %d: %#v", len(recorder.actionDenied), recorder.actionDenied)
+	}
+	if got := recorder.actionDenied[0].reason; got != "degraded_policy_enforced" {
+		t.Errorf("RecordActionDenied.reason = %q, want %q", got, "degraded_policy_enforced")
+	}
+	// 3. RecordDegraded must fire with the canonical reason code so
+	//    operators can query degraded_policy_enforced specifically.
+	if len(recorder.degraded) != 1 {
+		t.Fatalf("want 1 RecordDegraded call, got %d", len(recorder.degraded))
+	}
+	if got := recorder.degraded[0].reason; got != "degraded_policy_enforced" {
+		t.Errorf("RecordDegraded.reason = %q, want %q", got, "degraded_policy_enforced")
+	}
+	// 4. RecordFailClosed must fire — the hook truly fail-closed.
+	if len(recorder.failClosed) != 1 {
+		t.Fatalf("want 1 RecordFailClosed call, got %d", len(recorder.failClosed))
+	}
+}
+
+// Symmetric guard: observe mode keeps reporting the raw decision and does
+// NOT flip degraded / failClosed flags. Without this, future refactors of
+// the synthesis branch could silently start emitting fail-closed metrics
+// for observe deployments, hurting the audit story for opt-in tiers.
+func TestRunObserveDegradedKeepsRawObservability(t *testing.T) {
+	agentd := &fakeAgentdClient{fn: func(context.Context, AgentdRequest) (AgentdDecision, error) {
+		return AgentdDecision{Decision: Decision("recorded"), Degraded: true}, nil
+	}}
+	recorder := &hookRecordingRecorder{}
+	_, _, _ = runHook(t, RunOptions{
+		Args:     []string{"claude", "pre-tool-use"},
+		Stdin:    hookInput(`{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/x","content":"hi"}}`),
+		Agentd:   agentd,
+		Recorder: recorder,
+		Env:      map[string]string{"CORDUM_EDGE_MODE": "observe"},
+	})
+	if len(recorder.actionDecisions) != 1 || recorder.actionDecisions[0].decision != "recorded" {
+		t.Errorf("observe mode must keep the raw decision; got: %#v", recorder.actionDecisions)
+	}
+	if len(recorder.failClosed) != 0 {
+		t.Errorf("observe mode must not record fail-closed; got %d calls", len(recorder.failClosed))
+	}
+}

--- a/core/edge/claude/hook_output.go
+++ b/core/edge/claude/hook_output.go
@@ -54,13 +54,30 @@ func preToolUseOutput(d AgentdDecision) ClaudeHookOutput {
 	default:
 		return ClaudeHookOutput{}
 	}
-	return ClaudeHookOutput{HookSpecificOutput: &HookSpecificOutput{
+	out := ClaudeHookOutput{HookSpecificOutput: &HookSpecificOutput{
 		HookEventName:            "PreToolUse",
 		PermissionDecision:       permission,
 		PermissionDecisionReason: reason,
 		UpdatedInput:             redactHookBoundaryMap(d.UpdatedInput),
 		AdditionalContext:        d.AdditionalContext,
 	}}
+	// Also set the top-level `decision: "block"` mirror that every other
+	// hook output function in this file already does for deny/require_approval
+	// (see userPromptSubmitOutput, postToolUseOutput, configChangeOutput).
+	// End-to-end Edge testing on 2026-05-28 showed that Claude Code v2.1.x
+	// will silently proceed with the tool call when only the inner
+	// permissionDecision is set — it treats that as a soft ask, which in
+	// non-interactive `-p` mode is effectively allow. Setting BOTH fields
+	// is the canonical "hard block" shape Claude Code respects across
+	// interactive and headless invocations. PreToolUse was the odd one
+	// out; this brings it in line with the rest of the hook events.
+	if permission == string(DecisionDeny) {
+		out.Decision = "block"
+		if out.Reason == "" {
+			out.Reason = reason
+		}
+	}
+	return out
 }
 
 func userPromptSubmitOutput(d AgentdDecision) ClaudeHookOutput {

--- a/core/edge/claude/hook_output_mapper_test.go
+++ b/core/edge/claude/hook_output_mapper_test.go
@@ -27,7 +27,7 @@ func TestMapEdgeDecisionToHookOutputPreToolUseDeny(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MapEdgeDecisionToHookOutput: %v", err)
 	}
-	assertCompactJSON(t, marshalOutput(t, out), `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Reading .env is blocked by Cordum policy"}}`)
+	assertCompactJSON(t, marshalOutput(t, out), `{"decision":"block","reason":"Reading .env is blocked by Cordum policy","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Reading .env is blocked by Cordum policy"}}`)
 }
 
 func TestMapEdgeDecisionToHookOutputPreToolUseRequireApprovalIsImmediateDenyWithApprovalRef(t *testing.T) {
@@ -39,7 +39,7 @@ func TestMapEdgeDecisionToHookOutputPreToolUseRequireApprovalIsImmediateDenyWith
 	if err != nil {
 		t.Fatalf("MapEdgeDecisionToHookOutput: %v", err)
 	}
-	assertCompactJSON(t, marshalOutput(t, out), `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Editing production deployment files requires approval; approval_ref=edge_appr_01J7QY; approve then retry the tool call"}}`)
+	assertCompactJSON(t, marshalOutput(t, out), `{"decision":"block","reason":"Editing production deployment files requires approval; approval_ref=edge_appr_01J7QY; approve then retry the tool call","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Editing production deployment files requires approval; approval_ref=edge_appr_01J7QY; approve then retry the tool call"}}`)
 }
 
 func TestMapEdgeDecisionToHookOutputPreToolUseThrottleIsDenyWithReason(t *testing.T) {

--- a/core/edge/claude/hook_output_test.go
+++ b/core/edge/claude/hook_output_test.go
@@ -12,7 +12,7 @@ func TestPreToolUseOutputOmitsEmptyOptionalFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal returned error: %v", err)
 	}
-	assertCompactJSON(t, string(data), `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"blocked"}}`)
+	assertCompactJSON(t, string(data), `{"decision":"block","reason":"blocked","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"blocked"}}`)
 }
 
 func TestRequireApprovalMapsToImmediateDenyWithApprovalRef(t *testing.T) {
@@ -21,7 +21,7 @@ func TestRequireApprovalMapsToImmediateDenyWithApprovalRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal returned error: %v", err)
 	}
-	assertCompactJSON(t, string(data), `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"approval required; approval_ref=edge_appr_123; approve then retry the tool call"}}`)
+	assertCompactJSON(t, string(data), `{"decision":"block","reason":"approval required; approval_ref=edge_appr_123; approve then retry the tool call","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"approval required; approval_ref=edge_appr_123; approve then retry the tool call"}}`)
 }
 
 func TestPreToolUseAskIncludesUpdatedInput(t *testing.T) {

--- a/core/edge/claude/mapper.go
+++ b/core/edge/claude/mapper.go
@@ -941,7 +941,18 @@ func preToolUseHookOutput(decision string, resp EdgeDecisionResponse) ClaudeHook
 		hsop.UpdatedInput = resp.UpdatedInput
 		hsop.AdditionalContext = resp.AdditionalContext
 	}
-	return ClaudeHookOutput{HookSpecificOutput: hsop}
+	out := ClaudeHookOutput{HookSpecificOutput: hsop}
+	// Mirror the top-level `decision: "block"` that every other hook event
+	// mapper in this file emits for deny outcomes (userPromptSubmitHookOutput
+	// line ~953, postToolUseHookOutput, configChangeHookOutput). Without
+	// the outer field, Claude Code v2.1.x treats the deny as a soft ask
+	// and proceeds with the tool call in non-interactive (`claude -p`)
+	// mode. PreToolUse was the only path that omitted the mirror.
+	if hsop.PermissionDecision == "deny" {
+		out.Decision = "block"
+		out.Reason = hsop.PermissionDecisionReason
+	}
+	return out
 }
 
 func userPromptSubmitHookOutput(decision string, resp EdgeDecisionResponse) ClaudeHookOutput {

--- a/core/edge/claude/runner.go
+++ b/core/edge/claude/runner.go
@@ -71,7 +71,7 @@ func Run(ctx context.Context, opts RunOptions) int {
 	}
 	// Compute the hook output once, derive the metric/audit-recorded
 	// decision from it. Previously this fired recordHookObservability with
-	// the raw `decision.Decision` BEFORE writeRunOutput synthesized a deny
+	// the raw `decision.Decision` BEFORE hookOutputForRun synthesized a deny
 	// for the degraded+enforce case — so a fail-closed PreToolUse showed
 	// up in metrics as the original `RECORDED` decision with degraded=false,
 	// even though the hook actually emitted a block. CodeRabbit on #319
@@ -108,16 +108,11 @@ func evaluateAgentdHook(ctx context.Context, agentd AgentdClient, req AgentdRequ
 	return agentd.EvaluateHook(agentdCtx, req)
 }
 
-func writeRunOutput(stderr, stdout io.Writer, eventName string, decision AgentdDecision, opts RunOptions) int {
-	return writeRunOutputComputed(stderr, stdout, hookOutputForRun(eventName, decision, opts))
-}
-
 // writeRunOutputComputed is the shared write tail. Run() computes
 // hookOutputForRun upstream so it can derive the observability decision
-// from the synthesis path; everyone else (handleAgentdError, tests via
-// writeRunOutput) goes through here too. Keeping the empty-check and the
-// writeJSON error handling in one place means no caller has to remember
-// the contract.
+// from the synthesis path; handleAgentdError and the fail-closed paths go
+// through here too. Keeping the empty-check and the writeJSON error
+// handling in one place means no caller has to remember the contract.
 func writeRunOutputComputed(stderr, stdout io.Writer, out ClaudeHookOutput) int {
 	if isEmptyOutput(out) {
 		return 0

--- a/core/edge/claude/runner.go
+++ b/core/edge/claude/runner.go
@@ -222,6 +222,13 @@ func hookPolicyMode(opts RunOptions) string {
 	if mode := strings.TrimSpace(envValue(opts.Env, "CORDUM_EDGE_MODE")); mode != "" {
 		return mode
 	}
+	// The launcher sets both CORDUM_EDGE_MODE and CORDUM_EDGE_POLICY_MODE
+	// (see launcher_metadata.go); honor either so the hook reads the same
+	// value the operator passed via --policy-mode regardless of which env
+	// var survives a downstream wrapper.
+	if mode := strings.TrimSpace(envValue(opts.Env, "CORDUM_EDGE_POLICY_MODE")); mode != "" {
+		return mode
+	}
 	if parseBool(envValue(opts.Env, "CORDUM_AGENTD_FAIL_CLOSED")) {
 		return string(edgecore.PolicyModeEnterpriseStrict)
 	}
@@ -325,8 +332,47 @@ func hookOutputForRun(eventName string, decision AgentdDecision, opts RunOptions
 		return ClaudeHookOutputForDecision(eventName, decision)
 	case "FileChanged":
 		return ClaudeHookOutput{}
+	case "PreToolUse":
+		// When agentd flagged the response as degraded (gateway evaluation
+		// could not complete in time and a RECORDED placeholder came back
+		// instead of a real allow/deny/require_approval), the previous code
+		// fell through to ClaudeHookOutputForDecision → preToolUseOutput's
+		// `default:` case, which returns an empty output → Claude proceeds.
+		// In policy_mode=enforce / enterprise-strict that is a silent
+		// fail-OPEN on every risky tool call whenever the safety kernel
+		// is briefly slow. Fail-CLOSE instead: synthesize a deny with a
+		// reason that names the degraded state so the audit trail and the
+		// model both see why the call was blocked.
+		if decision.Degraded && enforcesOnDegraded(opts) {
+			reason := strings.TrimSpace(decision.Reason)
+			if reason == "" {
+				reason = "Cordum Edge evaluation not ready; blocking under policy_mode=" + hookPolicyMode(opts)
+			} else {
+				reason = "Cordum Edge evaluation degraded (" + reason + "); blocking under policy_mode=" + hookPolicyMode(opts)
+			}
+			return ClaudeHookOutputForDecision(eventName, AgentdDecision{
+				Decision: DecisionDeny,
+				Reason:   reason,
+			})
+		}
+		return ClaudeHookOutputForDecision(eventName, decision)
 	default:
 		return ClaudeHookOutputForDecision(eventName, decision)
+	}
+}
+
+// enforcesOnDegraded reports whether the active policy mode requires the
+// hook to treat a degraded agentd response as a deny. Today: enforce and
+// enterprise-strict do; observe does not (it just records). Centralized
+// here so the mode set stays in one place and future modes don't have to
+// touch hookOutputForRun.
+func enforcesOnDegraded(opts RunOptions) bool {
+	switch strings.ToLower(strings.TrimSpace(hookPolicyMode(opts))) {
+	case string(edgecore.PolicyModeEnforce),
+		string(edgecore.PolicyModeEnterpriseStrict):
+		return true
+	default:
+		return false
 	}
 }
 

--- a/core/edge/claude/runner.go
+++ b/core/edge/claude/runner.go
@@ -157,10 +157,24 @@ func handleAgentdError(stderr, stdout io.Writer, input HookInput, req AgentdRequ
 		recordHookObservability(opts, req, DecisionDeny, code, true, true, startedAt)
 		return 0
 	}
-	if localDevEnforce(opts) && input.HookEventName == "PreToolUse" {
-		localReason := "Cordum Edge local enforcer unavailable; blocking unclassified action"
+	// enforce + local-dev-enforce both degrade-CLOSED for risky / unknown
+	// PreToolUse actions. cordumctl edge doctor documents this contract
+	// ("enforce degrades closed for risky/unknown actions"), but until this
+	// fix only local-dev-enforce was wired up — `enforce` silently fell
+	// through to the catch-all `return 0` below (0 bytes of stdout, exit 0
+	// = Claude proceeds). End-to-end traces caught Write going through in
+	// policy_mode=enforce when agentd was unreachable (post EOF).
+	if (localDevEnforce(opts) || enforceMode(opts)) && input.HookEventName == "PreToolUse" {
+		// Preserve the "local enforcer" wording for local-dev-enforce so
+		// downstream monitors matching on the exact string keep firing;
+		// production enforce gets the unqualified phrasing.
+		enforcerLabel := "Cordum Edge enforcer"
+		if localDevEnforce(opts) {
+			enforcerLabel = "Cordum Edge local enforcer"
+		}
+		localReason := enforcerLabel + " unavailable; blocking unclassified action"
 		if riskyPreToolUse(input) {
-			localReason = "Cordum Edge local enforcer unavailable; blocking risky action"
+			localReason = enforcerLabel + " unavailable; blocking risky action"
 		}
 		out := failClosedOutput(input.HookEventName, localReason)
 		if werr := writeJSON(stdout, out); werr != nil {
@@ -285,9 +299,52 @@ func localDevEnforce(opts RunOptions) bool {
 	return mode == "local-dev-enforce" || mode == "local-dev enforce"
 }
 
+// enforceMode reports whether the active policy mode is "enforce" — the
+// production-shape mode where risky / unknown PreToolUse actions must
+// fail closed when agentd is unreachable. Distinct from failClosed
+// (which is the strictest enterprise-strict deny-everything-on-degraded)
+// and from localDevEnforce (which targets the dev workstation
+// explicitly). Reads both CORDUM_EDGE_POLICY_MODE and CORDUM_EDGE_MODE
+// because the launcher sets both (launcher_metadata.go); a downstream
+// wrapper that drops one of them shouldn't silently downgrade the
+// fail-mode posture.
+func enforceMode(opts RunOptions) bool {
+	if mode := strings.ToLower(strings.TrimSpace(envValue(opts.Env, "CORDUM_EDGE_POLICY_MODE"))); mode == "enforce" {
+		return true
+	}
+	return strings.EqualFold(envValue(opts.Env, "CORDUM_EDGE_MODE"), "enforce")
+}
+
+// fileMutationTools is the static set of Claude Code tools whose contract
+// includes writing or deleting on the operator's filesystem. Each of
+// these is risky-by-default for PreToolUse fail-closed gating — the
+// safety-kernel rules in cordum-edge-pack treat them as file.write
+// capability and the demo's claude-code.require-approval-for-edits rule
+// gates exactly this set. Kept as a map for O(1) lookup; case matters
+// because Claude Code tool names are PascalCase.
+var fileMutationTools = map[string]struct{}{
+	"Write":        {},
+	"Edit":         {},
+	"MultiEdit":    {},
+	"NotebookEdit": {},
+}
+
 func riskyPreToolUse(input HookInput) bool {
+	// Tool-less or unknown invocation — fail closed to surface the gap.
+	if input.ToolName == "" {
+		return true
+	}
+	// File-mutation tools are always risky for PreToolUse: their contract
+	// is "modify the filesystem". Previously this function only flagged
+	// Bash + destructive shell, which let Write / Edit / MultiEdit /
+	// NotebookEdit slip through enforcer-unavailable paths even though
+	// the demo policy pack's require-approval-for-edits rule clearly
+	// intends to gate them.
+	if _, ok := fileMutationTools[input.ToolName]; ok {
+		return true
+	}
 	if !strings.EqualFold(input.ToolName, "Bash") {
-		return input.ToolName == ""
+		return false
 	}
 	raw, ok := input.ToolInput["command"]
 	if !ok {

--- a/core/edge/claude/runner.go
+++ b/core/edge/claude/runner.go
@@ -69,8 +69,26 @@ func Run(ctx context.Context, opts RunOptions) int {
 	if err != nil {
 		return handleAgentdError(stderr, stdout, input, req, err, opts, startedAt)
 	}
-	recordHookObservability(opts, req, decision.Decision, hookDenyReasonCode(req, ""), false, false, startedAt)
-	return writeRunOutput(stderr, stdout, input.HookEventName, decision, opts)
+	// Compute the hook output once, derive the metric/audit-recorded
+	// decision from it. Previously this fired recordHookObservability with
+	// the raw `decision.Decision` BEFORE writeRunOutput synthesized a deny
+	// for the degraded+enforce case — so a fail-closed PreToolUse showed
+	// up in metrics as the original `RECORDED` decision with degraded=false,
+	// even though the hook actually emitted a block. CodeRabbit on #319
+	// caught this; recording after synthesis keeps metrics honest.
+	out := hookOutputForRun(input.HookEventName, decision, opts)
+	effectiveDecision := decision.Decision
+	degraded := decision.Degraded
+	failClosed := false
+	reasonCode := hookDenyReasonCode(req, "")
+	if input.HookEventName == "PreToolUse" && decision.Degraded && enforcesOnDegraded(opts) {
+		effectiveDecision = DecisionDeny
+		degraded = true
+		failClosed = true
+		reasonCode = "degraded_policy_enforced"
+	}
+	recordHookObservability(opts, req, effectiveDecision, reasonCode, degraded, failClosed, startedAt)
+	return writeRunOutputComputed(stderr, stdout, out)
 }
 
 func hookAgentdClient(opts RunOptions, postBudget time.Duration) (AgentdClient, error) {
@@ -91,7 +109,16 @@ func evaluateAgentdHook(ctx context.Context, agentd AgentdClient, req AgentdRequ
 }
 
 func writeRunOutput(stderr, stdout io.Writer, eventName string, decision AgentdDecision, opts RunOptions) int {
-	out := hookOutputForRun(eventName, decision, opts)
+	return writeRunOutputComputed(stderr, stdout, hookOutputForRun(eventName, decision, opts))
+}
+
+// writeRunOutputComputed is the shared write tail. Run() computes
+// hookOutputForRun upstream so it can derive the observability decision
+// from the synthesis path; everyone else (handleAgentdError, tests via
+// writeRunOutput) goes through here too. Keeping the empty-check and the
+// writeJSON error handling in one place means no caller has to remember
+// the contract.
+func writeRunOutputComputed(stderr, stdout io.Writer, out ClaudeHookOutput) int {
 	if isEmptyOutput(out) {
 		return 0
 	}

--- a/core/edge/claude/runner_test.go
+++ b/core/edge/claude/runner_test.go
@@ -185,7 +185,7 @@ func TestRunRecordsHookObservabilityForFailClosedAgentdOutage(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum Edge unavailable; blocking by fail-closed policy","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
 	assertNoSyntheticSecrets(t, stdout+stderr)
 	if len(recorder.actionDecisions) != 1 || recorder.actionDecisions[0].decision != "deny" || recorder.actionDecisions[0].kind != "hook.pre_tool_use" {
 		t.Fatalf("action decision calls = %#v, want deny hook.pre_tool_use", recorder.actionDecisions)
@@ -245,7 +245,7 @@ func TestRunPreToolUseDenyWritesDenyReasonForClaude(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum policy denied rm -rf"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum policy denied rm -rf","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum policy denied rm -rf"}}`)
 	if strings.Contains(stderr, "rm -rf") {
 		t.Fatalf("stderr leaked raw command: %q", stderr)
 	}
@@ -392,7 +392,7 @@ func TestRunStrictModeDeniesWhenAgentdUnavailable(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum Edge unavailable; blocking by fail-closed policy","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge unavailable; blocking by fail-closed policy"}}`)
 	if !strings.Contains(stderr, "agentd_unavailable") {
 		t.Fatalf("stderr missing stable outage code: %q", stderr)
 	}
@@ -420,7 +420,7 @@ func TestRunStrictModeDeniesWhenAgentdTimesOut(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge timeout; blocking by fail-closed policy"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum Edge timeout; blocking by fail-closed policy","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge timeout; blocking by fail-closed policy"}}`)
 	if !strings.Contains(stderr, "agentd_timeout") {
 		t.Fatalf("stderr missing timeout code: %q", stderr)
 	}
@@ -473,7 +473,7 @@ func TestSlowAgentdDoesNotConsumeResponseWriteReserve(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr=%q", code, stderr)
 	}
-	assertCompactJSON(t, stdout, `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge timeout; blocking by fail-closed policy"}}`)
+	assertCompactJSON(t, stdout, `{"decision":"block","reason":"Cordum Edge timeout; blocking by fail-closed policy","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Cordum Edge timeout; blocking by fail-closed policy"}}`)
 	if !strings.Contains(stderr, "agentd_timeout") {
 		t.Fatalf("stderr missing timeout code: %q", stderr)
 	}


### PR DESCRIPTION
## The bug end-to-end Edge testing uncovered

Today's session ran `cordumctl edge claude --policy-mode enforce` against a real Claude Code subprocess and asked it to Edit a file. The expectation: `claude-code.require-approval-for-edits` from the demo edge pack fires, the hook returns `permissionDecision=deny`, Claude refuses to edit.

Reality: the file was modified anyway, audit trail recorded `REQUIRE_APPROVAL` events 3–4 seconds AFTER `post_tool_use`. Walking the call graph showed why:

1. **`AgentdDecision` struct had no `Degraded` field.** Agentd's `EvaluateResponse` carries it (`evaluate_client.go:71`) but the hook-side struct (which is what gets deserialized) didn't. So even when agentd hit the fail-mode path, the hook received a struct with the field implicitly absent.

2. **`agentd.degradedDecision()` only set `Degraded: true` on the internal `EvaluateResponse`** — the `claude.AgentdDecision` returned to the hook left it unset.

3. **`preToolUseOutput`'s `default:` arm returns `ClaudeHookOutput{}` (= empty = allow)** for any decision not in `{allow,deny,ask,require_approval}`. A `RECORDED` placeholder from a fail-mode response fell here. Net: silent fail-OPEN on every risky tool call whenever the kernel was briefly slow.

This is a real production-shape vulnerability: an operator who configured `--policy-mode enforce` got `--policy-mode observe` behavior on every transient gateway hiccup.

## Fix

Three surgical spots, all backward-compatible:

```diff
 type AgentdDecision struct {
   Decision          Decision       `json:"decision"`
   Reason            string         `json:"reason,omitempty"`
   ApprovalRef       string         `json:"approval_ref,omitempty"`
   AdditionalContext string         `json:"additional_context,omitempty"`
   UpdatedInput      map[string]any `json:"updated_input,omitempty"`
+  Degraded          bool           `json:"degraded,omitempty"`
 }
```

```diff
 // agentd: degradedDecision()
-decision := claude.AgentdDecision{Decision: outcome.Decision}
+decision := claude.AgentdDecision{
+    Decision: outcome.Decision,
+    Degraded: true,
+}
```

```diff
 // runner: hookOutputForRun for PreToolUse
+if decision.Degraded && enforcesOnDegraded(opts) {
+    return ClaudeHookOutputForDecision("PreToolUse", AgentdDecision{
+        Decision: DecisionDeny,
+        Reason:   "Cordum Edge evaluation degraded (...); blocking under policy_mode=enforce",
+    })
+}
```

Plus a small one-liner widening `hookPolicyMode()` to also honor `CORDUM_EDGE_POLICY_MODE` (the launcher already sets both, but the hook was only reading one).

## Tests

4 new fail-mode tests pin the behavior at every relevant mode:

| Test | Mode | Decision in | Expected output |
|---|---|---|---|
| `TestRunEnforceDeniesDegradedPreToolUse` | `enforce` | `RECORDED + Degraded=true` | deny output naming the mode |
| `TestRunEnterpriseStrictDeniesDegradedPreToolUse` | `enterprise-strict` | `RECORDED + Degraded=true` | deny output |
| `TestRunObserveModeAllowsDegradedPreToolUse` | `observe` | `RECORDED + Degraded=true` | empty (no regression to observability mode) |
| `TestRunEnforceAllowsNonDegradedRecordedResponses` | `enforce` | `RECORDED + Degraded=false` | empty (only degraded triggers the fail-close) |

Full `core/edge/claude` (5.4 s) and `core/edge/agentd` (3.4 s) suites pass.

## Honest scope note

End-to-end testing also surfaced a SEPARATE issue — `claude-code.require-approval-for-edits` produced `REQUIRE_APPROVAL` audit events but the Edit still completed. Tracing showed the policy decision arrived after `post_tool_use`, suggesting either an async evaluator path or a Claude-Code-side retry; **that's a different fix** worth its own investigation/PR. This PR closes the degraded-fail-OPEN path, which is the more dangerous one (it's transparent to operators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hook outputs now include explicit top-level decision and reason when denying; degraded responses are synthesized to deny in enforce and enterprise-strict, while observe leaves them as no-ops.
  * Risky-tool classification expanded to include file-mutation tools so fail-closed gating applies consistently.
  * Observability now records the synthesized deny and emits canonical degraded-enforcement reason codes.

* **Tests**
  * Added end-to-end and regression tests for degraded/unavailable responses, policy modes, and observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cordum-io/cordum/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->