### PR TITLE
ci: run full CI and CodeQL on stacked moe/** pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [ main, develop ]
+  # 'moe/**' included so stacked agent PRs (base = another moe/* branch)
+  # get full CI instead of only the unfiltered smoke/e2e workflows.
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'moe/**' ]
 
 jobs:
   test:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,10 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+  # 'moe/**' included so stacked agent PRs (base = another moe/* branch)
+  # get CodeQL analysis instead of skipping it until the final merge to main.
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'moe/**' ]
   schedule:
     - cron: '0 0 * * 1'
 


### PR DESCRIPTION
## Why

PR #338 exposed a CI coverage gap: its base was another `moe/*` task branch (a stacked PR), and because `ci.yml` + `codeql.yml` filter `pull_request` to `main`/`develop`, the required suite (Test, Build, Lint, Security Scan, OpenAPI Validate) **never ran** — only the unfiltered workflows did (platform-smoke, e2e-tls, link-check). A safetykernel change merged into its stack base with 4 of ~19 checks.

The branch-protection net on `main` still caught everything before production (the stack's final PR to main runs the full suite), but intermediate stack merges were nearly ungated.

## What

Add `'moe/**'` to the `pull_request` branch filters in `ci.yml` and `codeql.yml`, so stacked agent PRs get the same gate as PRs to main.

## Notes
- Surgical: only `moe/**` bases added — no CI cost on other branch patterns.
- Merge ordering: merge this **after** #335/#336 land to avoid knocking them BEHIND.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI and security-scan workflow triggers to run for additional development branches (including moe/**), ensuring pull-request validation and CodeQL analysis also cover stacked/branch-based PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->