### PR TITLE
[bug] audit: drain buffered exporter with a fresh bounded context on Close (CRD-13, task-bdce8197)

### DIFF
--- a/core/audit/buffer.go
+++ b/core/audit/buffer.go
@@ -19,6 +19,9 @@ const (
 	defaultChanSize      = 1000
 	defaultExportTimeout = 10 * time.Second
 	defaultMaxRetries    = 3
+	// defaultDrainTimeout gives audit exporters their own bounded drain budget.
+	// Gateway defers server.Close until after its 15s HTTP/gRPC shutdown window.
+	defaultDrainTimeout = 15 * time.Second
 )
 
 var auditBatchDrops = promauto.NewCounter(prometheus.CounterOpts{
@@ -51,10 +54,16 @@ type BufferedExporter struct {
 	done     chan struct{}
 	wg       sync.WaitGroup
 
+	closeOnce sync.Once
+	closeErr  error
+	sendMu    sync.RWMutex
+	closed    bool
+
 	batchSize     int
 	flushInterval time.Duration
 	retryBackoff  time.Duration
 	retentionTTL  time.Duration
+	drainTimeout  time.Duration
 }
 
 // BufferOption configures a BufferedExporter.
@@ -81,6 +90,15 @@ func WithRetentionTTL(d time.Duration) BufferOption {
 	return func(b *BufferedExporter) { b.retentionTTL = d }
 }
 
+// WithDrainTimeout bounds how long Close spends exporting queued events.
+func WithDrainTimeout(d time.Duration) BufferOption {
+	return func(b *BufferedExporter) {
+		if d > 0 {
+			b.drainTimeout = d
+		}
+	}
+}
+
 // NewBufferedExporter wraps an Exporter with async batching.
 func NewBufferedExporter(exp Exporter, opts ...BufferOption) *BufferedExporter {
 	b := &BufferedExporter{
@@ -90,6 +108,7 @@ func NewBufferedExporter(exp Exporter, opts ...BufferOption) *BufferedExporter {
 		batchSize:     defaultBatchSize,
 		flushInterval: defaultFlushInterval,
 		retryBackoff:  time.Second,
+		drainTimeout:  defaultDrainTimeout,
 	}
 	for _, o := range opts {
 		o(b)
@@ -101,14 +120,39 @@ func NewBufferedExporter(exp Exporter, opts ...BufferOption) *BufferedExporter {
 
 // Send enqueues an event for export. Non-blocking; drops if buffer is full.
 func (b *BufferedExporter) Send(event SIEMEvent) {
-	select {
-	case b.ch <- event:
-	default:
-		slog.Warn("audit exporter buffer full, dropping event",
-			"event_type", event.EventType,
-			"action", event.Action,
-		)
+	reason := ""
+	b.sendMu.RLock()
+	if b.closed {
+		reason = "closed"
+	} else {
+		select {
+		case b.ch <- event:
+			b.sendMu.RUnlock()
+			return
+		default:
+			reason = "buffer_full"
+		}
 	}
+	b.sendMu.RUnlock()
+	b.logDroppedEvent(event, reason)
+}
+
+func (b *BufferedExporter) logDroppedEvent(event SIEMEvent, reason string) {
+	select {
+	case <-b.done:
+		if reason == "" {
+			reason = "closed"
+		}
+	default:
+		if reason == "" {
+			reason = "buffer_full"
+		}
+	}
+	slog.Warn("audit exporter dropping event",
+		"reason", reason,
+		"event_type", event.EventType,
+		"action", event.Action,
+	)
 }
 
 // Backend returns the underlying SIEM exporter wrapped by this buffer.
@@ -125,9 +169,17 @@ func (b *BufferedExporter) RetentionTTL() time.Duration {
 
 // Close drains remaining events and shuts down the exporter.
 func (b *BufferedExporter) Close() error {
-	close(b.done)
-	b.wg.Wait()
-	return b.exporter.Close()
+	b.closeOnce.Do(func() {
+		b.sendMu.Lock()
+		b.closed = true
+		close(b.done)
+		b.sendMu.Unlock()
+		b.wg.Wait()
+		if b.exporter != nil {
+			b.closeErr = b.exporter.Close()
+		}
+	})
+	return b.closeErr
 }
 
 func (b *BufferedExporter) loop() {
@@ -135,16 +187,12 @@ func (b *BufferedExporter) loop() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go func() {
-		<-b.done
-		cancel()
-	}()
 
 	batch := make([]SIEMEvent, 0, b.batchSize)
 	ticker := time.NewTicker(b.flushInterval)
 	defer ticker.Stop()
 
-	flush := func() {
+	flush := func(ctx context.Context) {
 		if len(batch) == 0 {
 			return
 		}
@@ -158,31 +206,45 @@ func (b *BufferedExporter) loop() {
 		select {
 		case ev, ok := <-b.ch:
 			if !ok {
-				flush()
+				flush(ctx)
 				return
 			}
 			batch = append(batch, ev)
 			if len(batch) >= b.batchSize {
-				flush()
+				flush(ctx)
 			}
 		case <-ticker.C:
-			flush()
+			flush(ctx)
 		case <-b.done:
-			// Drain remaining events from channel.
-			for {
-				select {
-				case ev := <-b.ch:
-					batch = append(batch, ev)
-					if len(batch) >= b.batchSize {
-						flush()
-					}
-				default:
-					flush()
-					return
-				}
-			}
+			b.drainQueuedEvents(&batch, flush)
+			return
 		}
 	}
+}
+
+func (b *BufferedExporter) drainQueuedEvents(batch *[]SIEMEvent, flush func(context.Context)) {
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), b.effectiveDrainTimeout())
+	defer drainCancel()
+
+	for {
+		select {
+		case ev := <-b.ch:
+			*batch = append(*batch, ev)
+			if len(*batch) >= b.batchSize {
+				flush(drainCtx)
+			}
+		default:
+			flush(drainCtx)
+			return
+		}
+	}
+}
+
+func (b *BufferedExporter) effectiveDrainTimeout() time.Duration {
+	if b.drainTimeout > 0 {
+		return b.drainTimeout
+	}
+	return defaultDrainTimeout
 }
 
 func (b *BufferedExporter) exportWithRetry(ctx context.Context, events []SIEMEvent) {

--- a/core/audit/buffer_test.go
+++ b/core/audit/buffer_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -47,6 +48,71 @@ func (m *mockExporter) totalEvents() int {
 	}
 	return n
 }
+
+// contextCheckingMockExporter simulates context-aware HTTP/SIEM exporters.
+type contextCheckingMockExporter struct {
+	mu           sync.Mutex
+	batches      [][]SIEMEvent
+	observedErrs []error
+}
+
+func (m *contextCheckingMockExporter) Export(ctx context.Context, events []SIEMEvent) error {
+	err := ctx.Err()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.observedErrs = append(m.observedErrs, err)
+	if err != nil {
+		return fmt.Errorf("audit export: %w", err)
+	}
+	cp := make([]SIEMEvent, len(events))
+	copy(cp, events)
+	m.batches = append(m.batches, cp)
+	return nil
+}
+
+func (m *contextCheckingMockExporter) Close() error { return nil }
+
+func (m *contextCheckingMockExporter) totalEvents() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, b := range m.batches {
+		n += len(b)
+	}
+	return n
+}
+
+func (m *contextCheckingMockExporter) cancelledContextCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, err := range m.observedErrs {
+		if err != nil {
+			n++
+		}
+	}
+	return n
+}
+
+type blockingExporter struct {
+	calls chan struct{}
+}
+
+func newBlockingExporter() *blockingExporter {
+	return &blockingExporter{calls: make(chan struct{}, 1)}
+}
+
+func (b *blockingExporter) Export(ctx context.Context, _ []SIEMEvent) error {
+	select {
+	case b.calls <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (b *blockingExporter) Close() error { return nil }
 
 func TestBufferedExporter_FlushOnBatchSize(t *testing.T) {
 	mock := &mockExporter{}
@@ -97,6 +163,99 @@ func TestBufferedExporter_DrainOnClose(t *testing.T) {
 
 	if got := mock.totalEvents(); got != 7 {
 		t.Errorf("total events after drain = %d, want 7", got)
+	}
+}
+
+func TestBufferedExporter_DrainOnClose_ContextAware(t *testing.T) {
+	mock := &contextCheckingMockExporter{}
+	buf := NewBufferedExporter(mock, WithBatchSize(100), WithFlushInterval(10*time.Second))
+
+	for i := 0; i < 7; i++ {
+		buf.Send(SIEMEvent{Action: "drain-context-aware"})
+	}
+	if err := buf.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := mock.totalEvents(); got != 7 {
+		t.Fatalf("total events after context-aware drain = %d, want 7", got)
+	}
+	if got := mock.cancelledContextCalls(); got != 0 {
+		t.Fatalf("export calls with cancelled context = %d, want 0", got)
+	}
+}
+
+func TestBufferedExporter_CloseLatencyBounded(t *testing.T) {
+	exporter := newBlockingExporter()
+	drainTimeout := 300 * time.Millisecond
+	buf := NewBufferedExporter(exporter,
+		WithBatchSize(100),
+		WithFlushInterval(10*time.Second),
+		WithDrainTimeout(drainTimeout),
+	)
+	for i := 0; i < 3; i++ {
+		buf.Send(SIEMEvent{Action: "blocked-drain"})
+	}
+
+	start := time.Now()
+	err := buf.Close()
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if elapsed > 2*drainTimeout+200*time.Millisecond {
+		t.Fatalf("Close elapsed %s, want <= %s", elapsed, 2*drainTimeout+200*time.Millisecond)
+	}
+	select {
+	case <-exporter.calls:
+	default:
+		t.Fatal("expected exporter to be called during bounded drain")
+	}
+
+	secondStart := time.Now()
+	if err := buf.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if secondElapsed := time.Since(secondStart); secondElapsed > 100*time.Millisecond {
+		t.Fatalf("second Close elapsed %s, want <= 100ms", secondElapsed)
+	}
+}
+
+func TestBufferedExporter_CloseEmptyQueueFast(t *testing.T) {
+	mock := &contextCheckingMockExporter{}
+	buf := NewBufferedExporter(mock,
+		WithBatchSize(100),
+		WithFlushInterval(10*time.Second),
+		WithDrainTimeout(300*time.Millisecond),
+	)
+
+	start := time.Now()
+	if err := buf.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("Close empty queue elapsed %s, want <= 100ms", elapsed)
+	}
+	if got := mock.totalEvents(); got != 0 {
+		t.Fatalf("total events after empty close = %d, want 0", got)
+	}
+}
+
+func TestBufferedExporter_SendAfterCloseDrops(t *testing.T) {
+	mock := &contextCheckingMockExporter{}
+	buf := NewBufferedExporter(mock, WithBatchSize(100), WithFlushInterval(10*time.Second))
+	if err := buf.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		buf.Send(SIEMEvent{Action: "after-close"})
+	}
+	if got := len(buf.ch); got != 0 {
+		t.Fatalf("buffer len after Send on closed exporter = %d, want 0", got)
+	}
+	if got := mock.totalEvents(); got != 0 {
+		t.Fatalf("exported events after Send on closed exporter = %d, want 0", got)
 	}
 }
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -315,6 +315,14 @@ server-derived; no Claude token/auth files are ever read). The compliance export
 | `CORDUM_AUDIT_BUFFER_SIZE` | Async buffer size for export batching |
 | `CORDUM_AUDIT_EXPORT_MAX_RETRIES` | Max retry attempts for failed exports |
 
+On shutdown, `Close` drains queued events to the configured backend with a
+fresh bounded context. The default drain budget is 15 seconds; embedders can
+override it with `WithDrainTimeout`. Events that still cannot export within
+that bound are dropped through the existing `audit batch permanently dropped
+after retries` error log and `auditBatchDrops` metric. Before this drain split,
+context-aware backends such as webhook, Datadog, and CloudWatch could drop
+queued events immediately with `context canceled` during `Close`.
+
 ### Webhook
 
 | Env Var | Description |


### PR DESCRIPTION
﻿## Summary

Fixes CRD-13 / Moe task `task-bdce8197`: `BufferedExporter.Close` now drains queued audit events with a fresh bounded context instead of canceling the context used for the shutdown drain.

## Faulting sequence

Before this change:

1. `BufferedExporter.Close` closed `b.done` and waited.
2. A watcher goroutine also received `b.done` and immediately canceled the exporter run context.
3. The Close drain branch swept queued events and called `flush()`.
4. `flush()` called `exportWithRetry(ctx, ...)` with the now-dead context.
5. Context-aware HTTP/SIEM exporters (webhook, Datadog, CloudWatch) saw `context canceled`; queued events accepted by `Send` were dropped.

RED repro from the new test:

```text
ERROR audit export failed attempt=1 events=7 error="audit export: context canceled"
WARN audit export cancelled during retry attempt=1 events=7
buffer_test.go:162: total events after context-aware drain = 0, want 7
```

## Fix shape

- Split lifecycle cancellation from graceful drain.
- Removed the shutdown watcher that canceled the run context before drain.
- Made `flush` take an explicit context.
- Close drain now uses a fresh `context.WithTimeout(context.Background(), drainTimeout)`.
- Added `WithDrainTimeout` with a 15s default derived from gateway shutdown sequencing.
- Made `Close` idempotent via `sync.Once`.
- Tightened Send/Close coordination so Sends accepted before Close are drained, and Sends after Close are dropped rather than enqueued into an orphaned channel.
- Documented shutdown drain semantics in `docs/audit.md`.

## Close latency bound

Raw retry behavior can be large: retries(3) × (10s export timeout + exponential backoff) per batch × up to 10 buffered batches. The fix applies one fresh drain context to the whole Close drain, so all batches/retries/backoff are capped by `defaultDrainTimeout` (15s by default; embedders can override via `WithDrainTimeout`).

## Validation

- RED verified pre-fix: `TestBufferedExporter_DrainOnClose_ContextAware` exported 0/7 with `context canceled`.
- `go test -count=3 ./core/audit/` → `ok ... 31.324s`
- `go vet ./core/audit/...` → EXIT=0
- `go build ./...` → EXIT=0

## Docs

See `docs/audit.md` §7 SIEM Export Configuration for the operator-facing shutdown drain semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `WithDrainTimeout` option to configure maximum drain time for buffered audit events during shutdown.

* **Bug Fixes**
  * Improved shutdown synchronization with bounded drain time (default 15 seconds) to ensure graceful event export completion.

* **Tests**
  * Added comprehensive test coverage for audit export close semantics and drain behavior.

* **Documentation**
  * Updated audit export pipeline documentation with shutdown behavior and drain timeout configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->