### PR TITLE
[bug] safetykernel: fail closed when truncation skips secret/PII scanning (CRD-4, task-5f641afe)

### DIFF
--- a/core/controlplane/safetykernel/output_policy.go
+++ b/core/controlplane/safetykernel/output_policy.go
@@ -187,23 +187,35 @@ func (s *server) EvaluateOutput(ctx context.Context, req *OutputEvaluateRequest)
 		req.OutputContent, contentTruncated = truncateOutputContent(req.OutputContent)
 	}
 
+	hasSensitiveScanners := outputRulesUseSensitiveScanners(rules)
 	for _, rule := range rules {
 		matched, findings := evaluateOutputRule(rule, req, scanners)
-		if contentTruncated {
-			findings = append(findings, outputFinding{
-				Type:     "content_truncated",
-				Severity: "info",
-				Detail:   fmt.Sprintf("content exceeded max regex input size (%d bytes), truncated", maxOutputScanBytes),
-				Scanner:  "size_check",
-			})
-		}
 		if !matched {
 			continue
+		}
+		// Truncated content with sensitive scanners fails closed: a REDACT
+		// decision can only cover the scanned head, not the unscanned tail.
+		if contentTruncated && hasSensitiveScanners && outputDecisionWeakerThanQuarantine(rule.decision) {
+			findings = append(findings, outputTruncatedFailClosedFinding())
+			resp.Decision = "quarantine"
+			resp.Reason = outputTruncatedFailClosedReason
+			resp.RuleID = rule.id
+			resp.Findings = findings
+			return resp, nil
+		}
+		if contentTruncated {
+			findings = append(findings, outputTruncatedInfoFinding())
 		}
 		resp.Decision = outputDecisionString(rule.decision)
 		resp.Reason = outputRuleReason(rule, findings)
 		resp.RuleID = rule.id
 		resp.Findings = findings
+		return resp, nil
+	}
+	if contentTruncated && hasSensitiveScanners {
+		resp.Decision = "quarantine"
+		resp.Reason = outputTruncatedFailClosedReason
+		resp.Findings = []outputFinding{outputTruncatedFailClosedFinding()}
 		return resp, nil
 	}
 
@@ -286,23 +298,35 @@ func (s *server) CheckOutput(ctx context.Context, req *pb.OutputCheckRequest) (*
 		return resp, nil
 	}
 	evalReq := outputEvaluateRequestFromProto(req, content)
+	hasSensitiveScanners := outputRulesUseSensitiveScanners(rules)
 	for _, rule := range rules {
 		matched, findings := evaluateOutputRule(rule, evalReq, scanners)
 		if !matched {
 			continue
 		}
+		// Truncated content with sensitive scanners fails closed: a REDACT
+		// decision can only cover the scanned head, not the unscanned tail.
+		if contentTruncated && hasSensitiveScanners && outputDecisionWeakerThanQuarantine(rule.decision) {
+			findings = append(findings, outputTruncatedFailClosedFinding())
+			resp.Decision = pb.OutputDecision_OUTPUT_DECISION_QUARANTINE
+			resp.Reason = outputTruncatedFailClosedReason
+			resp.RuleId = rule.id
+			resp.Findings = toProtoOutputFindings(findings)
+			return resp, nil
+		}
 		if contentTruncated {
-			findings = append(findings, outputFinding{
-				Type:     "content_truncated",
-				Severity: "info",
-				Detail:   fmt.Sprintf("content exceeded max regex input size (%d bytes), truncated", maxOutputScanBytes),
-				Scanner:  "size_check",
-			})
+			findings = append(findings, outputTruncatedInfoFinding())
 		}
 		resp.Decision = rule.decision
 		resp.Reason = outputRuleReason(rule, findings)
 		resp.RuleId = rule.id
 		resp.Findings = toProtoOutputFindings(findings)
+		return resp, nil
+	}
+	if contentTruncated && hasSensitiveScanners {
+		resp.Decision = pb.OutputDecision_OUTPUT_DECISION_QUARANTINE
+		resp.Reason = outputTruncatedFailClosedReason
+		resp.Findings = toProtoOutputFindings([]outputFinding{outputTruncatedFailClosedFinding()})
 		return resp, nil
 	}
 
