### PR TITLE
fix(production-gate): surface gate-4 remediation error instead of swallowing it

### DIFF
--- a/tools/scripts/production_gate.sh
+++ b/tools/scripts/production_gate.sh
@@ -986,11 +986,23 @@ gate_4_policy() {
     return 1
   }
 
-  (cd "${ROOT_DIR}" && CORDUM_API_KEY="${API_KEY}" \
+  # Capture the remediation run's output and surface it on failure. This step
+  # previously ran with `>/dev/null 2>&1`, which silently swallowed the cause of
+  # gate-4 failures (e.g. the demo worker failing to register / Redis auth), so a
+  # red nightly showed only "Gate 4 Policy FAIL" with no actionable detail.
+  local remediation_log
+  remediation_log="$(mktemp)"
+  if ! (cd "${ROOT_DIR}" && CORDUM_API_KEY="${API_KEY}" \
     CORDUM_ORG_ID="${ORG_ID}" \
     CORDUM_TENANT_ID="${TENANT_ID}" \
     CORDUM_API_BASE="${API_BASE}" \
-    "${SCRIPT_DIR}/demo_guardrails_run.sh" >/dev/null 2>&1)
+    "${SCRIPT_DIR}/demo_guardrails_run.sh" >"${remediation_log}" 2>&1); then
+    echo "gate 4: demo-guardrails remediation run failed:" >&2
+    sed 's/^/  | /' "${remediation_log}" >&2
+    rm -f "${remediation_log}"
+    return 1
+  fi
+  rm -f "${remediation_log}"
 
   echo "policy evaluate/simulate/explain/remediation/audit checks passed"
 }


### PR DESCRIPTION
**Why the nightly has been red (and undiagnosable) since ~2026-05-29.**

`gate_4_policy` runs the final demo-guardrails remediation step as:
```
... demo_guardrails_run.sh >/dev/null 2>&1
```
so when that step fails, the gate reports only an opaque `Gate 4 Policy | BLOCKING | FAIL` with **no detail** — the actual cause (the demo worker failing to register: Redis auth / TLS, etc.) is swallowed.

This patch captures the remediation output and prints it (indented) on failure, then returns 1. The 6 policy assertions (evaluate DENY/ALLOW, simulate REQUIRE_HUMAN, explain, snapshots, audit) and the pack install were verified to pass — the failure is entirely in this previously-silenced step.

**Verified locally:** Gate 4 now prints the underlying `worker did not register in time` + the worker's Redis error, instead of a blank FAIL. General-purpose diagnosability fix for the production-gate harness (independent of any demo). The next nightly run will reveal the exact Linux-side cause so it can be fixed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error reporting in production gate checks—remediation failures now display detailed logs for improved troubleshooting and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->