### PR TITLE
test(gateway): fix shadow-exception expiry time-bomb breaking Test (1.25)

### DIFF
--- a/core/controlplane/gateway/handlers_edge_shadow_exception_handlers_test.go
+++ b/core/controlplane/gateway/handlers_edge_shadow_exception_handlers_test.go
@@ -31,7 +31,7 @@ func shadowCtxWithRole(req *http.Request, role string) *http.Request {
 
 func validExceptionCreateBody() shadowExceptionCreateRequest {
 	return shadowExceptionCreateRequest{
-		ExpiresAt:       time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC),
+		ExpiresAt:       time.Now().Add(30 * 24 * time.Hour),
 		Reason:          "approved by SRE for known kube-system DaemonSet pattern",
 		ScopeSourceType: "kubernetes",
 		ScopeSourceID:   "k8s-detector-1",


### PR DESCRIPTION
## Problem
`Test (1.25)` (a **required** check) is failing on `main`, which blocks the entire dependabot merge queue (#343–#349, #353).

Root cause: `validExceptionCreateBody()` in `handlers_edge_shadow_exception_handlers_test.go` hardcoded `ExpiresAt: time.Date(2026, 6, 17, ...)`. As of 2026-06-21 that date is in the past, so every `TestShadowException_*` create now returns `400 expires_at must be in the future` instead of `201`. 11 tests fail. This is a time-bomb in the test fixture, not a production-code bug.

## Fix
Use a relative future date `time.Now().Add(30 * 24 * time.Hour)` (within the existing 90-day cap), matching the pattern already used by `TestShadowException_Create_RejectsExpiresAtBeyond90Days`.

## Verification
- `go test -run TestShadowException -count=1 ./core/controlplane/gateway/` → ok
- `go test -count=1 ./core/controlplane/gateway/` (full package) → ok (66s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test helpers for exception handler validation to use relative time calculations instead of fixed dates for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->