@@ -319,6 +343,57 @@ func outputPolicyEnabled(policy *config.SafetyPolicy, rules []compiledOutputRule
 	// Backward compatibility: if output_rules exist but output_policy block is absent,
 	// keep legacy enabled behavior.
 	return strings.TrimSpace(policy.OutputPolicy.FailMode) == ""
+}
+
+const outputTruncatedFailClosedReason = "content truncated; escalating to quarantine for sensitive output scanners"
+
+func outputTruncatedInfoFinding() outputFinding {
+	return outputFinding{
+		Type:     "content_truncated",
+		Severity: "info",
+		Detail:   fmt.Sprintf("content exceeded max regex input size (%d bytes), truncated", maxOutputScanBytes),
+		Scanner:  "size_check",
+	}
+}
+
+func outputTruncatedFailClosedFinding() outputFinding {
+	return outputFinding{
+		Type:     "content_truncated",
+		Severity: "high",
+		Detail:   "content exceeded max scan size (2 MiB); unscanned tail may contain secrets — failing closed",
+		Scanner:  "size_check",
+	}
+}
+
+func outputRulesUseSensitiveScanners(rules []compiledOutputRule) bool {
+	for _, rule := range rules {
+		if outputRuleUsesSensitiveScanner(rule) {
+			return true
+		}
+	}
+	return false
+}
+
+func outputRuleUsesSensitiveScanner(rule compiledOutputRule) bool {
+	for _, scanner := range rule.scanners {
+		if isSensitiveOutputScanner(scanner) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSensitiveOutputScanner(scanner string) bool {
+	switch normalizeScannerName(scanner) {
+	case "secret", "pii", "injection", "prompt_injection":
+		return true
+	default:
+		return false
+	}
+}
+
+func outputDecisionWeakerThanQuarantine(decision pb.OutputDecision) bool {
+	return decision != pb.OutputDecision_OUTPUT_DECISION_QUARANTINE
 }
 
 func outputRuleReason(rule compiledOutputRule, findings []outputFinding) string {

--- a/core/controlplane/safetykernel/output_policy_test.go
+++ b/core/controlplane/safetykernel/output_policy_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+const testAWSAccessKeyID = "AKIA1234567890ABCDEF"
+
 func boolPtr(v bool) *bool { return &v }
 
 func TestCompileOutputRulesNormalizesScannersAndEnable(t *testing.T) {
@@ -790,6 +792,15 @@ func hasOutputFindingType(findings []outputFinding, want string) bool {
 	return false
 }
 
+func hasOutputFinding(findings []outputFinding, wantType, wantSeverity string) bool {
+	for _, finding := range findings {
+		if finding.Type == wantType && finding.Severity == wantSeverity {
+			return true
+		}
+	}
+	return false
+}
+
 func hasProtoOutputFinding(findings []*pb.OutputFinding, wantType, wantSeverity string) bool {
 	for _, finding := range findings {
 		if finding.GetType() == wantType && finding.GetSeverity() == wantSeverity {
@@ -797,6 +808,19 @@ func hasProtoOutputFinding(findings []*pb.OutputFinding, wantType, wantSeverity 
 		}
 	}
 	return false
+}
+
+func makeBigContentWithSecret(secretOffset int) []byte {
+	content := make([]byte, maxOutputScanBytes+1024)
+	for i := range content {
+		content[i] = 'x'
+	}
+	secret := []byte(testAWSAccessKeyID)
+	if secretOffset < 0 || secretOffset+len(secret) > len(content) {
+		panic("secret offset outside test content")
+	}
+	copy(content[secretOffset:], secret)
+	return content
 }
 
 func TestEvaluateOutputKeywordAndContentType(t *testing.T) {
@@ -965,6 +989,163 @@ func TestContentTruncationFinding(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected content_truncated finding in response")
+	}
+}
+
+func TestCheckOutput_TruncatedTailSecret_FailsClosed(t *testing.T) {
+	srv := &server{scanners: defaultOutputScanners()}
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
+		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
+		OutputRules: []config.OutputPolicyRule{{
+			ID:       "out-secret-tail",
+			Decision: "quarantine",
+			Match: config.OutputPolicyMatch{
+				Topics:   []string{"job.*"},
+				Scanners: []string{"secret"},
+			},
+		}},
+	}, "snap-tail-secret")
+
+	resp, err := srv.CheckOutput(context.Background(), &pb.OutputCheckRequest{
+		JobId:         "job-tail-secret",
+		Topic:         "job.default",
+		Tenant:        "default",
+		OutputContent: makeBigContentWithSecret(maxOutputScanBytes + 32),
+	})
+	if err != nil {
+		t.Fatalf("check output: %v", err)
+	}
+	if resp.GetDecision() != pb.OutputDecision_OUTPUT_DECISION_QUARANTINE {
+		t.Fatalf("expected truncated secret-scanner output to fail closed, got %v: %#v", resp.GetDecision(), resp)
+	}
+	if !hasProtoOutputFinding(resp.GetFindings(), "content_truncated", "high") {
+		t.Fatalf("expected high-severity content_truncated finding, got %#v", resp.GetFindings())
+	}
+}
+
+func TestEvaluateOutput_TruncatedTailSecret_FailsClosed(t *testing.T) {
+	srv := &server{scanners: defaultOutputScanners()}
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
+		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
+		OutputRules: []config.OutputPolicyRule{{
+			ID:       "out-secret-tail-eval",
+			Decision: "quarantine",
+			Match: config.OutputPolicyMatch{
+				Topics:   []string{"job.*"},
+				Scanners: []string{"secret"},
+			},
+		}},
+	}, "snap-tail-secret-eval")
+
+	resp, err := srv.EvaluateOutput(context.Background(), &OutputEvaluateRequest{
+		JobID:         "job-tail-secret-eval",
+		Topic:         "job.default",
+		Tenant:        "default",
+		OutputContent: makeBigContentWithSecret(maxOutputScanBytes + 32),
+	})
+	if err != nil {
+		t.Fatalf("evaluate output: %v", err)
+	}
+	if resp.Decision != "quarantine" {
+		t.Fatalf("expected truncated secret-scanner output to fail closed, got %q: %#v", resp.Decision, resp)
+	}
+	if !hasOutputFinding(resp.Findings, "content_truncated", "high") {
+		t.Fatalf("expected high-severity content_truncated finding, got %#v", resp.Findings)
+	}
+}
+
+func TestCheckOutput_TruncatedHeadSecret_RedactEscalatesToQuarantine(t *testing.T) {
+	srv := &server{scanners: defaultOutputScanners()}
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
+		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
+		OutputRules: []config.OutputPolicyRule{{
+			ID:       "out-secret-redact-trunc",
+			Decision: "redact",
+			Match: config.OutputPolicyMatch{
+				Topics:   []string{"job.*"},
+				Scanners: []string{"secret"},
+			},
+		}},
+	}, "snap-redact-trunc")
+
+	resp, err := srv.CheckOutput(context.Background(), &pb.OutputCheckRequest{
+		JobId:         "job-redact-trunc",
+		Topic:         "job.default",
+		Tenant:        "default",
+		OutputContent: makeBigContentWithSecret(8),
+	})
+	if err != nil {
+		t.Fatalf("check output: %v", err)
+	}
+	if resp.GetDecision() != pb.OutputDecision_OUTPUT_DECISION_QUARANTINE {
+		t.Fatalf("expected truncated redaction to escalate to quarantine, got %v: %#v", resp.GetDecision(), resp)
+	}
+	if !hasProtoOutputFinding(resp.GetFindings(), "content_truncated", "high") {
+		t.Fatalf("expected high-severity content_truncated finding, got %#v", resp.GetFindings())
+	}
+}
+
+func TestCheckOutput_UnderCapTailSecret_NormalMatch(t *testing.T) {
+	srv := &server{scanners: defaultOutputScanners()}
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
+		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
+		OutputRules: []config.OutputPolicyRule{{
+			ID:       "out-secret-under-cap",
+			Decision: "quarantine",
+			Match: config.OutputPolicyMatch{
+				Topics:   []string{"job.*"},
+				Scanners: []string{"secret"},
+			},
+		}},
+	}, "snap-under-cap")
+
+	content := make([]byte, maxOutputScanBytes-128)
+	for i := range content {
+		content[i] = 'x'
+	}
+	copy(content[len(content)-64:], []byte(testAWSAccessKeyID))
+	resp, err := srv.CheckOutput(context.Background(), &pb.OutputCheckRequest{
+		JobId:         "job-under-cap",
+		Topic:         "job.default",
+		Tenant:        "default",
+		OutputContent: content,
+	})
+	if err != nil {
+		t.Fatalf("check output: %v", err)
+	}
+	if resp.GetDecision() != pb.OutputDecision_OUTPUT_DECISION_QUARANTINE {
+		t.Fatalf("expected under-cap tail secret to match normally, got %v: %#v", resp.GetDecision(), resp)
+	}
+	if hasProtoOutputFinding(resp.GetFindings(), "content_truncated", "high") {
+		t.Fatalf("under-cap content must not report truncation, got %#v", resp.GetFindings())
+	}
+}
+
+func TestCheckOutput_TruncatedNonSensitiveRules_Unchanged(t *testing.T) {
+	srv := &server{scanners: defaultOutputScanners()}
+	_ = srv.setPolicy(context.Background(), &config.SafetyPolicy{
+		OutputPolicy: config.OutputPolicyConfig{Enabled: true, FailMode: "open"},
+		OutputRules: []config.OutputPolicyRule{{
+			ID:       "out-keyword-only",
+			Decision: "quarantine",
+			Match: config.OutputPolicyMatch{
+				Topics:   []string{"job.*"},
+				Keywords: []string{"nonexistent-keyword"},
+			},
+		}},
+	}, "snap-keyword-only")
+
+	resp, err := srv.CheckOutput(context.Background(), &pb.OutputCheckRequest{
+		JobId:         "job-keyword-only",
+		Topic:         "job.default",
+		Tenant:        "default",
+		OutputContent: makeBigContentWithSecret(maxOutputScanBytes + 32),
+	})
+	if err != nil {
+		t.Fatalf("check output: %v", err)
+	}
+	if resp.GetDecision() != pb.OutputDecision_OUTPUT_DECISION_ALLOW {
+		t.Fatalf("expected non-sensitive truncated no-match to stay allow, got %v: %#v", resp.GetDecision(), resp)
 	}
 }
 

