### PR TITLE
[bug] scheduler: route critical-section state writes through the lock-fence context (CRD-14, task-7754adfb)

### DIFF
--- a/core/controlplane/scheduler/engine.go
+++ b/core/controlplane/scheduler/engine.go
@@ -1227,7 +1227,8 @@ func (e *Engine) handleJobRequest(req *pb.JobRequest, traceID string) error {
 			"job_id", safeJobID(req),
 			"topic", safeTopic(req),
 		)
-		if err := e.setJobState(jobID, JobStateFailed); err != nil {
+		// Outside any job lock — engine lifecycle context is the right bound.
+		if err := e.setJobState(e.ctx, jobID, JobStateFailed); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateFailed, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1309,7 +1310,7 @@ func (e *Engine) handleJobRequest(req *pb.JobRequest, traceID string) error {
 
 		switch currentState {
 		case "":
-			if err := e.setJobState(jobID, JobStatePending); err != nil {
+			if err := e.setJobState(lockCtx, jobID, JobStatePending); err != nil {
 				return RetryAfter(err, retryDelayStore)
 			}
 		case JobStateScheduled:
@@ -1383,7 +1384,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			"job_id", safeJobID(req),
 			"topic", safeTopic(req),
 		)
-		if err := e.setJobState(safeJobID(req), JobStateFailed); err != nil {
+		if err := e.setJobState(lockCtx, safeJobID(req), JobStateFailed); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", safeJobID(req), "target_state", JobStateFailed, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1403,7 +1404,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			"topic", topic,
 			"trace_id", traceID,
 		)
-		if err := e.setJobState(jobID, JobStateFailed); err != nil {
+		if err := e.setJobState(lockCtx, jobID, JobStateFailed); err != nil {
 			return RetryAfter(err, retryDelayStore)
 		}
 		e.incJobsCompleted(topic, pb.JobStatus_JOB_STATUS_FAILED.String())
@@ -1445,7 +1446,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 	if attempts >= maxSchedulingRetries {
 		reason := fmt.Sprintf("max scheduling retries exceeded (attempts=%d)", attempts)
 		slog.Warn("giving up on job", "job_id", jobID, "topic", topic, "attempts", attempts)
-		if err := e.setJobState(jobID, JobStateFailed); err != nil {
+		if err := e.setJobState(lockCtx, jobID, JobStateFailed); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateFailed, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1487,7 +1488,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			}
 			cancel()
 		}
-		if err := e.setJobState(jobID, JobStateFailed); err != nil {
+		if err := e.setJobState(lockCtx, jobID, JobStateFailed); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateFailed, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1541,7 +1542,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 					return RetryAfter(err, retryDelayPublish)
 				}
 			}
-			if err := e.setJobState(jobID, JobStateSucceeded); err != nil {
+			if err := e.setJobState(lockCtx, jobID, JobStateSucceeded); err != nil {
 				return RetryAfter(err, retryDelayStore)
 			}
 			return nil
@@ -1600,7 +1601,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			"reason", record.Reason,
 			"trace_id", traceID,
 		)
-		if err := e.setJobState(jobID, JobStateApproval); err != nil {
+		if err := e.setJobState(lockCtx, jobID, JobStateApproval); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateApproval, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1612,7 +1613,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			"reason", record.Reason,
 			"trace_id", traceID,
 		)
-		if err := e.setJobState(jobID, JobStateDenied); err != nil {
+		if err := e.setJobState(lockCtx, jobID, JobStateDenied); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateDenied, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1629,7 +1630,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			"reason", record.Reason,
 			"trace_id", traceID,
 		)
-		if err := e.setJobState(jobID, JobStateDenied); err != nil {
+		if err := e.setJobState(lockCtx, jobID, JobStateDenied); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateDenied, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1661,7 +1662,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 		}
 		if attempts >= allowedAttempts {
 			reason := fmt.Sprintf("max retries exceeded (attempts=%d, max_retries=%d)", attempts, maxRetries)
-			if err := e.setJobState(jobID, JobStateFailed); err != nil {
+			if err := e.setJobState(lockCtx, jobID, JobStateFailed); err != nil {
 				slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateFailed, "error", err)
 				return RetryAfter(err, retryDelayStore)
 			}
@@ -1800,7 +1801,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			return RetryAfter(err, backoffDelay(attempts, backoffBase, backoffMax))
 		}
 		dispatchErr := err // capture before setJobState shadows err
-		if err := e.setJobState(jobID, JobStateFailed); err != nil {
+		if err := e.setJobState(lockCtx, jobID, JobStateFailed); err != nil {
 			slog.Error("state transition failed, retrying", "job_id", jobID, "target_state", JobStateFailed, "error", err)
 			return RetryAfter(err, retryDelayStore)
 		}
@@ -1812,7 +1813,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 		return nil
 	}
 
-	if err := e.setJobState(jobID, JobStateScheduled); err != nil {
+	if err := e.setJobState(lockCtx, jobID, JobStateScheduled); err != nil {
 		return RetryAfter(err, retryDelayStore)
 	}
 
@@ -1822,7 +1823,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 
 	// Set DISPATCHED state BEFORE publishing to NATS to prevent duplicate
 	// dispatch on redelivery. If publish fails, we roll back to SCHEDULED.
-	if err := e.setJobState(jobID, JobStateDispatched); err != nil {
+	if err := e.setJobState(lockCtx, jobID, JobStateDispatched); err != nil {
 		return RetryAfter(err, retryDelayStore)
 	}
 
@@ -1843,7 +1844,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 			"subject", subject,
 			"error", err,
 		)
-		if rbErr := e.setJobState(jobID, JobStateScheduled); rbErr != nil {
+		if rbErr := e.setJobState(lockCtx, jobID, JobStateScheduled); rbErr != nil {
 			slog.Error("dispatch rollback failed",
 				"job_id", jobID, "error", rbErr)
 		}
@@ -1857,7 +1858,7 @@ func (e *Engine) processJob(lockCtx context.Context, req *pb.JobRequest, traceID
 	if e.metrics != nil {
 		e.metrics.ObserveDispatchLatency(topic, time.Since(dispatchStart).Seconds())
 	}
-	if err := e.setJobState(jobID, JobStateRunning); err != nil {
+	if err := e.setJobState(lockCtx, jobID, JobStateRunning); err != nil {
 		return RetryAfter(err, retryDelayStore)
 	}
 	return nil
@@ -1934,26 +1935,26 @@ func (e *Engine) applySubmitSchemaValidation(ctx context.Context, req *pb.JobReq
 		return false, RetryAfter(err, retryDelayStore)
 	}
 	if len(violations) > 0 {
-		return e.handleSchemaViolations(req, traceID, schemaID, mode, violations)
+		return e.handleSchemaViolations(ctx, req, traceID, schemaID, mode, violations)
 	}
 	if e.schemaRegistry == nil {
-		return e.failSchemaValidation(req, traceID, schemaID, "schema registry unavailable", "schema_registry_unavailable")
+		return e.failSchemaValidation(ctx, req, traceID, schemaID, "schema registry unavailable", "schema_registry_unavailable")
 	}
 	schemaJSON, err := e.schemaRegistry.Get(ctx, schemaID)
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
-			return e.failSchemaValidation(req, traceID, schemaID, "topic input schema not found", "schema_not_found")
+			return e.failSchemaValidation(ctx, req, traceID, schemaID, "topic input schema not found", "schema_not_found")
 		}
 		return false, RetryAfter(err, retryDelayStore)
 	}
 	violations, err = infraSchema.ValidateJSONPayload(ctx, e.schemaRegistry, schemaID, schemaJSON, payloadJSON)
 	if err != nil {
-		return e.failSchemaValidation(req, traceID, schemaID, "topic input schema invalid", "schema_invalid")
+		return e.failSchemaValidation(ctx, req, traceID, schemaID, "topic input schema invalid", "schema_invalid")
 	}
 	if len(violations) == 0 {
 		return false, nil
 	}
-	return e.handleSchemaViolations(req, traceID, schemaID, mode, violations)
+	return e.handleSchemaViolations(ctx, req, traceID, schemaID, mode, violations)
 }
 
 func (e *Engine) loadSubmitValidationPayload(ctx context.Context, req *pb.JobRequest) ([]byte, []infraSchema.Violation, error) {
@@ -1981,7 +1982,7 @@ func (e *Engine) loadSubmitValidationPayload(ctx context.Context, req *pb.JobReq
 	return data, nil, nil
 }
 
-func (e *Engine) handleSchemaViolations(req *pb.JobRequest, traceID, schemaID string, mode infraSchema.EnforcementMode, violations []infraSchema.Violation) (bool, error) {
+func (e *Engine) handleSchemaViolations(ctx context.Context, req *pb.JobRequest, traceID, schemaID string, mode infraSchema.EnforcementMode, violations []infraSchema.Violation) (bool, error) {
 	if len(violations) == 0 {
 		return false, nil
 	}
@@ -1995,7 +1996,7 @@ func (e *Engine) handleSchemaViolations(req *pb.JobRequest, traceID, schemaID st
 			"trace_id", traceID,
 			"violations", violations,
 		)
-		if err := e.setJobState(jobID, JobStateFailed); err != nil {
+		if err := e.setJobState(ctx, jobID, JobStateFailed); err != nil {
 			return false, RetryAfter(err, retryDelayStore)
 		}
 		e.incJobsCompleted(topic, pb.JobStatus_JOB_STATUS_FAILED.String())
@@ -2015,7 +2016,7 @@ func (e *Engine) handleSchemaViolations(req *pb.JobRequest, traceID, schemaID st
 	return false, nil
 }
 
-func (e *Engine) failSchemaValidation(req *pb.JobRequest, traceID, schemaID, reason, reasonCode string) (bool, error) {
+func (e *Engine) failSchemaValidation(ctx context.Context, req *pb.JobRequest, traceID, schemaID, reason, reasonCode string) (bool, error) {
 	jobID := strings.TrimSpace(req.GetJobId())
 	topic := strings.TrimSpace(req.GetTopic())
 	slog.Error("schema validation unavailable for job request",
@@ -2025,7 +2026,7 @@ func (e *Engine) failSchemaValidation(req *pb.JobRequest, traceID, schemaID, rea
 		"trace_id", traceID,
 		"reason", reason,
 	)
-	if err := e.setJobState(jobID, JobStateFailed); err != nil {
+	if err := e.setJobState(ctx, jobID, JobStateFailed); err != nil {
 		return false, RetryAfter(err, retryDelayStore)
 	}
 	e.incJobsCompleted(topic, pb.JobStatus_JOB_STATUS_FAILED.String())
@@ -2348,7 +2349,7 @@ func (e *Engine) handleJobResult(res *pb.JobResult) error {
 		var outputRecord OutputSafetyRecord
 		if succeeded {
 			persistOutputRecord := false
-			outputRecord = e.checkOutputSafety(jobID, topic, res, jobReq)
+			outputRecord = e.checkOutputSafety(lockCtx, jobID, topic, res, jobReq)
 			switch outputRecord.Decision {
 			case OutputQuarantine, OutputDeny:
 				state = JobStateQuarantined
@@ -2376,7 +2377,7 @@ func (e *Engine) handleJobResult(res *pb.JobResult) error {
 				}
 			}
 			if persistOutputRecord {
-				e.persistOutputSafety(jobID, outputRecord)
+				e.persistOutputSafety(lockCtx, jobID, outputRecord)
 			}
 		}
 
@@ -2386,16 +2387,16 @@ func (e *Engine) handleJobResult(res *pb.JobResult) error {
 		// (terminal-state check at the top of handleJobResult) blocks
 		// reprocessing, permanently orphaning the result data.
 		if res.ResultPtr != "" {
-			if err := e.setResultPtr(jobID, res.ResultPtr); err != nil {
+			if err := e.setResultPtr(lockCtx, jobID, res.ResultPtr); err != nil {
 				e.incResultPtrWriteFailure()
 				slog.Error("result ptr write failed, keeping job in current state for retry",
 					"job_id", jobID, "result_ptr", res.ResultPtr, "error", err)
 				return RetryAfter(err, retryDelayStore)
 			}
 		}
-		e.setWorkerID(jobID, strings.TrimSpace(res.GetWorkerId()))
-		e.setAgentInfoFromWorker(jobID, strings.TrimSpace(res.GetWorkerId()))
-		if err := e.setJobState(jobID, state); err != nil {
+		e.setWorkerID(lockCtx, jobID, strings.TrimSpace(res.GetWorkerId()))
+		e.setAgentInfoFromWorker(lockCtx, jobID, strings.TrimSpace(res.GetWorkerId()))
+		if err := e.setJobState(lockCtx, jobID, state); err != nil {
 			return RetryAfter(err, retryDelayStore)
 		}
 		if succeeded && e.outputSafetyEnabled.Load() && e.outputSafety != nil && jobReq != nil {
@@ -2427,7 +2428,7 @@ func (e *Engine) handleJobResult(res *pb.JobResult) error {
 	})
 }
 
-func (e *Engine) checkOutputSafety(jobID, topic string, res *pb.JobResult, req *pb.JobRequest) OutputSafetyRecord {
+func (e *Engine) checkOutputSafety(ctx context.Context, jobID, topic string, res *pb.JobResult, req *pb.JobRequest) OutputSafetyRecord {
 	record := OutputSafetyRecord{
 		Decision:    OutputAllow,
 		Phase:       "sync",
@@ -2495,7 +2496,7 @@ func (e *Engine) checkOutputSafety(jobID, topic string, res *pb.JobResult, req *
 	if record.Decision == OutputRedact {
 		e.incOutputRedactions(topic)
 	}
-	e.persistOutputSafety(jobID, record)
+	e.persistOutputSafety(ctx, jobID, record)
 	return record
 }
 
@@ -2533,7 +2534,10 @@ func (e *Engine) startAsyncOutputCheck(jobID, topic string, res *pb.JobResult, r
 					CheckedAt:   time.Now().UTC().UnixNano() / int64(time.Microsecond),
 					OriginalPtr: strings.TrimSpace(resCopy.GetResultPtr()),
 				}
-				e.persistOutputSafety(jobID, qRecord)
+				// The goroutine's own ctx is already cancelled by its deferred
+				// cancel when this recover path runs — use the engine lifecycle
+				// context (no lock is held here).
+				e.persistOutputSafety(e.ctx, jobID, qRecord)
 				e.incOutputPolicyQuarantined(topic)
 				e.incOutputDenials(topic)
 				// Best-effort quarantine state transition.
@@ -2596,7 +2600,7 @@ func (e *Engine) startAsyncOutputCheck(jobID, topic string, res *pb.JobResult, r
 		if record.OriginalPtr == "" {
 			record.OriginalPtr = strings.TrimSpace(resCopy.GetResultPtr())
 		}
-		e.persistOutputSafety(jobID, record)
+		e.persistOutputSafety(ctx, jobID, record)
 
 		if record.Decision == OutputRedact {
 			e.incOutputRedactions(topic)
@@ -2631,7 +2635,7 @@ func (e *Engine) startAsyncOutputCheck(jobID, topic string, res *pb.JobResult, r
 						}
 					}
 				}
-				if err := e.setJobState(jobID, JobStateQuarantined); err != nil {
+				if err := e.setJobState(lockCtx, jobID, JobStateQuarantined); err != nil {
 					return err
 				}
 				e.emitOutputAuditEvent(jobID, topic, outputPolicyAsync, reason, record.Decision)
@@ -2726,22 +2730,27 @@ func (e *Engine) materializeRedaction(jobID, topic string, res *pb.JobResult, re
 	return record
 }
 
-func (e *Engine) persistOutputSafety(jobID string, record OutputSafetyRecord) {
+// persistOutputSafety and the state helpers below accept the caller's
+// context as their first parameter and derive the store-op timeout from it.
+// Inside withJobLock critical sections callers MUST pass the fenced lockCtx
+// so writes stop once lock ownership is lost (see withJobLock); callers
+// outside any lock pass e.ctx (or their own lifecycle context) explicitly.
+func (e *Engine) persistOutputSafety(ctx context.Context, jobID string, record OutputSafetyRecord) {
 	if jobID == "" || e.jobStore == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, storeOpTimeout)
 	defer cancel()
 	if err := e.jobStore.SetOutputDecision(ctx, jobID, record); err != nil {
 		slog.Error("persist output safety failed", "job_id", jobID, "error", err)
 	}
 }
 
-func (e *Engine) setJobState(jobID string, state JobState) error {
+func (e *Engine) setJobState(ctx context.Context, jobID string, state JobState) error {
 	if e.jobStore == nil || jobID == "" {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, storeOpTimeout)
 	defer cancel()
 	if err := e.jobStore.SetState(ctx, jobID, state); err != nil {
 		slog.Error("failed to set job state", "job_id", jobID, "state", state, "error", err)
@@ -2751,11 +2760,11 @@ func (e *Engine) setJobState(jobID string, state JobState) error {
 	return nil
 }
 
-func (e *Engine) setResultPtr(jobID, ptr string) error {
+func (e *Engine) setResultPtr(ctx context.Context, jobID, ptr string) error {
 	if e.jobStore == nil || jobID == "" {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, storeOpTimeout)
 	defer cancel()
 	if err := e.jobStore.SetResultPtr(ctx, jobID, ptr); err != nil {
 		slog.Error("failed to persist result ptr", "job_id", jobID, "error", err)
@@ -2764,11 +2773,11 @@ func (e *Engine) setResultPtr(jobID, ptr string) error {
 	return nil
 }
 
-func (e *Engine) setWorkerID(jobID, workerID string) {
+func (e *Engine) setWorkerID(ctx context.Context, jobID, workerID string) {
 	if e.jobStore == nil || jobID == "" || workerID == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, storeOpTimeout)
 	defer cancel()
 	if err := e.jobStore.SetWorkerID(ctx, jobID, workerID); err != nil {
 		slog.Warn("worker_id write failed", "job_id", jobID, "worker_id", workerID, "error", err)
@@ -2778,11 +2787,11 @@ func (e *Engine) setWorkerID(jobID, workerID string) {
 // setAgentInfoFromWorker resolves the worker's agent identity and persists it
 // in job metadata for audit events. Uses the cached AgentResolver to avoid
 // per-job Redis lookups.
-func (e *Engine) setAgentInfoFromWorker(jobID, workerID string) {
+func (e *Engine) setAgentInfoFromWorker(ctx context.Context, jobID, workerID string) {
 	if e.agentResolver == nil || e.jobStore == nil || jobID == "" || workerID == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(e.ctx, storeOpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, storeOpTimeout)
 	defer cancel()
 	info := e.agentResolver.Resolve(ctx, workerID)
 	if store, ok := e.jobStore.(interface {

--- a/core/controlplane/scheduler/engine_audit_test.go
+++ b/core/controlplane/scheduler/engine_audit_test.go
@@ -26,7 +26,7 @@ func TestScheduler_FailedRetryableDoesNotSilentlyDrop(t *testing.T) {
 
 	// Seed prior dispatch state (the path the job took on its first attempt).
 	jobID := "job-retryable-not-terminal"
-	if err := engine.setJobState(jobID, JobStateRunning); err != nil {
+	if err := engine.setJobState(context.Background(), jobID, JobStateRunning); err != nil {
 		t.Fatalf("seed Running: %v", err)
 	}
 

--- a/core/controlplane/scheduler/engine_consistency_test.go
+++ b/core/controlplane/scheduler/engine_consistency_test.go
@@ -705,7 +705,7 @@ func TestSetStateTransitionValidation(t *testing.T) {
 
 	jobID := "job-transition"
 	for _, state := range transitions {
-		err := engine.setJobState(jobID, state)
+		err := engine.setJobState(context.Background(), jobID, state)
 		assert.NoError(t, err, "transition to %s should succeed", state)
 	}
 

--- a/core/controlplane/scheduler/engine_hardening_test.go
+++ b/core/controlplane/scheduler/engine_hardening_test.go
@@ -741,7 +741,13 @@ func TestLockFence_StateHelpersHonorFence(t *testing.T) {
 
 	err := engine.withJobLock(jobID, ttl, func(lockCtx context.Context) error {
 		// Wait for the fence to drop (renewal abandonment cancels lockCtx).
-		<-lockCtx.Done()
+		// Bounded so a regression in abandonment signaling fails the test
+		// fast instead of hanging the suite until the global timeout.
+		select {
+		case <-lockCtx.Done():
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for lock fence cancellation")
+		}
 
 		// Post-abandonment store writes via the state helpers. All of them
 		// must derive from the fenced context and therefore be rejected.

--- a/core/controlplane/scheduler/engine_hardening_test.go
+++ b/core/controlplane/scheduler/engine_hardening_test.go
@@ -677,6 +677,18 @@ type fenceRecordingStore struct {
 
 	obsMu  sync.Mutex
 	writes []fenceWrite
+
+	agentMu   sync.Mutex
+	agentInfo map[string]fenceAgentInfo
+}
+
+// fenceAgentInfo captures a persisted SetAgentInfo write for the live-fence
+// assertion. fakeJobStore has no agent-info storage of its own, so the test
+// double records it here.
+type fenceAgentInfo struct {
+	agentID  string
+	name     string
+	riskTier string
 }
 
 func (s *fenceRecordingStore) RenewLock(ctx context.Context, key, token string, ttl time.Duration) error {
@@ -727,6 +739,30 @@ func (s *fenceRecordingStore) SetOutputDecision(ctx context.Context, jobID strin
 	return s.fakeJobStore.SetOutputDecision(ctx, jobID, record)
 }
 
+// SetAgentInfo satisfies the optional interface that setAgentInfoFromWorker
+// type-asserts against. fakeJobStore does not implement it, so the helper would
+// otherwise skip the store write entirely and escape the fence regression
+// matrix. Recording it here covers the fifth CRD-14 write helper.
+func (s *fenceRecordingStore) SetAgentInfo(ctx context.Context, jobID, agentID, name, riskTier string) error {
+	if err := s.observe("SetAgentInfo", ctx); err != nil {
+		return err
+	}
+	s.agentMu.Lock()
+	if s.agentInfo == nil {
+		s.agentInfo = make(map[string]fenceAgentInfo)
+	}
+	s.agentInfo[jobID] = fenceAgentInfo{agentID: agentID, name: name, riskTier: riskTier}
+	s.agentMu.Unlock()
+	return nil
+}
+
+func (s *fenceRecordingStore) agentInfoFor(jobID string) (fenceAgentInfo, bool) {
+	s.agentMu.Lock()
+	defer s.agentMu.Unlock()
+	info, ok := s.agentInfo[jobID]
+	return info, ok
+}
+
 // TestLockFence_StateHelpersHonorFence is the CRD-14 regression test: once
 // lock renewal is abandoned and the fence context is cancelled, the engine
 // state helpers must not perform store writes with a live context. If a
@@ -734,7 +770,8 @@ func (s *fenceRecordingStore) SetOutputDecision(ctx context.Context, jobID strin
 // write succeeds after lock loss and this test fails.
 func TestLockFence_StateHelpersHonorFence(t *testing.T) {
 	store := &fenceRecordingStore{fakeJobStore: newFakeJobStore(), failRenew: true}
-	engine := NewEngine(&fakeBus{}, NewSafetyBasic(), newTestRegistry(t), NewNaiveStrategy(), store, nil)
+	engine := NewEngine(&fakeBus{}, NewSafetyBasic(), newTestRegistry(t), NewNaiveStrategy(), store, nil).
+		WithAgentResolver(NewAgentResolver(nil, nil))
 
 	const jobID = "job-fence-helpers"
 	ttl := 150 * time.Millisecond // renewal every 50ms; abandoned on 3rd failure
@@ -755,6 +792,7 @@ func TestLockFence_StateHelpersHonorFence(t *testing.T) {
 		_ = engine.setResultPtr(lockCtx, jobID, "res:fence")
 		engine.setWorkerID(lockCtx, jobID, "worker-fence")
 		engine.persistOutputSafety(lockCtx, jobID, OutputSafetyRecord{Decision: OutputQuarantine})
+		engine.setAgentInfoFromWorker(lockCtx, jobID, "worker-fence")
 		return nil
 	})
 	if !errors.Is(err, errLockAbandoned) {
@@ -762,8 +800,8 @@ func TestLockFence_StateHelpersHonorFence(t *testing.T) {
 	}
 
 	obs := store.observations()
-	if len(obs) != 4 {
-		t.Fatalf("expected 4 write attempts, got %d: %+v", len(obs), obs)
+	if len(obs) != 5 {
+		t.Fatalf("expected 5 write attempts, got %d: %+v", len(obs), obs)
 	}
 	for _, w := range obs {
 		if w.ctxErr == nil {
@@ -790,6 +828,9 @@ func TestLockFence_StateHelpersHonorFence(t *testing.T) {
 	if outputWritten {
 		t.Error("output safety record was persisted after lock abandonment")
 	}
+	if _, agentWritten := store.agentInfoFor(jobID); agentWritten {
+		t.Error("agent info was persisted after lock abandonment")
+	}
 }
 
 // TestLockFence_StateHelpersWorkWithLiveFence guards against over-rotation:
@@ -797,7 +838,8 @@ func TestLockFence_StateHelpersHonorFence(t *testing.T) {
 // (no false fail-closed behavior on the happy path).
 func TestLockFence_StateHelpersWorkWithLiveFence(t *testing.T) {
 	store := &fenceRecordingStore{fakeJobStore: newFakeJobStore(), failRenew: false}
-	engine := NewEngine(&fakeBus{}, NewSafetyBasic(), newTestRegistry(t), NewNaiveStrategy(), store, nil)
+	engine := NewEngine(&fakeBus{}, NewSafetyBasic(), newTestRegistry(t), NewNaiveStrategy(), store, nil).
+		WithAgentResolver(NewAgentResolver(nil, nil))
 
 	const jobID = "job-fence-live"
 	err := engine.withJobLock(jobID, jobLockTTL, func(lockCtx context.Context) error {
@@ -809,6 +851,7 @@ func TestLockFence_StateHelpersWorkWithLiveFence(t *testing.T) {
 		}
 		engine.setWorkerID(lockCtx, jobID, "worker-live")
 		engine.persistOutputSafety(lockCtx, jobID, OutputSafetyRecord{Decision: OutputAllow})
+		engine.setAgentInfoFromWorker(lockCtx, jobID, "worker-live")
 		return nil
 	})
 	if err != nil {
@@ -816,8 +859,8 @@ func TestLockFence_StateHelpersWorkWithLiveFence(t *testing.T) {
 	}
 
 	obs := store.observations()
-	if len(obs) != 4 {
-		t.Fatalf("expected 4 write attempts, got %d: %+v", len(obs), obs)
+	if len(obs) != 5 {
+		t.Fatalf("expected 5 write attempts, got %d: %+v", len(obs), obs)
 	}
 	for _, w := range obs {
 		if w.ctxErr != nil {
@@ -838,5 +881,14 @@ func TestLockFence_StateHelpersWorkWithLiveFence(t *testing.T) {
 	}
 	if !outputWritten || rec.Decision != OutputAllow {
 		t.Errorf("output record = %+v (written=%v), want Decision=%q", rec, outputWritten, OutputAllow)
+	}
+
+	// The bare AgentResolver resolves any worker to the "unlinked" sentinel,
+	// so the write should land with that identity under a healthy fence.
+	agent, agentWritten := store.agentInfoFor(jobID)
+	if !agentWritten {
+		t.Error("agent info was not persisted under a healthy fence")
+	} else if agent.agentID != agentCacheUnlinked {
+		t.Errorf("agent id = %q, want %q", agent.agentID, agentCacheUnlinked)
 	}
 }

--- a/core/controlplane/scheduler/engine_hardening_test.go
+++ b/core/controlplane/scheduler/engine_hardening_test.go
@@ -655,3 +655,182 @@ func TestActiveRenewals_ReturnsToZeroAfterLock(t *testing.T) {
 		t.Fatalf("expected 0 active renewals after lock release, got %d", got)
 	}
 }
+
+// ---- lock-fence state-helper tests (CRD-14) ----
+
+// fenceWrite records one store write attempt: which operation ran, and the
+// state of the supplied context at call time.
+type fenceWrite struct {
+	op     string
+	ctxErr error
+	cause  error
+}
+
+// fenceRecordingStore wraps fakeJobStore with context-aware write methods:
+// like the real Redis-backed store, every write fails when its context is
+// already cancelled. Each write attempt records ctx.Err() and context.Cause
+// observed at call time. RenewLock always fails when failRenew is set,
+// driving withJobLock into lock abandonment.
+type fenceRecordingStore struct {
+	*fakeJobStore
+	failRenew bool
+
+	obsMu  sync.Mutex
+	writes []fenceWrite
+}
+
+func (s *fenceRecordingStore) RenewLock(ctx context.Context, key, token string, ttl time.Duration) error {
+	if s.failRenew {
+		return errors.New("redis connection refused")
+	}
+	return s.fakeJobStore.RenewLock(ctx, key, token, ttl)
+}
+
+func (s *fenceRecordingStore) observe(op string, ctx context.Context) error {
+	s.obsMu.Lock()
+	s.writes = append(s.writes, fenceWrite{op: op, ctxErr: ctx.Err(), cause: context.Cause(ctx)})
+	s.obsMu.Unlock()
+	return ctx.Err()
+}
+
+func (s *fenceRecordingStore) observations() []fenceWrite {
+	s.obsMu.Lock()
+	defer s.obsMu.Unlock()
+	return append([]fenceWrite(nil), s.writes...)
+}
+
+func (s *fenceRecordingStore) SetState(ctx context.Context, jobID string, state JobState) error {
+	if err := s.observe("SetState", ctx); err != nil {
+		return err
+	}
+	return s.fakeJobStore.SetState(ctx, jobID, state)
+}
+
+func (s *fenceRecordingStore) SetResultPtr(ctx context.Context, jobID, ptr string) error {
+	if err := s.observe("SetResultPtr", ctx); err != nil {
+		return err
+	}
+	return s.fakeJobStore.SetResultPtr(ctx, jobID, ptr)
+}
+
+func (s *fenceRecordingStore) SetWorkerID(ctx context.Context, jobID, workerID string) error {
+	if err := s.observe("SetWorkerID", ctx); err != nil {
+		return err
+	}
+	return s.fakeJobStore.SetWorkerID(ctx, jobID, workerID)
+}
+
+func (s *fenceRecordingStore) SetOutputDecision(ctx context.Context, jobID string, record OutputSafetyRecord) error {
+	if err := s.observe("SetOutputDecision", ctx); err != nil {
+		return err
+	}
+	return s.fakeJobStore.SetOutputDecision(ctx, jobID, record)
+}
+
+// TestLockFence_StateHelpersHonorFence is the CRD-14 regression test: once
+// lock renewal is abandoned and the fence context is cancelled, the engine
+// state helpers must not perform store writes with a live context. If a
+// helper derives its timeout from e.ctx instead of the fenced lockCtx, the
+// write succeeds after lock loss and this test fails.
+func TestLockFence_StateHelpersHonorFence(t *testing.T) {
+	store := &fenceRecordingStore{fakeJobStore: newFakeJobStore(), failRenew: true}
+	engine := NewEngine(&fakeBus{}, NewSafetyBasic(), newTestRegistry(t), NewNaiveStrategy(), store, nil)
+
+	const jobID = "job-fence-helpers"
+	ttl := 150 * time.Millisecond // renewal every 50ms; abandoned on 3rd failure
+
+	err := engine.withJobLock(jobID, ttl, func(lockCtx context.Context) error {
+		// Wait for the fence to drop (renewal abandonment cancels lockCtx).
+		<-lockCtx.Done()
+
+		// Post-abandonment store writes via the state helpers. All of them
+		// must derive from the fenced context and therefore be rejected.
+		_ = engine.setJobState(lockCtx, jobID, JobStateFailed)
+		_ = engine.setResultPtr(lockCtx, jobID, "res:fence")
+		engine.setWorkerID(lockCtx, jobID, "worker-fence")
+		engine.persistOutputSafety(lockCtx, jobID, OutputSafetyRecord{Decision: OutputQuarantine})
+		return nil
+	})
+	if !errors.Is(err, errLockAbandoned) {
+		t.Fatalf("expected errLockAbandoned, got: %v", err)
+	}
+
+	obs := store.observations()
+	if len(obs) != 4 {
+		t.Fatalf("expected 4 write attempts, got %d: %+v", len(obs), obs)
+	}
+	for _, w := range obs {
+		if w.ctxErr == nil {
+			t.Errorf("%s: store write attempted with a LIVE context after lock abandonment; helpers must derive from the cancelled fence context", w.op)
+			continue
+		}
+		if !errors.Is(w.cause, errLockAbandoned) {
+			t.Errorf("%s: cancellation cause = %v, want errLockAbandoned", w.op, w.cause)
+		}
+	}
+
+	// Nothing may have landed in the underlying store after lock loss.
+	store.mu.RLock()
+	_, stateWritten := store.states[jobID]
+	ptr := store.ptrs[jobID]
+	_, outputWritten := store.output[jobID]
+	store.mu.RUnlock()
+	if stateWritten {
+		t.Error("job state was persisted after lock abandonment")
+	}
+	if ptr != "" {
+		t.Error("result ptr was persisted after lock abandonment")
+	}
+	if outputWritten {
+		t.Error("output safety record was persisted after lock abandonment")
+	}
+}
+
+// TestLockFence_StateHelpersWorkWithLiveFence guards against over-rotation:
+// with healthy renewals the helpers must keep succeeding inside the lock
+// (no false fail-closed behavior on the happy path).
+func TestLockFence_StateHelpersWorkWithLiveFence(t *testing.T) {
+	store := &fenceRecordingStore{fakeJobStore: newFakeJobStore(), failRenew: false}
+	engine := NewEngine(&fakeBus{}, NewSafetyBasic(), newTestRegistry(t), NewNaiveStrategy(), store, nil)
+
+	const jobID = "job-fence-live"
+	err := engine.withJobLock(jobID, jobLockTTL, func(lockCtx context.Context) error {
+		if err := engine.setJobState(lockCtx, jobID, JobStateRunning); err != nil {
+			t.Errorf("setJobState with live fence: %v", err)
+		}
+		if err := engine.setResultPtr(lockCtx, jobID, "res:live"); err != nil {
+			t.Errorf("setResultPtr with live fence: %v", err)
+		}
+		engine.setWorkerID(lockCtx, jobID, "worker-live")
+		engine.persistOutputSafety(lockCtx, jobID, OutputSafetyRecord{Decision: OutputAllow})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withJobLock: %v", err)
+	}
+
+	obs := store.observations()
+	if len(obs) != 4 {
+		t.Fatalf("expected 4 write attempts, got %d: %+v", len(obs), obs)
+	}
+	for _, w := range obs {
+		if w.ctxErr != nil {
+			t.Errorf("%s: write saw a cancelled context under healthy renewals: %v", w.op, w.ctxErr)
+		}
+	}
+
+	store.mu.RLock()
+	state := store.states[jobID]
+	ptr := store.ptrs[jobID]
+	rec, outputWritten := store.output[jobID]
+	store.mu.RUnlock()
+	if state != JobStateRunning {
+		t.Errorf("state = %q, want %q", state, JobStateRunning)
+	}
+	if ptr != "res:live" {
+		t.Errorf("result ptr = %q, want %q", ptr, "res:live")
+	}
+	if !outputWritten || rec.Decision != OutputAllow {
+		t.Errorf("output record = %+v (written=%v), want Decision=%q", rec, outputWritten, OutputAllow)
+	}
+}


### PR DESCRIPTION
## Summary

`withJobLock` cancels its fence context (`fenceCancel(errLockAbandoned)`) when lock renewal fails `maxRenewalFailures` times, but the state helpers (`setJobState`, `setResultPtr`, `setWorkerID`, `setAgentInfoFromWorker`, `persistOutputSafety`) derived their store-op timeouts from `e.ctx`. Post-abandonment store writes therefore still succeeded with an uncancelled engine context and could race the takeover handler's state transitions (BUG_SWEEP_2026-06-05 finding **CRD-14**, P1).

**Fix:** all five helpers now take the caller's `context.Context` as their first parameter and derive `storeOpTimeout` from it. No parallel `...Ctx` wrapper variants — the compiler forces every caller to choose a context. Three in-lock helper functions (`handleSchemaViolations`, `failSchemaValidation`, `checkOutputSafety`) got the ctx threaded through so their internal writes ride the same fence.

## Failure-semantics change

Store writes attempted **after lock abandonment now fail loudly** (logged / propagated as `RetryAfter`, wrapped by `withJobLock` as `lock abandoned during execution`) instead of silently overwriting another handler's state. Redelivery stays safe via the existing terminal/dispatched-state guards at the top of both lock closures. Every error path was walked: no panics, no unbounded retries, no half-commits (state writes precede DLQ emits; the nested quarantine lock keeps its bounded 3-attempt retry + DLQ safety net).

## Call-site classification (the control artifact)

| Sites (engine.go) | Enclosing scope | Class | ctx passed |
|---|---|---|---|
| :1212 | `handleJobRequest` pre-lock invalid-request branch | unlocked | `e.ctx` (explicit) |
| :1294 | `handleJobRequest` lock closure | sync-in-lock | `lockCtx` |
| :1368,:1388,:1430,:1472,:1526,:1585,:1597,:1614,:1646,:1785,:1797,:1807,:1828,:1842 | `processJob` (receives `lockCtx` param) | sync-in-lock | `lockCtx` |
| :1980,:2010 | `handleSchemaViolations` / `failSchemaValidation` (ctx threaded; sole caller `applySubmitSchemaValidation` receives `lockCtx`) | sync-in-lock | threaded `ctx` |
| :2361,:2371,:2378,:2379,:2380 | `handleJobResult` lock closure | sync-in-lock | `lockCtx` |
| :2489 | `checkOutputSafety` (ctx threaded; sole caller is the `handleJobResult` closure — sync metadata fast-path) | sync-in-lock | threaded `ctx` |
| :2530 | async output-check goroutine, panic-recovery defer (its 30s ctx is already cancelled there via LIFO defer) | async/unlocked | `e.ctx` (explicit) |
| :2593 | async output-check goroutine main flow | async | goroutine's own `Background`+30s ctx |
| :2628 | nested `withJobLock` closure inside async goroutine | nested-lock | nested `lockCtx` |

Key subtlety: the deferred `fenceCancel(nil)` kills the fence on **every** `withJobLock` exit, so the async output-check path must never receive the outer `lockCtx` — it gets its own lifecycle context, keeping happy-path output persistence working (11 output-safety tests pass ×2).

## Regression tests

- `TestLockFence_StateHelpersHonorFence` (engine_hardening_test.go) — fence-aware recording store + always-failing renewals; waits on `<-lockCtx.Done()`, then calls the helpers. **Failed pre-fix** ("store write attempted with a LIVE context after lock abandonment; job state was persisted after lock abandonment"), passes post-fix (writes rejected, cancellation cause = `errLockAbandoned`, nothing persisted).
- `TestLockFence_StateHelpersWorkWithLiveFence` — healthy renewals: all helpers succeed in-lock (no false fail-closed).

## Verification

- `go test -count=3 ./core/controlplane/scheduler/` → ok 99.905s (flake gate; `-race` unavailable on this platform)
- `go vet ./core/controlplane/scheduler/...` → clean; `go build ./...` → clean
- Blast radius `go test -count=1 ./core/...` → only failures are the 2 documented pre-existing CRD-1 copilot time-bomb tests (gateway `handlers_copilot_sessions_test.go:147/:436`) = HEAD baseline
- Committed tree verified standalone in a detached worktree: build/vet/tests green, zero references to the unrelated telemetry WIP that remains uncommitted in the shared working tree (hunk-level staging via constructed blob; separation proven in both directions)

Task: task-7754adfb · Epic: epic-c631a548 · Finding: CRD-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Scheduler persistence and state updates now derive timeouts and cancellation from the active operation context, making job state transitions and result persistence more robust during lock renewals and interruptions.

* **Tests**
  * Added regression tests for lock-fence scenarios to verify state-update helpers honor cancellation and prevent writes when locks are abandoned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->