### PR TITLE
feat(edge): move Edge approvals from session drawer to Approvals page

### DIFF
--- a/core/controlplane/gateway/edge_evaluate_test.go
+++ b/core/controlplane/gateway/edge_evaluate_test.go
@@ -405,7 +405,7 @@ func TestGatewayEdgeEvaluateRequireApprovalResponseIncludesRetryMetadata(t *test
 }
 
 // EDGE-059 — /api/v1/edge/evaluate must let callers shorten the default
-// 5-minute approval TTL via approval_ttl_seconds in the request body.
+// 20-minute approval TTL via approval_ttl_seconds in the request body.
 // Pre-fix the TTL was hardcoded; e2e gates that needed to exercise
 // approval expiration (EDGE-056 gate_approval_expired) had no way to
 // shorten the wait without violating the bounded-sleep rail. Per
@@ -489,18 +489,18 @@ func TestEnqueueEdgeEvaluateApprovalDefaultTTLWhenUnset(t *testing.T) {
 	}
 	now := time.Now().UTC()
 	expiresIn := stored.ExpiresAt.Sub(now)
-	// Expect ≈ 5min — allow [4m55s, 5m05s] slack.
-	if expiresIn < 295*time.Second || expiresIn > 305*time.Second {
-		t.Fatalf("default TTL → expires_at delta = %v, want ~5min ±5s", expiresIn)
+	// Expect ≈ 20min — allow [19m55s, 20m05s] slack.
+	if expiresIn < 1195*time.Second || expiresIn > 1205*time.Second {
+		t.Fatalf("default TTL → expires_at delta = %v, want ~20min ±5s", expiresIn)
 	}
 }
 
 func TestEnqueueEdgeEvaluateApprovalCapsExtendAttempts(t *testing.T) {
 	s, handler, session := setupEdgeEvaluateApprovalRequiredServer(t)
 
-	// Caller asks for 999 seconds (16+ minutes) — server-side cap drops to 5min default.
+	// Caller asks for 2400 seconds (40 minutes) — server-side cap drops to 20min default.
 	rr := edgeRoutePOST(t, handler, "/api/v1/edge/evaluate",
-		edgeEvaluateBodyWithApprovalTTL(session.SessionID, session.ExecutionID, edgeRouteTenant, "Bash", map[string]any{"command": "npm test"}, 999))
+		edgeEvaluateBodyWithApprovalTTL(session.SessionID, session.ExecutionID, edgeRouteTenant, "Bash", map[string]any{"command": "npm test"}, 2400))
 	if rr.Code != http.StatusOK {
 		t.Fatalf("evaluate status = %d, want 200; body=%s", rr.Code, rr.Body.String())
 	}
@@ -511,8 +511,8 @@ func TestEnqueueEdgeEvaluateApprovalCapsExtendAttempts(t *testing.T) {
 		t.Fatalf("GetApproval(%q): (%#v,%v,%v)", resp.ApprovalRef, stored, ok, err)
 	}
 	expiresIn := stored.ExpiresAt.Sub(time.Now().UTC())
-	if expiresIn < 295*time.Second || expiresIn > 305*time.Second {
-		t.Fatalf("approval_ttl_seconds=999 (>5min cap) → expires_at delta = %v, want ~5min ±5s (cap fired)", expiresIn)
+	if expiresIn < 1195*time.Second || expiresIn > 1205*time.Second {
+		t.Fatalf("approval_ttl_seconds=2400 (>20min cap) → expires_at delta = %v, want ~20min ±5s (cap fired)", expiresIn)
 	}
 }
 
@@ -532,8 +532,8 @@ func TestEnqueueEdgeEvaluateApprovalEnforcesNegativeFallthroughToDefault(t *test
 		t.Fatalf("GetApproval(%q): (%#v,%v,%v)", resp.ApprovalRef, stored, ok, err)
 	}
 	expiresIn := stored.ExpiresAt.Sub(time.Now().UTC())
-	if expiresIn < 295*time.Second || expiresIn > 305*time.Second {
-		t.Fatalf("approval_ttl_seconds=-5 → expires_at delta = %v, want ~5min ±5s (negative falls through to default)", expiresIn)
+	if expiresIn < 1195*time.Second || expiresIn > 1205*time.Second {
+		t.Fatalf("approval_ttl_seconds=-5 → expires_at delta = %v, want ~20min ±5s (negative falls through to default)", expiresIn)
 	}
 }
 
@@ -838,7 +838,7 @@ func TestGatewayEdgeEvaluateAutoConsumeExpiredApprovalReturnsDeny(t *testing.T) 
 	// production expiry sweep walks the per-tenant pending index and marks
 	// approvals with ExpiresAt < now as ApprovalStatusExpired, which is the
 	// exact code path the lookup must observe. The store default TTL is