--- a/docs/output-policy.md
+++ b/docs/output-policy.md
@@ -218,6 +218,24 @@ Built-in scanner implementations currently live in `core/controlplane/safetykern
 | `code_injection` / `injection` | Injection and exploit fragments | SQL (`union select`, `drop table`), shell (`rm -rf`, `curl|sh`), prompt injection phrases | `high`, `medium` |
 | `max_output_bytes` rule match | Oversized output | metadata size threshold | policy-defined |
 
+### 6.1 Scan-size limit and truncation fail-mode
+
+Safety Kernel scans at most 2 MiB of output content per evaluation (`maxOutputScanBytes`). This keeps regex and scanner work bounded, but it also means content beyond the cap is not inspected.
+
+When secret/PII/injection-class scanners are enabled, truncated output now fails closed:
+
+- oversized output with no scanner hit in the scanned head is `QUARANTINE` instead of `ALLOW`
+- `REDACT` decisions on truncated output escalate to `QUARANTINE` because redaction only covers the scanned head, not the unscanned tail
+- the response includes a high-severity `content_truncated` finding from `size_check`
+
+Outputs governed only by non-sensitive rules, such as keyword/topic rules without secret, PII, or injection scanners, keep the previous partial-scan behavior.
+
+Operator remediation:
+
+- keep sensitive job outputs below the 2 MiB scan cap when they must be released automatically
+- write large results as bounded artifacts or result pointers whose inspected payload stays below the cap
+- use an output-size rule such as the default `output-size-limit` entry in [3.4 Default rule set](#34-default-rule-set-in-configsafetyyaml) to quarantine large outputs deliberately before operators need to reason about partial scans
+
 ## 7. Scanner Pattern Definitions (`config/output_scanners.yaml`)
 
 Cordum ships scanner definitions in `config/output_scanners.yaml`. Safety Kernel loads this file at startup and falls back to built-in scanners if parsing fails.


### PR DESCRIPTION
## Summary

Fixes CRD-4 / task-5f641afe: output safety scanning truncated content to the first 2 MiB, then allowed no-match results even when secret/PII/injection scanners were enabled. A padded output could place a secret after the scan boundary and get `ALLOW`.

This PR adds a fail-closed invariant in both output-safety entrypoints:

- if scanned content was truncated and the active output policy includes sensitive scanners (`secret`, `pii`, `injection`, `prompt_injection`), no-match results now return `QUARANTINE` with high-severity `content_truncated`
- if a truncated output matches an `ALLOW`/`REDACT` sensitive-scanner rule, the decision escalates to `QUARANTINE`
- `REDACT` escalates because redaction only covers the scanned head; the unscanned tail may still contain sensitive content
- non-sensitive keyword/topic-only rules keep the previous partial-scan behavior

## Dependency / base

Stacked on CRD-3 (`task-74a83bec`, PR #335, branch `moe/epic-c631a548/task-74a83bec`) because CRD-3 changed the same `CheckOutput` path. This PR is intentionally based on that branch so the diff is CRD-4-only.

## Operator impact

Legitimate producers emitting >2 MiB outputs while sensitive scanners are enabled can now quarantine instead of partially scanning and allowing. This is deliberate fail-safe behavior. Operator docs were updated in `docs/output-policy.md` under `Scan-size limit and truncation fail-mode` with remediation guidance:

- keep sensitive outputs under 2 MiB when they must be released automatically
- use bounded artifacts/result pointers
- use output-size rules such as the default `output-size-limit` to quarantine large output deliberately

## Test evidence

| Gate | Result |
| --- | --- |
| RED pre-fix targeted tests | EXIT=1; tail CheckOutput got `ALLOW`, tail EvaluateOutput got `allow`, head REDACT got `OUTPUT_DECISION_REDACT` |
| Targeted tests after fix | EXIT=0; `ok github.com/cordum/cordum/core/controlplane/safetykernel 1.958s` |
| `go test -count=3 ./core/controlplane/safetykernel/` | EXIT=0; `ok github.com/cordum/cordum/core/controlplane/safetykernel 16.560s` |
| `go vet ./core/controlplane/safetykernel/...` | EXIT=0; no output |
| `go build ./...` | EXIT=0; no output |

## Notes

Dashboard verification rail: N/A — no `cordum/dashboard/` files touched.