-	// 5 minutes (core/edge/approval_store.go); 1h is comfortably past that.
+	// 20 minutes (core/edge/approval_store.go); 1h is comfortably past that.
 	expiredAt := time.Now().UTC().Add(time.Hour)
 	if _, err := s.edgeStore.ExpireApprovals(context.Background(), edgeRouteTenant, expiredAt); err != nil {
 		t.Fatalf("ExpireApprovals: %v", err)

--- a/core/controlplane/gateway/handlers_edge_approvals.go
+++ b/core/controlplane/gateway/handlers_edge_approvals.go
@@ -325,9 +325,14 @@ func edgeApprovalListQueryFromRequest(r *http.Request, tenantID string) (edgecor
 			return edgecore.ListApprovalsQuery{}, errors.New("invalid status")
 		}
 	}
-	if (query.SessionID != "" || query.ExecutionID != "" || query.ActionHash != "") &&
-		(query.SessionID == "" || query.ExecutionID == "" || query.ActionHash == "") {
-		return edgecore.ListApprovalsQuery{}, errors.New("session_id, execution_id, and action_hash are required together")
+	// action_hash requires all three tuple fields (session_id + execution_id + action_hash).
+	// session_id alone (without execution_id or action_hash) is valid — used by the
+	// EdgeApprovalsDrawer to list all approvals for a session.
+	if query.ActionHash != "" && (query.SessionID == "" || query.ExecutionID == "") {
+		return edgecore.ListApprovalsQuery{}, errors.New("action_hash requires session_id and execution_id")
+	}
+	if query.ExecutionID != "" && query.SessionID == "" {
+		return edgecore.ListApprovalsQuery{}, errors.New("execution_id requires session_id")
 	}
 	return query, nil
 }

--- a/core/controlplane/gateway/handlers_edge_evaluate.go
+++ b/core/controlplane/gateway/handlers_edge_evaluate.go
@@ -777,13 +777,13 @@ const (
 )
 
 // boundEdgeEvaluateApprovalTTL clamps the caller-requested approval TTL to
-// the [1s, 5min] window (EDGE-059). Values <= 0 return the 5-min default.
-// Values > 5min also return the 5-min default — callers can ONLY shorten
+// the [1s, 20min] window (EDGE-059). Values <= 0 return the 20-min default.
+// Values > 20min also return the 20-min default — callers can ONLY shorten
 // the TTL, preserving the security floor against malicious indefinite-hold
 // requests. Mirror of boundEdgeEvaluateWaitTimeout for the approval-TTL
 // field on edgeEvaluateRequest.
 func boundEdgeEvaluateApprovalTTL(requestedSec int) time.Duration {
-	const defaultApprovalTTL = 5 * time.Minute
+	const defaultApprovalTTL = 20 * time.Minute
 	const minApprovalTTL = time.Second
 	if requestedSec <= 0 {
 		return defaultApprovalTTL

--- a/core/controlplane/gateway/handlers_edge_evaluate.go
+++ b/core/controlplane/gateway/handlers_edge_evaluate.go
@@ -89,11 +89,11 @@ type edgeEvaluateRequest struct {
 	WaitForApproval       bool `json:"wait_for_approval"`
 	ApprovalWaitTimeoutMS int  `json:"approval_wait_timeout_ms"`
 
-	// ApprovalTTLSeconds shortens the default 5-minute approval TTL when set
+	// ApprovalTTLSeconds overrides the default 20-minute approval TTL when set
 	// (EDGE-059: enables e2e gates that need to exercise approval expiration
 	// inside a bounded sleep window). Server-side cap: callers can ONLY
-	// shorten the TTL, never extend it past the 5-minute default — preserves
-	// the existing security floor. Min 1 second; values <= 0 use the default.
+	// shorten the TTL, never extend it past the 20-minute default — preserves
+	// the security floor. Min 1 second; values <= 0 use the default.
 	ApprovalTTLSeconds int `json:"approval_ttl_seconds,omitempty"`
 }
 
@@ -1182,7 +1182,7 @@ func (s *server) enqueueEdgeEvaluateApproval(ctx context.Context, store edgecore
 		ActionHash:     strings.TrimSpace(actionHash),
 		InputHash:      strings.TrimSpace(event.InputHash),
 		// EDGE-059 — caller-shortened TTL via edgeEvaluateRequest.ApprovalTTLSeconds.
-		// boundEdgeEvaluateApprovalTTL caps at the previously-hardcoded 5-min default.
+		// boundEdgeEvaluateApprovalTTL caps at the 20-min default.
 		TTL:      boundEdgeEvaluateApprovalTTL(ttlSecondsHint),
 		Labels:   edgecore.Labels{"source": "edge.evaluate"},
 		Metadata: edgecore.Metadata{"source": "edge.evaluate"},

--- a/core/edge/approval_store_redis.go
+++ b/core/edge/approval_store_redis.go
@@ -356,6 +356,9 @@ func (s *RedisStore) ListApprovals(ctx context.Context, query ListApprovalsQuery
 			if query.SessionID != "" && approval.SessionID != query.SessionID {
 				continue
 			}
+			if query.ExecutionID != "" && approval.ExecutionID != query.ExecutionID {
+				continue
+			}
 			items = append(items, *approval)
 		}
 		sort.SliceStable(items, func(i, j int) bool {

--- a/core/edge/approval_store_redis.go
+++ b/core/edge/approval_store_redis.go
@@ -353,6 +353,9 @@ func (s *RedisStore) ListApprovals(ctx context.Context, query ListApprovalsQuery
 			if principalID != "" && approval.PrincipalID != principalID {
 				continue
 			}
+			if query.SessionID != "" && approval.SessionID != query.SessionID {
+				continue
+			}
 			items = append(items, *approval)
 		}
 		sort.SliceStable(items, func(i, j int) bool {

--- a/dashboard/src/components/approvals/EdgeApprovalsSection.tsx
+++ b/dashboard/src/components/approvals/EdgeApprovalsSection.tsx
@@ -322,9 +322,9 @@ export function EdgeApprovalsSection({ fullPage = false }: EdgeApprovalsSectionP
   };
 
   const handleDeny = (reason: string) => {
-    if (!denyTarget || rejectMutation.isPending) return;
+    if (!denyTarget || rejectMutation.isPending || !reason.trim()) return;
     rejectMutation.mutate(
-      { approvalRef: denyTarget.approvalRef, reason: reason || "Denied by operator." },
+      { approvalRef: denyTarget.approvalRef, reason: reason.trim() },
       {
         onSuccess: () => {
           if (selected?.approvalRef === denyTarget.approvalRef) setSelected(null);

--- a/dashboard/src/components/approvals/EdgeApprovalsSection.tsx
+++ b/dashboard/src/components/approvals/EdgeApprovalsSection.tsx
@@ -1,0 +1,637 @@
+import { useMemo, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { EdgeApproval } from "@/api/types";
+import {
+  useEdgeApprovals,
+  useApproveEdgeApproval,
+  useRejectEdgeApproval,
+} from "@/hooks/useEdgeSessions";
+import { useDialogA11y } from "@/hooks/useDialogA11y";
+import {
+  StatusBadge,
+  statusToneBorderClasses,
+  type BadgeVariant,
+} from "@/components/ui/StatusBadge";
+import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SkeletonCard, SkeletonTable } from "@/components/ui/Skeleton";
+import { Textarea } from "@/components/ui/Textarea";
+import { Tabs } from "@/components/ui/Tabs";
+import { StatTile } from "@/components/ui/StatTile";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Timer,
+  X,
+  ArrowRight,
+  RefreshCw,
+  ShieldAlert,
+} from "lucide-react";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import {
+  approvalStatusVariant,
+  compactHash,
+  isExpired,
+  isTerminal,
+} from "@/components/edge/edgeApprovalUtils";
+import { friendlyError } from "@/lib/friendlyError";
+import { toast } from "sonner";
+
+function edgeApprovalTitle(approval: EdgeApproval): string {
+  return approval.metadata?.action || approval.reason || "Governed Edge action";
+}
+
+function formatEdgeStatusLabel(status: string): string {
+  if (status === "rejected") return "Denied";
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function isEdgeApprovalActionable(approval: EdgeApproval): boolean {
+  return approval.status === "pending" && !isExpired(approval);
+}
+
+interface FactRowProps {
+  label: string;
+  value?: string | null;
+  mono?: boolean;
+}
+
+function FactRow({ label, value, mono }: FactRowProps) {
+  if (!value) return null;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </span>
+      <span className={cn("text-xs text-foreground break-all", mono && "font-mono")}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface DetailDrawerProps {
+  approval: EdgeApproval;
+  onClose: () => void;
+  drawerRef: React.RefObject<HTMLDivElement | null>;
+  onApprove: (a: EdgeApproval) => void;
+  onDeny: (a: EdgeApproval) => void;
+  approving: boolean;
+  denying: boolean;
+}
+
+function DetailDrawer({
+  approval,
+  onClose,
+  drawerRef,
+  onApprove,
+  onDeny,
+  approving,
+  denying,
+}: DetailDrawerProps) {
+  const actionable = isEdgeApprovalActionable(approval);
+  const expired = isExpired(approval);
+  const terminal = isTerminal(approval);
+  const title = edgeApprovalTitle(approval);
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-black/40"
+        onClick={onClose}
+        aria-hidden
+      />
+      <motion.div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="edge-approval-drawer-title"
+        initial={{ x: 440 }}
+        animate={{ x: 0 }}
+        transition={{ type: "spring", stiffness: 300, damping: 30 }}
+        className="fixed inset-y-0 right-0 z-50 w-full max-w-[520px] overflow-y-auto border-l border-border bg-surface-1 shadow-2xl"
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-border p-5">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge
+                variant={approvalStatusVariant(approval.status)}
+                dot
+                pulse={actionable}
+              >
+                {formatEdgeStatusLabel(approval.status)}
+              </StatusBadge>
+              <StatusBadge variant="info">Edge · Claude Code</StatusBadge>
+              {expired && !terminal && (
+                <StatusBadge variant="danger">Expired</StatusBadge>
+              )}
+            </div>
+            <h2
+              id="edge-approval-drawer-title"
+              className="font-display text-base font-semibold text-foreground"
+            >
+              {title}
+            </h2>
+            <p className="font-mono text-xs text-muted-foreground">
+              {approval.approvalRef}
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close approval detail"
+            onClick={onClose}
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center -mr-2 rounded-full text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="space-y-5 p-5">
+          <section
+            aria-labelledby="edge-appr-reason-section"
+            className="rounded-3xl border border-border bg-surface-2/60 p-4"
+          >
+            <p
+              id="edge-appr-reason-section"
+              className="mb-2 text-xs font-mono uppercase tracking-wide text-muted-foreground"
+            >
+              Trigger reason
+            </p>
+            <p className="text-sm text-foreground">{approval.reason}</p>
+            {approval.resolutionReason && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Resolution: {approval.resolutionReason}
+              </p>
+            )}
+          </section>
+
+          <section
+            aria-labelledby="edge-appr-facts-section"
+            className="rounded-3xl border border-border bg-surface-2/40 p-4"
+          >
+            <p
+              id="edge-appr-facts-section"
+              className="mb-3 text-xs font-mono uppercase tracking-wide text-muted-foreground"
+            >
+              Action details
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              <FactRow label="Requester" value={approval.requester || approval.principalId} />
+              <FactRow label="Rule" value={approval.ruleId} mono />
+              <FactRow label="Action hash" value={compactHash(approval.actionHash)} mono />
+              <FactRow label="Input hash" value={compactHash(approval.inputHash)} mono />
+              <FactRow label="Policy snapshot" value={compactHash(approval.policySnapshot)} mono />
+              <FactRow label="Session" value={compactHash(approval.sessionId)} mono />
+              <FactRow
+                label="Created"
+                value={approval.createdAt ? formatRelativeTime(approval.createdAt) : undefined}
+              />
+              <FactRow
+                label="Expires"
+                value={approval.expiresAt ? formatRelativeTime(approval.expiresAt) : "—"}
+              />
+              {approval.resolvedAt && (
+                <FactRow label="Resolved" value={formatRelativeTime(approval.resolvedAt)} />
+              )}
+              {approval.resolvedBy && (
+                <FactRow label="Resolved by" value={approval.resolvedBy} />
+              )}
+            </div>
+          </section>
+
+          {approval.metadata && Object.keys(approval.metadata).length > 0 && (
+            <section
+              aria-labelledby="edge-appr-metadata-section"
+              className="rounded-3xl border border-border bg-surface-2/30 p-4"
+            >
+              <p
+                id="edge-appr-metadata-section"
+                className="mb-3 text-xs font-mono uppercase tracking-wide text-muted-foreground"
+              >
+                Metadata
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                {Object.entries(approval.metadata).map(([k, v]) => (
+                  <FactRow key={k} label={k.replace(/_/g, " ")} value={v} mono />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {actionable && (
+            <section
+              aria-label="Approval actions"
+              className="rounded-3xl border border-border bg-surface-2/40 p-4"
+            >
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Button
+                  variant="primary"
+                  className="w-full"
+                  aria-label={`Approve ${title}`}
+                  disabled={approving || denying}
+                  loading={approving}
+                  onClick={() => onApprove(approval)}
+                >
+                  <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+                  Approve
+                </Button>
+                <Button
+                  variant="danger"
+                  className="w-full"
+                  aria-label={`Deny ${title}`}
+                  disabled={denying || approving}
+                  loading={denying}
+                  onClick={() => onDeny(approval)}
+                >
+                  <XCircle className="mr-1 h-3.5 w-3.5" />
+                  Deny
+                </Button>
+              </div>
+            </section>
+          )}
+        </div>
+      </motion.div>
+    </>
+  );
+}
+
+interface EdgeApprovalsSectionProps {
+  /** When true the section renders a full standalone page view (stat tiles + tabs). */
+  fullPage?: boolean;
+}
+
+export function EdgeApprovalsSection({ fullPage = false }: EdgeApprovalsSectionProps) {
+  const [activeTab, setActiveTab] = useState("pending");
+  const [selected, setSelected] = useState<EdgeApproval | null>(null);
+  const [denyTarget, setDenyTarget] = useState<EdgeApproval | null>(null);
+  const [denyReason, setDenyReason] = useState("");
+
+  const drawerRef = useDialogA11y(() => setSelected(null), {
+    enabled: !!selected,
+    initialFocusSelector: 'button[aria-label="Close approval detail"]',
+  });
+
+  const { data, isLoading, isError, error, refetch } = useEdgeApprovals({ limit: 200 });
+  const approveMutation = useApproveEdgeApproval();
+  const rejectMutation = useRejectEdgeApproval();
+
+  const allItems = data?.items ?? [];
+
+  const pending = useMemo(() => allItems.filter((a) => a.status === "pending"), [allItems]);
+  const approved = useMemo(() => allItems.filter((a) => a.status === "approved"), [allItems]);
+  const denied = useMemo(() => allItems.filter((a) => a.status === "rejected"), [allItems]);
+  const expired = useMemo(
+    () => allItems.filter((a) => a.status === "expired" || a.status === "invalidated"),
+    [allItems],
+  );
+
+  const filtered = useMemo(() => {
+    const base =
+      activeTab === "all"
+        ? allItems
+        : activeTab === "pending"
+          ? pending
+          : activeTab === "approved"
+            ? approved
+            : activeTab === "rejected"
+              ? denied
+              : expired;
+    return [...base].sort((a, b) => {
+      if (a.status === "pending" && b.status !== "pending") return -1;
+      if (b.status === "pending" && a.status !== "pending") return 1;
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+  }, [activeTab, allItems, pending, approved, denied, expired]);
+
+  const handleApprove = (approval: EdgeApproval) => {
+    if (approveMutation.isPending) return;
+    approveMutation.mutate(
+      { approvalRef: approval.approvalRef },
+      {
+        onSuccess: () => {
+          if (selected?.approvalRef === approval.approvalRef) setSelected(null);
+        },
+        onError: (err) => {
+          const friendly = friendlyError(err, "approve edge action");
+          toast.error(friendly.title, { description: friendly.description });
+        },
+      },
+    );
+  };
+
+  const handleDeny = (reason: string) => {
+    if (!denyTarget || rejectMutation.isPending) return;
+    rejectMutation.mutate(
+      { approvalRef: denyTarget.approvalRef, reason: reason || "Denied by operator." },
+      {
+        onSuccess: () => {
+          if (selected?.approvalRef === denyTarget.approvalRef) setSelected(null);
+          setDenyTarget(null);
+          setDenyReason("");
+        },
+        onError: (err) => {
+          const friendly = friendlyError(err, "deny edge action");
+          toast.error(friendly.title, { description: friendly.description });
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-5">
+      {fullPage && (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3 }}
+          className="grid gap-4 md:grid-cols-4"
+        >
+          {isLoading ? (
+            Array.from({ length: 4 }).map((_, i) => <SkeletonCard key={i} />)
+          ) : (
+            <>
+              <StatTile
+                accent={pending.length > 0 ? "warning" : "muted"}
+                label="Pending"
+                value={pending.length}
+                helperText={pending.length > 0 ? "Needs operator review" : "Queue clear"}
+                icon={
+                  <Clock
+                    className={cn(
+                      "h-4 w-4",
+                      pending.length > 0 ? "text-warning" : "text-muted-foreground",
+                    )}
+                  />
+                }
+              />
+              <StatTile
+                accent="healthy"
+                label="Approved"
+                value={approved.length}
+                helperText="Resolved — action allowed"
+                icon={<CheckCircle2 className="h-4 w-4 text-success" />}
+              />
+              <StatTile
+                accent={denied.length > 0 ? "governance" : "muted"}
+                label="Denied"
+                value={denied.length}
+                helperText={denied.length > 0 ? "Action blocked" : "No denied items"}
+                icon={
+                  <XCircle
+                    className={cn(
+                      "h-4 w-4",
+                      denied.length > 0 ? "text-governance" : "text-muted-foreground",
+                    )}
+                  />
+                }
+              />
+              <StatTile
+                accent="muted"
+                label="Expired / Invalidated"
+                value={expired.length}
+                helperText="Timed out or policy changed"
+                icon={<Timer className="h-4 w-4 text-muted-foreground" />}
+              />
+            </>
+          )}
+        </motion.div>
+      )}
+
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        {fullPage && (
+          <Tabs
+            ariaLabel="Edge approval status filters"
+            variant="segmented"
+            className="w-full lg:w-auto"
+            activeTab={activeTab}
+            onChange={setActiveTab}
+            tabs={[
+              { id: "pending", label: "Pending", count: pending.length },
+              { id: "approved", label: "Approved", count: approved.length },
+              { id: "rejected", label: "Denied", count: denied.length },
+              { id: "expired", label: "Expired", count: expired.length },
+              { id: "all", label: "All", count: allItems.length },
+            ]}
+          />
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          className={fullPage ? "ml-auto" : ""}
+          onClick={() => void refetch()}
+        >
+          <RefreshCw className="mr-1 h-3 w-3" />
+          Refresh
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <SkeletonTable rows={3} />
+      ) : isError ? (
+        <EmptyState
+          icon={<XCircle className="h-5 w-5" />}
+          title="Edge approvals unavailable"
+          description={
+            error instanceof Error ? error.message : "Could not load edge approvals."
+          }
+          action={
+            <Button variant="outline" size="sm" onClick={() => void refetch()}>
+              Try again
+            </Button>
+          }
+        />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          icon={<ShieldAlert className="h-5 w-5" />}
+          title={activeTab === "pending" ? "No pending edge approvals" : "No edge approvals found"}
+          description={
+            activeTab === "pending"
+              ? "Edge approvals appear when Claude Code tries a governed action (e.g. editing a file). Start a governed session to trigger one."
+              : "Try a different status filter."
+          }
+        />
+      ) : (
+        <div className="space-y-3">
+          <AnimatePresence mode="popLayout">
+            {filtered.map((approval) => {
+              const actionable = isEdgeApprovalActionable(approval);
+              const title = edgeApprovalTitle(approval);
+              const expired = isExpired(approval);
+
+              return (
+                <motion.article
+                  key={approval.approvalRef}
+                  layout
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, x: -100, height: 0, marginBottom: 0, overflow: "hidden" }}
+                  transition={{ duration: 0.3 }}
+                  className={cn(
+                    "instrument-card group cursor-pointer overflow-hidden border-border/70 bg-surface-1/95 focus:outline-none focus:ring-1 focus:ring-cordum",
+                    approval.status === "pending" && !expired && statusToneBorderClasses.warning,
+                    approval.status === "rejected" && statusToneBorderClasses.governance,
+                    approval.status === "invalidated" && "border-destructive/30",
+                  )}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Open edge approval detail for ${title}`}
+                  onClick={() => setSelected(approval)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelected(approval);
+                    }
+                  }}
+                >
+                  <div className="flex flex-col gap-4 p-4 md:p-5">
+                    <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                      <div className="min-w-0 flex-1 space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <StatusBadge
+                            variant={approvalStatusVariant(approval.status) as BadgeVariant}
+                            dot
+                            pulse={actionable}
+                          >
+                            {formatEdgeStatusLabel(approval.status)}
+                          </StatusBadge>
+                          <StatusBadge variant="info">Edge · Claude Code</StatusBadge>
+                          {expired && approval.status === "pending" && (
+                            <StatusBadge variant="danger">Expired</StatusBadge>
+                          )}
+                        </div>
+                        <p className="text-sm font-medium text-foreground">{title}</p>
+                        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                          {(approval.requester || approval.principalId) && (
+                            <span>
+                              Requester:{" "}
+                              <span className="font-mono text-foreground">
+                                {approval.requester || approval.principalId}
+                              </span>
+                            </span>
+                          )}
+                          {approval.ruleId && (
+                            <span>
+                              Rule:{" "}
+                              <span className="font-mono text-foreground">{approval.ruleId}</span>
+                            </span>
+                          )}
+                          {approval.createdAt && (
+                            <span>{formatRelativeTime(approval.createdAt)}</span>
+                          )}
+                          {approval.expiresAt && approval.status === "pending" && (
+                            <span className={cn(expired && "text-destructive")}>
+                              Expires {formatRelativeTime(approval.expiresAt)}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      {actionable ? (
+                        <div className="flex shrink-0 flex-wrap gap-2 xl:flex-col xl:items-stretch">
+                          <Button
+                            size="sm"
+                            variant="danger"
+                            aria-label={`Deny ${title}`}
+                            disabled={rejectMutation.isPending || approveMutation.isPending}
+                            loading={rejectMutation.isPending}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDenyTarget(approval);
+                              setDenyReason("");
+                            }}
+                          >
+                            <XCircle className="mr-1 h-3.5 w-3.5" />
+                            Deny
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="primary"
+                            aria-label={`Approve ${title}`}
+                            disabled={approveMutation.isPending || rejectMutation.isPending}
+                            loading={approveMutation.isPending}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleApprove(approval);
+                            }}
+                          >
+                            <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+                            Approve
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="shrink-0 pt-1 text-muted-foreground transition-colors group-hover:text-cordum">
+                          <ArrowRight className="h-4 w-4" />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </motion.article>
+              );
+            })}
+          </AnimatePresence>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={!!denyTarget}
+        onClose={() => setDenyTarget(null)}
+        onConfirm={() => handleDeny(denyReason)}
+        title="Deny edge action"
+        description={
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Explain why this governed action should be denied. The reason becomes part of the audit trail.
+            </p>
+            <div>
+              <label className="mb-1 block text-xs font-mono uppercase tracking-wide text-muted-foreground">
+                Reason <span className="text-destructive">*</span>
+              </label>
+              <Textarea
+                value={denyReason}
+                onChange={(e) => {
+                  if (e.target.value.length <= 500) setDenyReason(e.target.value);
+                }}
+                placeholder="Why should this action be denied?"
+                rows={3}
+                maxLength={500}
+                aria-required="true"
+                aria-label="Denial reason"
+                className="resize-none bg-surface-2 px-3 py-2 shadow-none focus:ring-cordum/30"
+              />
+              <p
+                className={cn(
+                  "mt-1 text-right text-xs",
+                  denyReason.length > 400 ? "text-warning" : "text-muted-foreground",
+                  denyReason.length >= 500 && "text-destructive",
+                )}
+              >
+                {denyReason.length} / 500
+              </p>
+            </div>
+          </div>
+        }
+        confirmLabel={denyReason.trim() ? "Deny" : "Enter reason to deny"}
+        variant="destructive"
+        loading={rejectMutation.isPending}
+        initialFocusSelector='textarea[aria-label="Denial reason"]'
+      />
+
+      {selected && (
+        <DetailDrawer
+          approval={selected}
+          onClose={() => setSelected(null)}
+          drawerRef={drawerRef}
+          onApprove={handleApprove}
+          onDeny={(a) => {
+            setDenyTarget(a);
+            setDenyReason("");
+          }}
+          approving={approveMutation.isPending}
+          denying={rejectMutation.isPending}
+        />
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -15,6 +15,7 @@ import {
 import { useDialogA11y } from "@/hooks/useDialogA11y";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { McpApprovalsSection } from "@/components/approvals/McpApprovalsSection";
+import { EdgeApprovalsSection } from "@/components/approvals/EdgeApprovalsSection";
 import { WorkflowContext } from "@/components/approvals/WorkflowContext";
 import {
   StatusBadge,
@@ -529,25 +530,10 @@ export default function ApprovalsPage() {
     error,
     refetch,
   } = useApprovals();
-  // task-266f21ad: `?lane=edge` is the URL contract the new Edge sidebar
-  // item lands on (via /edge/approvals → /approvals?lane=edge redirect).
-  // Today's /approvals feed does not yet carry Edge-sourced approvals
-  // (those flow through EdgeApprovalsDrawer on EdgeSessionDetailPage);
-  // the lane filter is wired here so the URL contract is correct now and
-  // will surface real items the moment a future task wires edge approvals
-  // into the global feed. Predicate matches the existing `source` /
-  // `kind` strings used by getApprovalSourceMeta — extend the OR-list as
-  // new edge-source labels appear in `decisionSummary.source`.
   const [searchParams] = useSearchParams();
   const lane = searchParams.get("lane")?.trim().toLowerCase() ?? "";
   const allApprovals = approvalsData?.items ?? [];
-  const approvals = useMemo(() => {
-    if (lane !== "edge") return allApprovals;
-    return allApprovals.filter((a) => {
-      const src = a.decisionSummary?.source?.toLowerCase() ?? "";
-      return src.startsWith("edge");
-    });
-  }, [allApprovals, lane]);
+  const approvals = useMemo(() => allApprovals, [allApprovals]);
   const approveMutation = useApproveJob();
   const rejectMutation = useRejectJob();
 
@@ -627,21 +613,22 @@ export default function ApprovalsPage() {
     <div className="space-y-6">
       <PageHeader
         label="Safety"
-        title="Approvals"
-        subtitle="Review the business decision first, then inspect technical audit detail only when needed."
-        actions={
-          <Button variant="outline" size="sm" onClick={() => refetch()}>
-            <RefreshCw className="mr-1 h-3 w-3" />
-            Refresh
-          </Button>
+        title={lane === "edge" ? "Edge Approvals" : "Approvals"}
+        subtitle={
+          lane === "edge"
+            ? "Review governed Claude Code actions. Approve to allow the retry; deny to block it permanently."
+            : "Review the business decision first, then inspect technical audit detail only when needed."
         }
       />
 
-      {/* MCP tool-call approvals — surfaced above job approvals so
-          operators see the high-privilege agent-driven calls before
-          the routine job queue. Each card shows tool_name + requester
-          + args-preview (modal) + approve/reject. */}
-      <McpApprovalsSection statusFilter="pending" />
+      {lane === "edge" ? (
+        <EdgeApprovalsSection fullPage />
+      ) : (
+        <>
+          {/* MCP tool-call approvals — surfaced above job approvals so
+              operators see the high-privilege agent-driven calls before
+              the routine job queue. */}
+          <McpApprovalsSection statusFilter="pending" />
 
       <motion.div
         initial={{ opacity: 0, y: 12 }}
@@ -1232,6 +1219,8 @@ export default function ApprovalsPage() {
           </motion.div>
         </>
       )}
+      </>
+    )}
     </div>
   );
 }

--- a/dashboard/src/pages/EdgeSessionDetailPage.tsx
+++ b/dashboard/src/pages/EdgeSessionDetailPage.tsx
@@ -21,7 +21,6 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import type { AgentActionEvent, EdgeDecision } from "@/api/types";
-import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -31,7 +30,6 @@ import {
   useEdgeSessionEvents,
   useEdgeExecutions,
 } from "@/hooks/useEdgeSessions";
-import { EdgeApprovalsDrawer } from "@/components/edge/EdgeApprovalsDrawer";
 import { EdgeArtifactsPanel } from "@/components/edge/EdgeArtifactsPanel";
 import { EdgeEventInspector } from "@/components/edge/EdgeEventInspector";
 import { MCPLane } from "@/components/timeline/lanes/MCPLane";
@@ -91,7 +89,6 @@ export default function EdgeSessionDetailPage() {
   const eventsQuery = useEdgeSessionEvents(sessionId, { limit: 500 });
   const executionsQuery = useEdgeExecutions({ sessionId });
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
-  const [approvalsOpen, setApprovalsOpen] = useState(false);
   const [filter, setFilter] = useState<Filter>({ executionId: "", decision: "", kind: "" });
   // EDGE-050 — UI surface for the 3-events-per-hook collapse. Default
   // hides pre-evaluation receipts (status=degraded agentd-receipt rows)
@@ -168,9 +165,12 @@ export default function EdgeSessionDetailPage() {
         <div className="flex flex-wrap items-center gap-2">
           <StatusBadge variant={statusVariant(session.status)}>{session.status}</StatusBadge>
           <StatusBadge variant="info">{session.policyMode}</StatusBadge>
-          <Button variant="outline" size="sm" onClick={() => setApprovalsOpen(true)}>
+          <Link
+            to="/approvals?lane=edge"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-surface-1 px-3 py-1.5 text-sm font-medium text-foreground hover:bg-surface-2 transition-colors"
+          >
             <Inbox className="h-3.5 w-3.5" /> Approvals
-          </Button>
+          </Link>
         </div>
       </header>
 
@@ -253,13 +253,6 @@ export default function EdgeSessionDetailPage() {
         event={selectedEvent}
         open={selectedEvent !== null}
         onClose={() => setSelectedEventId(null)}
-      />
-      <EdgeApprovalsDrawer
-        open={approvalsOpen}
-        onClose={() => setApprovalsOpen(false)}
-        sessionId={session.sessionId}
-        events={events}
-        currentPrincipalId={session.principalId}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- **Gateway**: relax `ListEdgeApprovals` validation to allow `session_id`-only queries (was requiring all three of `session_id + execution_id + action_hash` together, which broke the dashboard's session-scoped fetch that the drawer used)
- **Gateway**: extend default approval TTL from 5 min → 20 min so operators have enough time to navigate to the page and act during a live Edge session
- **Redis store**: add `session_id` post-filter in `ListApprovals` fallback path so session-scoped queries return only that session's approvals
- **Dashboard**: new `EdgeApprovalsSection` component — stat tiles (pending/approved/denied/expired), status tabs, approval cards with inline Approve/Deny, and a detail slide-in drawer (action hash, policy snapshot, requester, expiry, metadata)
- **`ApprovalsPage`**: `?lane=edge` now renders `EdgeApprovalsSection` in full-page mode with its own header ("Edge Approvals") instead of showing an empty job-approval feed
- **`EdgeSessionDetailPage`**: removed `EdgeApprovalsDrawer` and `approvalsOpen` state; the Approvals button is now a `<Link to="/approvals?lane=edge">` — approvals live on the dedicated page

## Test plan

- [ ] Run a governed Claude Code session (`C:\projects\start-edge.ps1`), trigger an Edit on a file
- [ ] Visit `http://localhost:8082/approvals?lane=edge` — pending approval card should appear with Approve/Deny buttons
- [ ] Approve → Claude retries and the edit goes through
- [ ] Deny → Claude sees the denial reason
- [ ] Edge Sessions detail page: "Approvals" link navigates to `/approvals?lane=edge`
- [ ] `/approvals` (no lane) still shows job approvals unchanged
- [ ] `pnpm exec tsc --noEmit` + `pnpm run test` + `pnpm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated edge approvals UI with filterable, sortable list, detail drawer, and approve/deny flows including denial-reason entry and confirmation.

* **Bug Fixes**
  * Adjusted approval query validation and result filtering for more flexible session/execution/action combinations.
  * Increased default approval TTL from 5 to 20 minutes and enforced server-side TTL clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->