### PR TITLE
feat(edge): LLM-proxy PII/secret redaction via Safety Kernel scanners + data-leakage demo

### DIFF
--- a/core/controlplane/gateway/handlers_edge_llm_ingest.go
+++ b/core/controlplane/gateway/handlers_edge_llm_ingest.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cordum/cordum/core/controlplane/gateway/auth"
+	"github.com/cordum/cordum/core/controlplane/safetykernel"
 	edgecore "github.com/cordum/cordum/core/edge"
 	"github.com/cordum/cordum/core/edge/llmingest"
 	"github.com/cordum/cordum/core/edge/runtimeingest"
@@ -103,7 +104,7 @@ func (s *server) handleEdgeLLMIngest(w http.ResponseWriter, r *http.Request) {
 	for i := range batch.Events {
 		batch.Events[i].TenantID = tenantID
 	}
-	adapter := llmingest.NewAdapter(llmingest.AdapterOptions{})
+	adapter := llmingest.NewAdapter(llmingest.AdapterOptions{Redactor: llmContentRedactor()})
 	result, err := adapter.Map(batch)
 	if err != nil {
 		writeLLMIngestAdapterError(w, r, err)
@@ -143,6 +144,31 @@ func (s *server) handleEdgeLLMIngest(w http.ResponseWriter, r *http.Request) {
 		AcceptedCount: len(result.Events),
 		Decisions:     result.Decisions,
 	})
+}
+
+// llmContentRedactor builds the LLM-proxy content redactor from the SHARED
+// Safety Kernel scanners (PII + secrets + operator terms), configured via
+// CORDUM_EDGE_LLM_* env. It is injected into the llmingest adapter so the edge
+// layer reuses the control plane's single detection source of truth without
+// importing it.
+func llmContentRedactor() llmingest.ContentRedactor {
+	opts := safetykernel.ContentScanOptionsFromEnv(os.Getenv)
+	return func(content string) (string, []string) {
+		redacted, findings := safetykernel.RedactContent([]byte(content), opts)
+		if len(findings) == 0 {
+			return redacted, nil
+		}
+		seen := make(map[string]struct{}, len(findings))
+		types := make([]string, 0, len(findings))
+		for _, f := range findings {
+			if _, ok := seen[f.Type]; ok {
+				continue
+			}
+			seen[f.Type] = struct{}{}
+			types = append(types, f.Type)
+		}
+		return redacted, types
+	}
 }
 
 func writeLLMIngestResponse(w http.ResponseWriter, status int, resp llmIngestResponse) {

--- a/core/controlplane/gateway/handlers_edge_llm_ingest_test.go
+++ b/core/controlplane/gateway/handlers_edge_llm_ingest_test.go
@@ -210,14 +210,53 @@ func TestLLMIngest_RedactsSecretInPrompt(t *testing.T) {
 	if strings.Contains(rr.Body.String(), llmTestAWSKey) {
 		t.Fatalf("response leaked the raw secret: %s", rr.Body.String())
 	}
+	// The handler redacts via the shared Safety Kernel scanners, which classify
+	// an AWS key under the "secret_leak" finding type.
 	found := false
 	for _, f := range d.Findings {
-		if f == "aws_credential" {
+		if f == "secret_leak" {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("findings missing aws_credential: %v", d.Findings)
+		t.Fatalf("findings missing secret_leak: %v", d.Findings)
+	}
+}
+
+// TestLLMIngest_RedactsPIIViaKernelScanners proves the LLM-proxy path reuses the
+// shared kernel PII scanner (not a duplicate edge regex): an email in a meeting
+// prompt is masked in place, the surrounding prose is preserved, and the raw
+// address never appears in the response or stored event.
+func TestLLMIngest_RedactsPIIViaKernelScanners(t *testing.T) {
+	enableLLMIngest(t)
+	s, _ := newEdgeRouteTestServer(t)
+	setupLLMIngestRBAC(t, s)
+	session, execution := createLLMIngestParents(t, s, "pii", edgecore.AdapterLLMProxy)
+	rr := postLLMIngestWithAuth(t, s, llmIngestAuthContext(testLLMProxyRole, "llm-proxy-1"),
+		llmIngestBody("llm-proxy-1", session.SessionID, execution.ExecutionID, "evt-pii",
+			"Summarize the 1:1; follow up with alice@example.com next week."))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeLLMIngestResponse(t, rr)
+	d := resp.Decisions[0]
+	if d.Decision != llmingest.DecisionRedact {
+		t.Fatalf("decision = %q, want redact", d.Decision)
+	}
+	if strings.Contains(rr.Body.String(), "alice@example.com") {
+		t.Fatalf("response leaked PII: %s", rr.Body.String())
+	}
+	if !strings.Contains(d.RedactedContent, "Summarize the 1:1") {
+		t.Fatalf("prose not preserved: %q", d.RedactedContent)
+	}
+	found := false
+	for _, f := range d.Findings {
+		if f == "pii" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("findings missing pii: %v", d.Findings)
 	}
 }
 

--- a/core/controlplane/safetykernel/content_redact.go
+++ b/core/controlplane/safetykernel/content_redact.go
@@ -1,0 +1,186 @@
+package safetykernel
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ContentFinding is the exported, package-agnostic shape of one detection hit
+// in arbitrary content. It mirrors the internal outputFinding so callers
+// (notably the LLM-proxy ingest path) can reuse the SHIPPED scanners — the same
+// piiScanner / secretScanner / keywordScanner the Safety Kernel uses — without
+// importing the unexported types or duplicating any pattern. This is the
+// content analogue of ScanForPromptInjection.
+type ContentFinding struct {
+	// Type is the scanner finding type: "pii", "secret_leak", "keyword_match",
+	// or "custom" (operator pattern).
+	Type string
+	// Detail is the human-readable rule label (e.g. "email address detected").
+	Detail string
+	// Severity is the scanner severity ("critical" | "high" | "medium").
+	Severity string
+	// Confidence is the scanner confidence in [0,1].
+	Confidence float64
+	// Offset and Length locate the matched span within the scanned content so a
+	// caller can redact exactly that region.
+	Offset int
+	Length int
+}
+
+// NamedContentPattern is an operator-supplied regex (e.g. a salary format or
+// project codename) layered on top of the built-in scanners.
+type NamedContentPattern struct {
+	Name    string
+	Pattern *regexp.Regexp
+}
+
+// ContentScanOptions selects which shipped scanners run plus any operator
+// additions. Zero value scans nothing; the LLM-proxy path enables PII+secrets
+// by default via ContentScanOptionsFromEnv.
+type ContentScanOptions struct {
+	IncludePII     bool
+	IncludeSecrets bool
+	Keywords       []string
+	ExtraPatterns  []NamedContentPattern
+}
+
+// ScanContent runs the selected SHIPPED scanners over content and returns every
+// finding, sorted by offset. It is read-only and side-effect-free; it reuses
+// newPIIScanner / newSecretScanner / newKeywordScanner so there is exactly one
+// detection source of truth across the control plane and the edge.
+func ScanContent(content []byte, opts ContentScanOptions) []ContentFinding {
+	if len(content) == 0 {
+		return nil
+	}
+	var scanners []OutputScanner
+	if opts.IncludeSecrets {
+		scanners = append(scanners, newSecretScanner())
+	}
+	if opts.IncludePII {
+		scanners = append(scanners, newPIIScanner())
+	}
+	if len(opts.Keywords) > 0 {
+		scanners = append(scanners, newKeywordScanner(opts.Keywords))
+	}
+	if len(opts.ExtraPatterns) > 0 {
+		pats := make([]regexPattern, 0, len(opts.ExtraPatterns))
+		for _, np := range opts.ExtraPatterns {
+			if np.Pattern == nil {
+				continue
+			}
+			pats = append(pats, regexPattern{
+				Label:      np.Name,
+				Severity:   "high",
+				Pattern:    np.Pattern.String(),
+				Expression: np.Pattern,
+				Confidence: 0.9,
+			})
+		}
+		if len(pats) > 0 {
+			scanners = append(scanners, newRegexScanner("custom", "custom", pats))
+		}
+	}
+	var findings []ContentFinding
+	for _, sc := range scanners {
+		for _, f := range sc.Scan(content) {
+			findings = append(findings, ContentFinding{
+				Type:       f.Type,
+				Detail:     f.Detail,
+				Severity:   f.Severity,
+				Confidence: float64(f.Confidence),
+				Offset:     int(f.Offset),
+				Length:     int(f.Length),
+			})
+		}
+	}
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Offset != findings[j].Offset {
+			return findings[i].Offset < findings[j].Offset
+		}
+		return findings[i].Length > findings[j].Length // longer span first on a tie
+	})
+	return findings
+}
+
+// RedactContent scans content with the SHIPPED scanners and masks each matched
+// span in place with "<redacted:type>", preserving the surrounding text so an
+// LLM prompt/response stays usable. Returns the redacted string and the
+// findings (offsets refer to the ORIGINAL content). Overlapping spans are
+// merged (earliest finding keeps its type).
+func RedactContent(content []byte, opts ContentScanOptions) (string, []ContentFinding) {
+	findings := ScanContent(content, opts)
+	if len(findings) == 0 {
+		return string(content), nil
+	}
+	text := string(content)
+	var b strings.Builder
+	cursor := 0
+	for _, f := range findings {
+		if f.Offset < cursor || f.Offset < 0 || f.Offset+f.Length > len(text) {
+			continue // overlaps a prior span, or out of range — skip
+		}
+		b.WriteString(text[cursor:f.Offset])
+		b.WriteString("<redacted:")
+		b.WriteString(f.Type)
+		b.WriteString(">")
+		cursor = f.Offset + f.Length
+	}
+	b.WriteString(text[cursor:])
+	return b.String(), findings
+}
+
+// ContentScanOptionsFromEnv builds ContentScanOptions from CORDUM_EDGE_LLM_*
+// environment variables for the LLM-proxy path. PII and secret detection are ON
+// by default (the whole point of the proxy); operators add org-specific terms.
+//
+//	CORDUM_EDGE_LLM_DETECT_PII      = "false" to disable built-in PII (default on)
+//	CORDUM_EDGE_LLM_DETECT_SECRETS  = "false" to disable secrets   (default on)
+//	CORDUM_EDGE_LLM_REDACT_KEYWORDS = comma-separated literal terms
+//	CORDUM_EDGE_LLM_REDACT_PATTERNS = JSON array of {"name","pattern"}
+//
+// Invalid custom regexes are dropped (best-effort).
+func ContentScanOptionsFromEnv(getenv func(string) string) ContentScanOptions {
+	if getenv == nil {
+		return ContentScanOptions{IncludePII: true, IncludeSecrets: true}
+	}
+	notFalse := func(v string) bool {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "false", "0", "no":
+			return false
+		}
+		return true
+	}
+	opts := ContentScanOptions{
+		IncludePII:     notFalse(getenv("CORDUM_EDGE_LLM_DETECT_PII")),
+		IncludeSecrets: notFalse(getenv("CORDUM_EDGE_LLM_DETECT_SECRETS")),
+	}
+	if raw := strings.TrimSpace(getenv("CORDUM_EDGE_LLM_REDACT_KEYWORDS")); raw != "" {
+		for _, kw := range strings.Split(raw, ",") {
+			if t := strings.TrimSpace(kw); t != "" {
+				opts.Keywords = append(opts.Keywords, t)
+			}
+		}
+	}
+	if raw := strings.TrimSpace(getenv("CORDUM_EDGE_LLM_REDACT_PATTERNS")); raw != "" {
+		var specs []struct {
+			Name    string `json:"name"`
+			Pattern string `json:"pattern"`
+		}
+		if err := json.Unmarshal([]byte(raw), &specs); err == nil {
+			for _, s := range specs {
+				name := strings.TrimSpace(s.Name)
+				if name == "" || strings.TrimSpace(s.Pattern) == "" {
+					continue
+				}
+				re, err := regexp.Compile(s.Pattern)
+				if err != nil {
+					continue
+				}
+				opts.ExtraPatterns = append(opts.ExtraPatterns, NamedContentPattern{Name: name, Pattern: re})
+			}
+		}
+	}
+	return opts
+}

--- a/core/controlplane/safetykernel/content_redact.go
+++ b/core/controlplane/safetykernel/content_redact.go
@@ -118,14 +118,26 @@ func RedactContent(content []byte, opts ContentScanOptions) (string, []ContentFi
 	var b strings.Builder
 	cursor := 0
 	for _, f := range findings {
-		if f.Offset < cursor || f.Offset < 0 || f.Offset+f.Length > len(text) {
-			continue // overlaps a prior span, or out of range — skip
+		if f.Offset < 0 || f.Offset+f.Length > len(text) {
+			continue // out of range — skip
+		}
+		end := f.Offset + f.Length
+		if f.Offset < cursor {
+			// Overlaps a span already redacted. Even though this finding's
+			// own marker is dropped (the earlier finding's marker wins), its
+			// span must still be folded into the redacted region — otherwise
+			// any tail extending past the earlier finding's end would be
+			// copied out verbatim as raw, unredacted text below.
+			if end > cursor {
+				cursor = end
+			}
+			continue
 		}
 		b.WriteString(text[cursor:f.Offset])
 		b.WriteString("<redacted:")
 		b.WriteString(f.Type)
 		b.WriteString(">")
-		cursor = f.Offset + f.Length
+		cursor = end
 	}
 	b.WriteString(text[cursor:])
 	return b.String(), findings

--- a/core/controlplane/safetykernel/content_redact_test.go
+++ b/core/controlplane/safetykernel/content_redact_test.go
@@ -1,0 +1,120 @@
+package safetykernel
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const ckAWSKey = "AKIAIOSFODNN7EXAMPLE"
+
+func ckTypes(fs []ContentFinding) map[string]int {
+	out := map[string]int{}
+	for _, f := range fs {
+		out[f.Type]++
+	}
+	return out
+}
+
+func TestScanContent_PIIAndSecret(t *testing.T) {
+	content := []byte("Reach alice@example.com and deploy " + ckAWSKey + " now.")
+	fs := ScanContent(content, ContentScanOptions{IncludePII: true, IncludeSecrets: true})
+	got := ckTypes(fs)
+	if got["pii"] == 0 {
+		t.Fatalf("expected a pii finding (email): %+v", fs)
+	}
+	if got["secret_leak"] == 0 {
+		t.Fatalf("expected a secret_leak finding (aws key): %+v", fs)
+	}
+	// Findings carry offsets so callers can redact exactly the span.
+	for _, f := range fs {
+		if f.Length <= 0 || f.Offset < 0 || f.Offset+f.Length > len(content) {
+			t.Fatalf("finding has bad span: %+v", f)
+		}
+	}
+}
+
+func TestRedactContent_InPlacePreservesProse(t *testing.T) {
+	content := []byte("Email alice@example.com about the plan; key " + ckAWSKey + " ok.")
+	red, fs := RedactContent(content, ContentScanOptions{IncludePII: true, IncludeSecrets: true})
+	if strings.Contains(red, "alice@example.com") || strings.Contains(red, ckAWSKey) {
+		t.Fatalf("redacted content leaked a value: %q", red)
+	}
+	if !strings.Contains(red, "<redacted:pii>") || !strings.Contains(red, "<redacted:secret_leak>") {
+		t.Fatalf("expected in-place markers: %q", red)
+	}
+	for _, keep := range []string{"Email ", " about the plan; key ", " ok."} {
+		if !strings.Contains(red, keep) {
+			t.Fatalf("prose not preserved (%q): %q", keep, red)
+		}
+	}
+	if len(fs) == 0 {
+		t.Fatal("expected findings returned")
+	}
+}
+
+func TestScanContent_Keyword(t *testing.T) {
+	fs := ScanContent([]byte("We discussed Project Titan today."), ContentScanOptions{Keywords: []string{"Project Titan"}})
+	if ckTypes(fs)["keyword_match"] == 0 {
+		t.Fatalf("expected keyword_match: %+v", fs)
+	}
+}
+
+func TestScanContent_CustomPattern(t *testing.T) {
+	salary := regexp.MustCompile(`\$\d{1,3}(?:,\d{3})+`)
+	red, fs := RedactContent([]byte("Comp is $185,000 this year."),
+		ContentScanOptions{ExtraPatterns: []NamedContentPattern{{Name: "salary", Pattern: salary}}})
+	if ckTypes(fs)["custom"] == 0 {
+		t.Fatalf("expected custom finding: %+v", fs)
+	}
+	if strings.Contains(red, "$185,000") {
+		t.Fatalf("salary not redacted: %q", red)
+	}
+}
+
+func TestScanContent_CardLuhn(t *testing.T) {
+	valid := ScanContent([]byte("card 4242 4242 4242 4242 ok"), ContentScanOptions{IncludePII: true})
+	if ckTypes(valid)["pii"] == 0 {
+		t.Fatalf("valid Luhn card should be detected: %+v", valid)
+	}
+	invalid := ScanContent([]byte("ref 1234 5678 9012 3456 ok"), ContentScanOptions{IncludePII: true})
+	if ckTypes(invalid)["pii"] != 0 {
+		t.Fatalf("Luhn-invalid digits should NOT be flagged as a card: %+v", invalid)
+	}
+}
+
+func TestContentScanOptionsFromEnv(t *testing.T) {
+	// Defaults: PII + secrets ON.
+	def := ContentScanOptionsFromEnv(func(string) string { return "" })
+	if !def.IncludePII || !def.IncludeSecrets {
+		t.Fatalf("defaults should enable PII+secrets: %+v", def)
+	}
+	env := map[string]string{
+		"CORDUM_EDGE_LLM_DETECT_PII":      "false",
+		"CORDUM_EDGE_LLM_REDACT_KEYWORDS": "Project Titan, Acme ,",
+		"CORDUM_EDGE_LLM_REDACT_PATTERNS": `[{"name":"salary","pattern":"\\$\\d+"},{"name":"bad","pattern":"("}]`,
+	}
+	opts := ContentScanOptionsFromEnv(func(k string) string { return env[k] })
+	if opts.IncludePII {
+		t.Fatalf("DETECT_PII=false should disable PII: %+v", opts)
+	}
+	if !opts.IncludeSecrets {
+		t.Fatalf("secrets should remain on by default: %+v", opts)
+	}
+	if len(opts.Keywords) != 2 {
+		t.Fatalf("keywords parse wrong: %v", opts.Keywords)
+	}
+	if len(opts.ExtraPatterns) != 1 || opts.ExtraPatterns[0].Name != "salary" {
+		t.Fatalf("only the valid named pattern should survive: %+v", opts.ExtraPatterns)
+	}
+}
+
+func TestScanContent_EmptyAndZeroOptions(t *testing.T) {
+	if fs := ScanContent(nil, ContentScanOptions{IncludePII: true}); fs != nil {
+		t.Fatalf("empty content should yield no findings: %+v", fs)
+	}
+	// Zero options scan nothing even on sensitive content.
+	if fs := ScanContent([]byte(ckAWSKey), ContentScanOptions{}); len(fs) != 0 {
+		t.Fatalf("zero options must scan nothing: %+v", fs)
+	}
+}

--- a/core/controlplane/safetykernel/content_redact_test.go
+++ b/core/controlplane/safetykernel/content_redact_test.go
@@ -53,6 +53,20 @@ func TestRedactContent_InPlacePreservesProse(t *testing.T) {
 	}
 }
 
+func TestScanContent_LLMProviderKey(t *testing.T) {
+	// Unquoted OpenAI/Anthropic-style key must be caught (LLM-proxy critical).
+	for _, c := range []string{
+		"OPENAI_API_KEY=sk-demo1234567890ABCDEFitsnotreal",
+		"use sk-ant-api03-abcdef0123456789ABCDEF please",
+		"stripe sk_live_abcdef0123456789ABCDEF",
+	} {
+		fs := ScanContent([]byte(c), ContentScanOptions{IncludeSecrets: true})
+		if ckTypes(fs)["secret_leak"] == 0 {
+			t.Fatalf("expected secret_leak for %q: %+v", c, fs)
+		}
+	}
+}
+
 func TestScanContent_Keyword(t *testing.T) {
 	fs := ScanContent([]byte("We discussed Project Titan today."), ContentScanOptions{Keywords: []string{"Project Titan"}})
 	if ckTypes(fs)["keyword_match"] == 0 {

--- a/core/controlplane/safetykernel/content_redact_test.go
+++ b/core/controlplane/safetykernel/content_redact_test.go
@@ -123,6 +123,86 @@ func TestContentScanOptionsFromEnv(t *testing.T) {
 	}
 }
 
+// TestRedactContent_OverlapMergesSpans reproduces the leak from a partial
+// overlap: finding A covers offset 0-10, finding B covers offset 5-15 (its
+// tail, chars 10-15, extends past A's end). Before the fix, the merge loop
+// left cursor at A's end (10) when it skipped B, so B's tail ("BBBBB") was
+// copied into the output verbatim on the next write. The fix must advance
+// cursor to max(cursor, B.Offset+B.Length) so the whole overlapping region
+// is folded into one redacted span.
+func TestRedactContent_OverlapMergesSpans(t *testing.T) {
+	content := []byte("AAAAAAAAAABBBBB_TAIL_SECRET_XYZ")
+	outer := regexp.MustCompile(`A{10}`)      // matches offset 0-10
+	inner := regexp.MustCompile(`A{5}B{5}`)   // matches offset 5-15 (tail "BBBBB" beyond outer's end)
+	red, fs := RedactContent(content, ContentScanOptions{
+		ExtraPatterns: []NamedContentPattern{
+			{Name: "outer", Pattern: outer},
+			{Name: "inner", Pattern: inner},
+		},
+	})
+	if len(fs) != 2 {
+		t.Fatalf("expected both overlapping findings reported, got %+v", fs)
+	}
+	if strings.Contains(red, "BBBBB") {
+		t.Fatalf("overlapping finding's tail leaked unredacted: %q", red)
+	}
+	if !strings.Contains(red, "<redacted:custom>") {
+		t.Fatalf("expected a redaction marker: %q", red)
+	}
+	if !strings.Contains(red, "_TAIL_SECRET_XYZ") {
+		t.Fatalf("trailing non-matched text should be preserved: %q", red)
+	}
+	if got, want := red, "<redacted:custom>_TAIL_SECRET_XYZ"; got != want {
+		t.Fatalf("unexpected redacted output: got %q want %q", got, want)
+	}
+}
+
+// TestRedactContent_ContainedFindingDoesNotLeak covers a finding that is
+// fully contained within an earlier, larger finding (not just a partial
+// tail overlap). The contained finding must not reopen any output.
+func TestRedactContent_ContainedFindingDoesNotLeak(t *testing.T) {
+	content := []byte("XXXXXYYYYYZZZZZWWWWW")
+	outer := regexp.MustCompile(`XXXXXYYYYYZZZZZWWWWW`) // offset 0-20
+	inner := regexp.MustCompile(`YYYYYZZZZZ`)            // offset 5-15, fully inside outer
+	red, fs := RedactContent(content, ContentScanOptions{
+		ExtraPatterns: []NamedContentPattern{
+			{Name: "outer", Pattern: outer},
+			{Name: "inner", Pattern: inner},
+		},
+	})
+	if len(fs) != 2 {
+		t.Fatalf("expected both findings reported, got %+v", fs)
+	}
+	if red != "<redacted:custom>" {
+		t.Fatalf("contained finding should not leak or reopen output: got %q", red)
+	}
+}
+
+// TestRedactContent_AdjacentFindingsNotMerged is a regression guard: two
+// findings that merely touch (one ends exactly where the next begins) are
+// NOT overlapping and must both produce their own redaction marker rather
+// than being folded into a single span.
+func TestRedactContent_AdjacentFindingsNotMerged(t *testing.T) {
+	content := []byte("PPPPPQQQQQ")
+	first := regexp.MustCompile(`P{5}`)  // offset 0-5
+	second := regexp.MustCompile(`Q{5}`) // offset 5-10, adjacent (not overlapping)
+	red, fs := RedactContent(content, ContentScanOptions{
+		ExtraPatterns: []NamedContentPattern{
+			{Name: "first", Pattern: first},
+			{Name: "second", Pattern: second},
+		},
+	})
+	if len(fs) != 2 {
+		t.Fatalf("expected both adjacent findings reported, got %+v", fs)
+	}
+	if want := "<redacted:custom><redacted:custom>"; red != want {
+		t.Fatalf("adjacent findings should each get their own marker: got %q want %q", red, want)
+	}
+	if got := strings.Count(red, "<redacted:custom>"); got != 2 {
+		t.Fatalf("expected 2 separate redaction markers, got %d in %q", got, red)
+	}
+}
+
 func TestScanContent_EmptyAndZeroOptions(t *testing.T) {
 	if fs := ScanContent(nil, ContentScanOptions{IncludePII: true}); fs != nil {
 		t.Fatalf("empty content should yield no findings: %+v", fs)

--- a/core/controlplane/safetykernel/scanners.go
+++ b/core/controlplane/safetykernel/scanners.go
@@ -222,6 +222,24 @@ func newSecretScanner() *regexScanner {
 			Expression: regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`),
 			Confidence: 0.98,
 		},
+		{
+			// LLM provider API keys (OpenAI sk-/sk-proj-, Anthropic sk-ant-).
+			// Critical for an LLM-proxy: an unquoted `sk-...` in a prompt would
+			// otherwise slip past the quoted-credential-assignment rule above.
+			Label:      "llm provider api key",
+			Severity:   "critical",
+			Pattern:    `\bsk-[A-Za-z0-9_-]{16,}`,
+			Expression: regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{16,}`),
+			Confidence: 0.95,
+		},
+		{
+			// Stripe-style live/test secret keys.
+			Label:      "stripe secret key",
+			Severity:   "critical",
+			Pattern:    `\bsk_(?:live|test)_[A-Za-z0-9]{16,}`,
+			Expression: regexp.MustCompile(`\bsk_(?:live|test)_[A-Za-z0-9]{16,}`),
+			Confidence: 0.97,
+		},
 	})
 }
 

--- a/core/edge/llmingest/adapter.go
+++ b/core/edge/llmingest/adapter.go
@@ -579,14 +579,39 @@ func buildLLMInput(env LLMEventEnvelope) map[string]any {
 	return input
 }
 
-// redactedContentString returns the redacted "content" value as a string for
-// the proxy to forward, when present. Structured "messages" are not flattened
-// here — the proxy reconstructs those from its own copy guided by Findings.
+// redactedContentString returns the redacted content as a string for the
+// proxy to forward, when present. Single-turn envelopes use the "content"
+// key directly; multi-message envelopes (built via env.Messages) carry their
+// redacted text under "messages" instead, so those are flattened into a
+// "role: content" transcript — otherwise RedactedContent would stay empty for
+// every chat-style envelope even when Decision == DecisionRedact, and a
+// caller following the DecisionRedact contract could fall back to forwarding
+// the unredacted original.
 func redactedContentString(inputRedacted map[string]any) string {
 	if v, ok := inputRedacted["content"].(string); ok {
 		return v
 	}
-	return ""
+	msgs, ok := inputRedacted["messages"].([]any)
+	if !ok || len(msgs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		entry, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		content, _ := entry["content"].(string)
+		if content == "" {
+			continue
+		}
+		if role, ok := entry["role"].(string); ok && role != "" {
+			parts = append(parts, role+": "+content)
+			continue
+		}
+		parts = append(parts, content)
+	}
+	return strings.Join(parts, "\n")
 }
 
 func uniqueFindingTypes(findings []edgecore.RedactionFinding) []string {

--- a/core/edge/llmingest/adapter.go
+++ b/core/edge/llmingest/adapter.go
@@ -174,15 +174,30 @@ type MapResult struct {
 	Dropped   []DropReport
 }
 
-// AdapterOptions configures the adapter. Reserved for forward compatibility;
-// the LLM adapter intentionally has no sampling knob (every chat is governed).
-type AdapterOptions struct{}
+// ContentRedactor redacts a single prompt/response content string and returns
+// the redacted text plus the finding TYPES detected (never raw values). It is
+// INJECTED by the gateway so the LLM-proxy path reuses the shared Safety Kernel
+// scanners — the edge layer never imports the control plane (see
+// safetykernel.RedactContent / the scanners_export injection pattern). When the
+// adapter has no redactor, content falls back to the generic edge secret
+// redactor so the package stays usable and testable standalone.
+type ContentRedactor func(content string) (redacted string, findings []string)
+
+// AdapterOptions configures the adapter. There is intentionally no sampling
+// knob (every chat is governed).
+type AdapterOptions struct {
+	// Redactor, when set, redacts prompt/response content via the shared kernel
+	// scanners. Nil falls back to the generic edge secret redactor.
+	Redactor ContentRedactor
+}
 
 // Adapter validates + maps LLM envelopes into edge.AgentActionEvent records.
-type Adapter struct{}
+type Adapter struct {
+	opts AdapterOptions
+}
 
-// NewAdapter constructs an adapter.
-func NewAdapter(_ AdapterOptions) *Adapter { return &Adapter{} }
+// NewAdapter constructs an adapter with the supplied (optional) injected redactor.
+func NewAdapter(opts AdapterOptions) *Adapter { return &Adapter{opts: opts} }
 
 // Map validates the batch and maps every envelope into an edge.AgentActionEvent
 // plus a per-event advisory decision. The first invalid envelope aborts the
@@ -214,7 +229,7 @@ func (a *Adapter) Map(batch LLMBatch) (MapResult, error) {
 		} else if len(raw) > MaxLLMRawEnvelopeBytes {
 			return MapResult{}, fmt.Errorf("events[%d]: %w: envelope %d bytes > cap %d", i, ErrLLMBatchTooLarge, len(raw), MaxLLMRawEnvelopeBytes)
 		}
-		evt, decision, err := mapEnvelope(sourceID, env)
+		evt, decision, err := a.mapEnvelope(sourceID, env)
 		if err != nil {
 			return MapResult{}, fmt.Errorf("events[%d]: %w", i, err)
 		}
@@ -310,24 +325,10 @@ func isValidDirection(direction string) bool {
 	return false
 }
 
-func mapEnvelope(sourceID string, env LLMEventEnvelope) (edgecore.AgentActionEvent, EventDecision, error) {
-	input := buildLLMInput(env)
-	redacted, err := edgecore.RedactValue(input, edgecore.RedactionOptions{
-		HashMode:       edgecore.RedactionHashNone,
-		MaxDepth:       6,
-		MaxItems:       MaxLLMMessages*2 + 16,
-		MaxStringBytes: MaxLLMRedactedStringBytes,
-		MaxTotalBytes:  MaxLLMRedactedTotalBytes,
-	})
+func (a *Adapter) mapEnvelope(sourceID string, env LLMEventEnvelope) (edgecore.AgentActionEvent, EventDecision, error) {
+	inputRedacted, findingTypes, redactedFlag, truncatedFlag, err := a.redactInput(env)
 	if err != nil {
-		return edgecore.AgentActionEvent{}, EventDecision{}, fmt.Errorf("%w: redaction failed", ErrInvalidEnvelope)
-	}
-	inputRedacted, _ := redacted.Value.(map[string]any)
-	if inputRedacted == nil {
-		// Whole value tripped the too-large guard and collapsed to a string
-		// placeholder. Preserve it under a recognized key so the event still
-		// classifies and the audit trail records that content was present.
-		inputRedacted = map[string]any{"content": redacted.Value}
+		return edgecore.AgentActionEvent{}, EventDecision{}, err
 	}
 
 	eventID := stableEventID(sourceID, env)
@@ -343,8 +344,7 @@ func mapEnvelope(sourceID string, env LLMEventEnvelope) (edgecore.AgentActionEve
 	if d := strings.TrimSpace(env.Direction); d != "" {
 		labels["llm.direction"] = d
 	}
-	findingTypes := uniqueFindingTypes(redacted.Findings)
-	if redacted.Redacted || len(findingTypes) > 0 {
+	if redactedFlag || len(findingTypes) > 0 {
 		labels["llm.redacted"] = "true"
 		for _, ft := range findingTypes {
 			if len(labels) >= edgecore.MaxLabelEntries {
@@ -408,15 +408,122 @@ func mapEnvelope(sourceID string, env LLMEventEnvelope) (edgecore.AgentActionEve
 		SourceEventID:   env.SourceEventID,
 		Kind:            env.Kind,
 		Decision:        DecisionRecord,
-		Redacted:        redacted.Redacted,
-		Truncated:       redacted.Truncated,
+		Redacted:        redactedFlag,
+		Truncated:       truncatedFlag,
 		RedactedContent: redactedContentString(inputRedacted),
 		Findings:        findingTypes,
 	}
-	if redacted.Redacted || len(findingTypes) > 0 {
+	if redactedFlag || len(findingTypes) > 0 {
 		decision.Decision = DecisionRedact
 	}
 	return event, decision, nil
+}
+
+// redactInput produces the redacted InputRedacted map for an envelope plus the
+// finding types, whether anything was redacted, and whether content was
+// truncated. With an injected ContentRedactor (the shared Safety Kernel
+// scanners) it redacts prompt/response content in place, preserving prose;
+// otherwise it falls back to the generic edge secret redactor over the whole
+// input map so the package remains usable standalone.
+func (a *Adapter) redactInput(env LLMEventEnvelope) (map[string]any, []string, bool, bool, error) {
+	if a.opts.Redactor == nil {
+		input := buildLLMInput(env)
+		redacted, err := edgecore.RedactValue(input, edgecore.RedactionOptions{
+			HashMode:       edgecore.RedactionHashNone,
+			MaxDepth:       6,
+			MaxItems:       MaxLLMMessages*2 + 16,
+			MaxStringBytes: MaxLLMRedactedStringBytes,
+			MaxTotalBytes:  MaxLLMRedactedTotalBytes,
+		})
+		if err != nil {
+			return nil, nil, false, false, fmt.Errorf("%w: redaction failed", ErrInvalidEnvelope)
+		}
+		inputRedacted, _ := redacted.Value.(map[string]any)
+		if inputRedacted == nil {
+			// Whole value tripped the too-large guard and collapsed to a string
+			// placeholder. Preserve it under a recognized key so the event still
+			// classifies and the audit trail records that content was present.
+			inputRedacted = map[string]any{"content": redacted.Value}
+		}
+		return inputRedacted, uniqueFindingTypes(redacted.Findings), redacted.Redacted, redacted.Truncated, nil
+	}
+
+	input := map[string]any{}
+	if v := strings.TrimSpace(env.Provider); v != "" {
+		input["provider"] = v
+	}
+	if v := strings.TrimSpace(env.Model); v != "" {
+		input["model"] = v
+	}
+	if v := strings.TrimSpace(env.Direction); v != "" {
+		input["direction"] = v
+	}
+	seen := map[string]struct{}{}
+	var findingTypes []string
+	anyRedacted := false
+	truncated := false
+	redact := func(s string) string {
+		bounded, t := boundLLMString(s)
+		if t {
+			truncated = true
+		}
+		out, fs := a.opts.Redactor(bounded)
+		for _, f := range fs {
+			anyRedacted = true
+			if _, ok := seen[f]; !ok {
+				seen[f] = struct{}{}
+				findingTypes = append(findingTypes, f)
+			}
+		}
+		return out
+	}
+	if env.Content != "" {
+		input["content"] = redact(env.Content)
+	}
+	if len(env.Messages) > 0 {
+		msgs := make([]any, 0, len(env.Messages))
+		for _, m := range env.Messages {
+			entry := map[string]any{}
+			if r := strings.TrimSpace(m.Role); r != "" {
+				entry["role"] = r
+			}
+			if m.Content != "" {
+				entry["content"] = redact(m.Content)
+			}
+			if len(entry) > 0 {
+				msgs = append(msgs, entry)
+			}
+		}
+		if len(msgs) > 0 {
+			input["messages"] = msgs
+		}
+	}
+	if env.Tokens != nil {
+		if env.Tokens.Input > 0 {
+			input["input_tokens"] = env.Tokens.Input
+		}
+		if env.Tokens.Output > 0 {
+			input["output_tokens"] = env.Tokens.Output
+		}
+		if env.Tokens.Total > 0 {
+			input["total_tokens"] = env.Tokens.Total
+		}
+	}
+	if env.CostUSD > 0 {
+		input["cost_usd"] = env.CostUSD
+	}
+	sort.Strings(findingTypes)
+	return input, findingTypes, anyRedacted, truncated, nil
+}
+
+// boundLLMString truncates content to MaxLLMRedactedStringBytes so stored
+// evidence stays bounded; returns whether truncation occurred. A trailing
+// partial rune left by the byte cut is harmless — JSON marshalling sanitizes it.
+func boundLLMString(s string) (string, bool) {
+	if len(s) <= MaxLLMRedactedStringBytes {
+		return s, false
+	}
+	return s[:MaxLLMRedactedStringBytes], true
 }
 
 // buildLLMInput assembles the pre-redaction input map using keys the edge

--- a/core/edge/llmingest/redactor_test.go
+++ b/core/edge/llmingest/redactor_test.go
@@ -1,0 +1,103 @@
+package llmingest
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func redactorEnvelope(content string) LLMEventEnvelope {
+	return LLMEventEnvelope{
+		TenantID:      "tenant-a",
+		SessionID:     "sess-1",
+		ExecutionID:   "exec-1",
+		SourceEventID: "evt-1",
+		ObservedAt:    time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC),
+		Kind:          KindRequestPre,
+		Provider:      "openai",
+		Model:         "gpt-4o-mini",
+		Direction:     DirectionPrompt,
+		Content:       content,
+	}
+}
+
+// TestMap_UsesInjectedRedactor proves the adapter delegates content redaction to
+// the injected (shared Safety Kernel) redactor rather than any edge-local PII
+// logic — content is masked in place, findings surface, and the event is labeled.
+func TestMap_UsesInjectedRedactor(t *testing.T) {
+	called := false
+	fake := func(content string) (string, []string) {
+		called = true
+		if strings.Contains(content, "alice@example.com") {
+			return strings.ReplaceAll(content, "alice@example.com", "<redacted:pii>"), []string{"pii"}
+		}
+		return content, nil
+	}
+	a := NewAdapter(AdapterOptions{Redactor: fake})
+	res, err := a.Map(LLMBatch{
+		Source: SourceIdentity{ID: "openai-proxy"},
+		Events: []LLMEventEnvelope{redactorEnvelope("Summarize 1:1; ping alice@example.com.")},
+	})
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	if !called {
+		t.Fatal("injected redactor was not used")
+	}
+	d := res.Decisions[0]
+	if d.Decision != DecisionRedact {
+		t.Fatalf("decision = %q, want redact", d.Decision)
+	}
+	if strings.Contains(d.RedactedContent, "alice@example.com") {
+		t.Fatalf("redacted content leaked PII: %q", d.RedactedContent)
+	}
+	if !strings.Contains(d.RedactedContent, "Summarize 1:1") {
+		t.Fatalf("prose not preserved: %q", d.RedactedContent)
+	}
+	if len(d.Findings) != 1 || d.Findings[0] != "pii" {
+		t.Fatalf("findings = %v, want [pii]", d.Findings)
+	}
+	if res.Events[0].Labels["llm.finding.pii"] != "true" {
+		t.Fatalf("event missing llm.finding.pii label: %v", res.Events[0].Labels)
+	}
+}
+
+// TestMap_CleanContentViaInjectedRedactor: no findings → record, content intact.
+func TestMap_CleanContentViaInjectedRedactor(t *testing.T) {
+	fake := func(content string) (string, []string) { return content, nil }
+	a := NewAdapter(AdapterOptions{Redactor: fake})
+	res, err := a.Map(LLMBatch{
+		Source: SourceIdentity{ID: "openai-proxy"},
+		Events: []LLMEventEnvelope{redactorEnvelope("summarize the standup")},
+	})
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	d := res.Decisions[0]
+	if d.Decision != DecisionRecord || d.Redacted {
+		t.Fatalf("clean content should record: %+v", d)
+	}
+	if d.RedactedContent != "summarize the standup" {
+		t.Fatalf("clean content should pass through: %q", d.RedactedContent)
+	}
+}
+
+// TestMap_FallsBackWithoutRedactor proves a nil redactor still redacts secrets
+// via the generic edge redactor (the standalone/test path) — Phase 2 behavior.
+func TestMap_FallsBackWithoutRedactor(t *testing.T) {
+	a := NewAdapter(AdapterOptions{}) // no injected redactor
+	res, err := a.Map(LLMBatch{
+		Source: SourceIdentity{ID: "openai-proxy"},
+		Events: []LLMEventEnvelope{redactorEnvelope("deploy with " + awsExampleKey + " now")},
+	})
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	d := res.Decisions[0]
+	if d.Decision != DecisionRedact {
+		t.Fatalf("secret should still redact via fallback: %+v", d)
+	}
+	if !containsString(d.Findings, "aws_credential") {
+		t.Fatalf("fallback should detect aws_credential: %v", d.Findings)
+	}
+}

--- a/core/edge/llmingest/redactor_test.go
+++ b/core/edge/llmingest/redactor_test.go
@@ -82,6 +82,57 @@ func TestMap_CleanContentViaInjectedRedactor(t *testing.T) {
 	}
 }
 
+// TestMap_MultiMessageRedactedContentPopulated proves that a chat-style
+// envelope (env.Messages, not env.Content) still populates RedactedContent
+// via the injected ContentRedactor when Decision == DecisionRedact — the
+// proxy contract for DecisionRedact says it "SHOULD forward RedactedContent
+// instead of the original", so this field must not stay empty just because
+// the envelope used the multi-message shape.
+func TestMap_MultiMessageRedactedContentPopulated(t *testing.T) {
+	fake := func(content string) (string, []string) {
+		if strings.Contains(content, "alice@example.com") {
+			return strings.ReplaceAll(content, "alice@example.com", "<redacted:pii>"), []string{"pii"}
+		}
+		return content, nil
+	}
+	a := NewAdapter(AdapterOptions{Redactor: fake})
+	env := LLMEventEnvelope{
+		TenantID:      "tenant-a",
+		SessionID:     "sess-1",
+		ExecutionID:   "exec-1",
+		SourceEventID: "evt-1",
+		ObservedAt:    time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC),
+		Kind:          KindRequestPre,
+		Provider:      "openai",
+		Model:         "gpt-4o-mini",
+		Direction:     DirectionPrompt,
+		Messages: []LLMMessage{
+			{Role: "system", Content: "Be concise."},
+			{Role: "user", Content: "Summarize 1:1; ping alice@example.com."},
+		},
+	}
+	res, err := a.Map(LLMBatch{
+		Source: SourceIdentity{ID: "openai-proxy"},
+		Events: []LLMEventEnvelope{env},
+	})
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	d := res.Decisions[0]
+	if d.Decision != DecisionRedact {
+		t.Fatalf("decision = %q, want redact", d.Decision)
+	}
+	if d.RedactedContent == "" {
+		t.Fatal("RedactedContent must be populated for a multi-message envelope when Decision == redact")
+	}
+	if strings.Contains(d.RedactedContent, "alice@example.com") {
+		t.Fatalf("redacted content leaked PII: %q", d.RedactedContent)
+	}
+	if !strings.Contains(d.RedactedContent, "Be concise.") || !strings.Contains(d.RedactedContent, "Summarize 1:1") {
+		t.Fatalf("expected both message contents flattened in: %q", d.RedactedContent)
+	}
+}
+
 // TestMap_FallsBackWithoutRedactor proves a nil redactor still redacts secrets
 // via the generic edge redactor (the standalone/test path) — Phase 2 behavior.
 func TestMap_FallsBackWithoutRedactor(t *testing.T) {

--- a/demo/llm-governance/README.md
+++ b/demo/llm-governance/README.md
@@ -79,6 +79,19 @@ The single integration change for any LangChain app:
 ChatOpenAI(model="gpt-4o-mini", base_url="http://localhost:8088/v1", api_key=...)
 ```
 
+## Verified end-to-end (Docker)
+
+Run against the local dev stack, one meeting transcript through the proxy:
+- **Egress:** none of the raw values (names, emails, phone, card, comp, codename, `sk-` key) reached the model.
+- **Audit:** the turn is recorded as `layer=llm`, `decision=RECORDED`, with `llm.finding.{pii,secret_leak,keyword_match,custom}` labels and **only redacted** input stored — e.g. `OPENAI_API_KEY=<redacted:secret_leak>`.
+
+## Gotchas (from the E2E run)
+
+- **Two keys.** Creating the edge session/execution needs an `admin`/`user` role; ingest needs the `llm_proxy` role. The proxy uses `CORDUM_BOOTSTRAP_API_KEY` for the former and `CORDUM_API_KEY` for the latter.
+- **RBAC stacks:** if RBAC is entitled, create the role once — `PUT /api/v1/auth/roles/llm_proxy {"permissions":["edge.llm.ingest"]}` (`setup.sh` does this).
+- **Container env:** the gateway must receive `CORDUM_EDGE_LLM_*` + `CORDUM_API_KEYS` in its *container* environment (compose `environment:`/override), not just a root `.env` the compose file doesn't map.
+- **Local TLS:** the dev gateway cert has no `localhost` SAN → set `CORDUM_TLS_INSECURE=true` for the proxy (run_demo.sh does this).
+
 ## Configuration
 
 Gateway-side (`config/gateway.demo.env`, read by the gateway via

--- a/demo/llm-governance/README.md
+++ b/demo/llm-governance/README.md
@@ -1,0 +1,108 @@
+# LLM data-leakage governance demo
+
+**Scenario:** an AI agent that sits in on meetings and produces summaries +
+action items, built on **LangChain/LangGraph + the OpenAI API**. Meeting
+content is some of the most sensitive data a company has — names, comp, customer
+details, strategy, the occasional secret pasted into notes — and all of it flows
+to a third-party model API.
+
+**What this demo shows:** Cordum puts a governance checkpoint in front of
+OpenAI so **every prompt and response is redacted and audited before it can
+leave your boundary** — with no change to the agent beyond pointing its OpenAI
+client at the Cordum proxy.
+
+```
+  meeting agent ──/v1/chat/completions──▶  Cordum proxy  ──┬──▶ Cordum gateway
+  (LangChain ChatOpenAI,                                   │     POST /api/v1/edge/llm/events
+   base_url = proxy)                                       │     • redact via the SHARED
+                                                           │       Safety Kernel scanners
+                                                           │     • immutable audit (layer=llm)
+                                                           │
+                                                           └──▶ OpenAI  ← receives the
+                                                                          REDACTED payload only
+```
+
+The proxy invents no redaction logic. Detection happens **once**, in Cordum's
+control plane (the Safety Kernel scanners), and the edge/LLM path reuses it —
+one source of truth for the whole platform.
+
+## The three beats
+
+1. **Raw meeting transcript** (`fixtures/meeting_transcript.txt`) — contains
+   names, emails, a phone number, a payment card, a comp figure, a project
+   codename, and an accidentally-pasted API key.
+2. **What OpenAI actually receives** — the proxy prints the redacted payload;
+   every sensitive span is masked in place (`<redacted:pii>`,
+   `<redacted:secret_leak>`, `<redacted:keyword_match>`, `<redacted:custom>`),
+   while the rest of the discussion is preserved so the summary still works.
+3. **Proof for the auditor** — the turn appears in the Edge audit trail
+   (`/api/v1/edge/sessions/<id>/events`) as a `layer=llm` event with
+   `llm.finding.*` labels and **only redacted** input stored — never the raw
+   values.
+
+## What gets redacted (honest)
+
+| In the transcript | Caught by | Mechanism |
+|---|---|---|
+| emails, phone, payment card (Luhn) | built-in **PII scanner** | `safetykernel` `piiScanner` |
+| pasted `sk-…` API key | built-in **secret scanner** | `safetykernel` `secretScanner` |
+| salary / comp figure (`$185,000`) | **custom pattern** (tenant config) | kernel regex scanner |
+| employee names, project codename, company | **keyword roster** (tenant config) | kernel keyword scanner |
+
+These are **regex + Luhn + keyword** detectors — fast, deterministic, in-path.
+They will **not** catch an arbitrary, un-rostered person name in free prose
+(e.g. someone mentioned once). That requires contextual NER/ML, which plugs into
+the same `OutputScanner` interface (Microsoft Presidio / AWS Comprehend / GCP
+DLP) — see *Roadmap* below. We show only redactions that genuinely happen.
+
+## Run it
+
+```bash
+# 0) Cordum stack up (from repo root):  ./tools/scripts/quickstart.sh
+# 1) Enable the demo on the gateway (PII+secret+keyword+custom redaction):
+./setup.sh --apply           # appends config/gateway.demo.env to .env, restarts gateway
+
+# 2) Install proxy + agent deps:
+pip install -r proxy/requirements.txt -r agent/requirements.txt
+
+# 3) Run end-to-end (starts proxy, runs the agent, prints the audit trail):
+./run_demo.sh
+```
+
+Defaults run **fully offline** with a mock upstream — no data is sent to OpenAI
+during the demo (important when the whole point is preventing data egress). To
+forward to the real API: `UPSTREAM=openai OPENAI_API_KEY=sk-… ./run_demo.sh`.
+
+The single integration change for any LangChain app:
+
+```python
+ChatOpenAI(model="gpt-4o-mini", base_url="http://localhost:8088/v1", api_key=...)
+```
+
+## Configuration
+
+Gateway-side (`config/gateway.demo.env`, read by the gateway via
+`safetykernel.ContentScanOptionsFromEnv`):
+
+- `CORDUM_EDGE_LLM_INGEST_ENABLED=true` — expose the endpoint
+- `CORDUM_EDGE_LLM_DETECT_PII` / `_DETECT_SECRETS` — built-in scanners (default on)
+- `CORDUM_EDGE_LLM_REDACT_KEYWORDS` — org roster / codenames (comma-separated)
+- `CORDUM_EDGE_LLM_REDACT_PATTERNS` — org custom regexes (JSON `[{"name","pattern"}]`)
+
+## How it maps to the platform
+
+- **Detection = the Safety Kernel scanners** (`core/controlplane/safetykernel/scanners.go`,
+  exposed via `RedactContent`/`ScanContent` in `content_redact.go`). Edge never
+  re-implements detection; the gateway **injects** the kernel redactor into the
+  `core/edge/llmingest` adapter — edge and control plane share one system.
+- **Ingest + audit** = `POST /api/v1/edge/llm/events` (`llm-proxy` execution
+  adapter, tenant-scoped). See `docs/edge/llm-proxy-governance.md`.
+- **Blocking a prompt/response** (deny, not just redact) reuses the
+  layer-agnostic `POST /api/v1/edge/evaluate` (the safety kernel decision).
+
+## Roadmap (to close the regex gap)
+
+Contextual / ML PII for arbitrary names and entities plugs in behind the
+existing `OutputScanner` interface — Microsoft Presidio, AWS Comprehend, or GCP
+DLP as an additional scanner — with **no change** to the proxy or the edge path,
+because detection is centralized in the kernel.

--- a/demo/llm-governance/agent/meeting_agent.py
+++ b/demo/llm-governance/agent/meeting_agent.py
@@ -1,0 +1,69 @@
+"""Sample meeting-assistant agent (LangChain) — governed by Cordum.
+
+This stands in for a production AI agent that ingests meeting transcripts and
+produces summaries + action items using OpenAI. The ONLY change needed to
+govern it is pointing the OpenAI client's base_url at the Cordum proxy — the
+agent code is otherwise unchanged. Every prompt is then redacted + audited by
+Cordum's control plane before it can reach OpenAI.
+
+Run (after the proxy is up on :8088):
+    pip install -r requirements.txt
+    python meeting_agent.py ../fixtures/meeting_transcript.txt
+
+Plain OpenAI SDK equivalent (no LangChain) — same idea:
+    from openai import OpenAI
+    client = OpenAI(base_url="http://localhost:8088/v1", api_key="not-used-by-mock")
+    client.chat.completions.create(model="gpt-4o-mini", messages=[...])
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+from langchain_openai import ChatOpenAI
+
+PROXY = os.getenv("CORDUM_PROXY_URL", "http://localhost:8088/v1")
+
+SYSTEM = (
+    "You are a meeting assistant. Summarize the meeting and list concrete "
+    "action items with owners and due dates."
+)
+
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else "../fixtures/meeting_transcript.txt"
+    with open(path, encoding="utf-8") as fh:
+        transcript = fh.read()
+
+    # The one line that puts Cordum in the path: base_url -> the governance proxy.
+    llm = ChatOpenAI(
+        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        base_url=PROXY,
+        api_key=os.getenv("OPENAI_API_KEY", "not-used-by-mock"),
+        temperature=0,
+    )
+
+    print("=" * 70)
+    print("  Meeting assistant agent  →  Cordum proxy  →  OpenAI")
+    print("=" * 70)
+    print(f"  proxy: {PROXY}")
+    print(f"  transcript: {path} ({len(transcript)} chars, contains PII + a secret)")
+    print()
+
+    resp = llm.invoke(
+        [
+            ("system", SYSTEM),
+            ("human", f"Here is the meeting transcript:\n\n{transcript}"),
+        ]
+    )
+
+    print("--- model response (what the agent gets back) ---")
+    print(resp.content)
+    print()
+    print("Note: with the default mock upstream, the response echoes exactly the")
+    print("REDACTED payload OpenAI received — proving no raw PII/secrets left the")
+    print("boundary. Check the Cordum dashboard / audit for the recorded turn.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/llm-governance/agent/requirements.txt
+++ b/demo/llm-governance/agent/requirements.txt
@@ -1,0 +1,2 @@
+langchain-openai>=0.2.0
+langchain-core>=0.3.0

--- a/demo/llm-governance/config/gateway.demo.env
+++ b/demo/llm-governance/config/gateway.demo.env
@@ -16,9 +16,13 @@ CORDUM_EDGE_LLM_DETECT_SECRETS=true
 # project codenames, company name. Caught by the kernel keyword scanner.
 CORDUM_EDGE_LLM_REDACT_KEYWORDS=John Smith,Sarah Lee,Jordan Rivera,Project Aurora,Acme Robotics
 
-# Org-specific custom regex (e.g. a salary/comp format). JSON array.
-CORDUM_EDGE_LLM_REDACT_PATTERNS=[{"name":"salary","pattern":"\\$\\s?\\d{1,3}(?:,\\d{3})+"}]
+# Org-specific custom regex (e.g. a salary/comp format). JSON array. The pattern
+# is written without backslashes so it survives .env parsing unchanged
+# ([$] ?[0-9]{1,3}(,[0-9]{3})+ matches $185,000 / $1,250,000).
+CORDUM_EDGE_LLM_REDACT_PATTERNS=[{"name":"salary","pattern":"[$] ?[0-9]{1,3}(,[0-9]{3})+"}]
 
-# A trusted proxy identity (role llm_proxy → permission edge.llm.ingest).
-# The proxy sends source.source_id == this principal_id.
-CORDUM_API_KEYS=[{"key":"demo-llm-proxy-key","tenant":"default","role":"llm_proxy","principal_id":"llm-proxy-1"}]
+# API keys. The proxy needs TWO roles: an admin/user key to create the edge
+# session+execution (bootstrap), and the least-privilege llm_proxy key to push
+# events. Replace the admin key with your stack's real admin key.
+# The proxy sends source.source_id == the llm_proxy principal_id.
+CORDUM_API_KEYS=[{"key":"REPLACE_WITH_STACK_ADMIN_KEY","tenant":"default","role":"admin","principal_id":"admin"},{"key":"demo-llm-proxy-key","tenant":"default","role":"llm_proxy","principal_id":"llm-proxy-1"}]

--- a/demo/llm-governance/config/gateway.demo.env
+++ b/demo/llm-governance/config/gateway.demo.env
@@ -1,0 +1,24 @@
+# Gateway-side configuration for the LLM-governance demo.
+# Merge these into the Cordum stack's top-level .env, then restart api-gateway.
+# The gateway reads CORDUM_EDGE_LLM_* via safetykernel.ContentScanOptionsFromEnv
+# and applies them through the SHARED Safety Kernel scanners — no edge-local
+# detection. PII + secrets are on by default; the keyword roster + salary
+# pattern are this tenant's org-specific additions.
+
+# Expose POST /api/v1/edge/llm/events (disabled by default).
+CORDUM_EDGE_LLM_INGEST_ENABLED=true
+
+# Built-in detectors (default on; shown explicitly for the demo).
+CORDUM_EDGE_LLM_DETECT_PII=true
+CORDUM_EDGE_LLM_DETECT_SECRETS=true
+
+# Org-specific terms a regex/PII detector can't know — employee roster,
+# project codenames, company name. Caught by the kernel keyword scanner.
+CORDUM_EDGE_LLM_REDACT_KEYWORDS=John Smith,Sarah Lee,Jordan Rivera,Project Aurora,Acme Robotics
+
+# Org-specific custom regex (e.g. a salary/comp format). JSON array.
+CORDUM_EDGE_LLM_REDACT_PATTERNS=[{"name":"salary","pattern":"\\$\\s?\\d{1,3}(?:,\\d{3})+"}]
+
+# A trusted proxy identity (role llm_proxy → permission edge.llm.ingest).
+# The proxy sends source.source_id == this principal_id.
+CORDUM_API_KEYS=[{"key":"demo-llm-proxy-key","tenant":"default","role":"llm_proxy","principal_id":"llm-proxy-1"}]

--- a/demo/llm-governance/fixtures/meeting_transcript.txt
+++ b/demo/llm-governance/fixtures/meeting_transcript.txt
@@ -1,0 +1,22 @@
+Weekly Leadership Sync — Acme Robotics — (fictional sample for the demo)
+
+Attendees: John Smith (VP Eng), Sarah Lee (Head of People)
+
+John Smith: Let's start with Project Aurora. We're two weeks behind on the
+launch. I need to bump the lead engineer's comp to retain them — proposing we
+raise their salary to $185,000 effective next quarter.
+
+Sarah Lee: Noted. For the offer letter, send it to the candidate at
+jordan.rivera@example.com and cc me at sarah.lee@acme.example. Their mobile is
++1 (415) 555-0142 if you need to reach them today.
+
+John Smith: Also — finance flagged a corporate card charge. The card on file is
+4242 4242 4242 4242; we should rotate it.
+
+Sarah Lee: One more thing, the staging deploy script still has a hard-coded key
+in it: OPENAI_API_KEY=sk-demo1234567890ABCDEFitsnotreal . Please get that out of
+the repo.
+
+John Smith: Action items: (1) I'll finalize the Project Aurora timeline, (2)
+Sarah sends the Acme Robotics offer to Jordan, (3) we rotate the card and pull
+the key from the deploy script.

--- a/demo/llm-governance/proxy/cordum_openai_proxy.py
+++ b/demo/llm-governance/proxy/cordum_openai_proxy.py
@@ -47,6 +47,9 @@ from fastapi.responses import JSONResponse
 
 GATEWAY = os.getenv("CORDUM_GATEWAY", "https://localhost:8081").rstrip("/")
 API_KEY = os.getenv("CORDUM_API_KEY", "")
+# Session/execution creation requires an admin/user role; LLM ingest requires the
+# least-privilege llm_proxy role. They are distinct keys (defaults to API_KEY).
+BOOTSTRAP_KEY = os.getenv("CORDUM_BOOTSTRAP_API_KEY", API_KEY)
 TENANT = os.getenv("CORDUM_TENANT", "default")
 PRINCIPAL = os.getenv("CORDUM_PROXY_PRINCIPAL", "llm-proxy-1")
 CA_CERT = os.getenv("CORDUM_CA_CERT", "./certs/ca/ca.crt")
@@ -54,17 +57,19 @@ UPSTREAM = os.getenv("UPSTREAM", "mock").lower()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 OPENAI_BASE = os.getenv("OPENAI_BASE", "https://api.openai.com/v1").rstrip("/")
 
-# verify: path to CA bundle when present, else skip (demo-only).
-_VERIFY: Any = CA_CERT if os.path.exists(CA_CERT) else False
+# TLS verification toward the gateway. Set CORDUM_TLS_INSECURE=true for a local
+# self-signed dev stack whose server cert has no "localhost" SAN (demo only).
+_INSECURE = os.getenv("CORDUM_TLS_INSECURE", "").lower() in ("1", "true", "yes")
+_VERIFY: Any = False if _INSECURE else (CA_CERT if os.path.exists(CA_CERT) else False)
 
 app = FastAPI(title="Cordum OpenAI governance proxy")
 
 _state: dict[str, str] = {}  # session_id / execution_id, created at startup
 
 
-def _gw_headers() -> dict[str, str]:
+def _gw_headers(key: str) -> dict[str, str]:
     return {
-        "X-API-Key": API_KEY,
+        "X-API-Key": key,
         "X-Tenant-ID": TENANT,
         "Content-Type": "application/json",
     }
@@ -79,7 +84,7 @@ def _bootstrap_session() -> None:
     with httpx.Client(verify=_VERIFY, timeout=10.0) as c:
         sess = c.post(
             f"{GATEWAY}/api/v1/edge/sessions",
-            headers=_gw_headers(),
+            headers=_gw_headers(BOOTSTRAP_KEY),
             json={
                 "agent_product": "meeting-assistant",
                 "agent_version": "demo",
@@ -92,7 +97,7 @@ def _bootstrap_session() -> None:
         session_id = sess.json()["session_id"]
         exe = c.post(
             f"{GATEWAY}/api/v1/edge/executions",
-            headers=_gw_headers(),
+            headers=_gw_headers(BOOTSTRAP_KEY),
             json={
                 "session_id": session_id,
                 "adapter": "llm-proxy",
@@ -120,7 +125,7 @@ def _ingest(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """POST a batch of LLM events to the gateway; return per-event decisions."""
     body = {"source": {"source_id": PRINCIPAL}, "events": events}
     with httpx.Client(verify=_VERIFY, timeout=15.0) as c:
-        resp = c.post(f"{GATEWAY}/api/v1/edge/llm/events", headers=_gw_headers(), json=body)
+        resp = c.post(f"{GATEWAY}/api/v1/edge/llm/events", headers=_gw_headers(API_KEY), json=body)
         resp.raise_for_status()
         return resp.json().get("decisions", [])
 
@@ -206,7 +211,7 @@ async def chat_completions(request: Request) -> JSONResponse:
     print(f"\n[cordum-proxy] turn={turn} model={model}")
     print(f"  prompt findings: {in_findings or 'none'}")
     if in_findings:
-        print("  → OpenAI will receive the REDACTED prompt (sensitive spans masked)")
+        print("  -> OpenAI will receive the REDACTED prompt (sensitive spans masked)")
 
     if UPSTREAM == "openai" and OPENAI_API_KEY:
         completion = _real_completion(body, redacted_messages)

--- a/demo/llm-governance/proxy/cordum_openai_proxy.py
+++ b/demo/llm-governance/proxy/cordum_openai_proxy.py
@@ -1,0 +1,232 @@
+"""Cordum OpenAI governance proxy.
+
+A drop-in, OpenAI-compatible endpoint that sits between an AI agent (e.g. a
+LangChain/LangGraph meeting assistant) and OpenAI. Every chat turn is routed
+through Cordum's control plane BEFORE it reaches the model provider:
+
+    agent ──/v1/chat/completions──▶ THIS PROXY ──┬─▶ Cordum gateway
+                                                  │     /api/v1/edge/llm/events
+                                                  │     (redact via the SHARED
+                                                  │      Safety Kernel scanners
+                                                  │      + immutable audit)
+                                                  └─▶ OpenAI  (REDACTED payload)
+
+The proxy never invents redaction logic — the gateway does it, using Cordum's
+Safety Kernel scanners (PII + secrets + operator terms). The proxy only swaps
+the outbound message content for the gateway-redacted version, so secrets and
+PII never leave your boundary, and the entire turn lands in the Edge audit trail.
+
+The default upstream is an offline MOCK that echoes exactly what it received —
+so a data-leakage demo never actually ships data to OpenAI. Set UPSTREAM=openai
+(+ OPENAI_API_KEY) to forward to the real API.
+
+Run:
+    pip install -r requirements.txt
+    uvicorn cordum_openai_proxy:app --port 8088
+
+Env:
+    CORDUM_GATEWAY        gateway base URL           (default https://localhost:8081)
+    CORDUM_API_KEY        proxy API key (role=llm_proxy / perm edge.llm.ingest)
+    CORDUM_TENANT         tenant id                  (default "default")
+    CORDUM_PROXY_PRINCIPAL the principal_id bound to the API key (== source_id)
+    CORDUM_CA_CERT        path to the gateway CA cert (default ./certs/ca/ca.crt)
+    UPSTREAM              "mock" | "openai"          (default "mock")
+    OPENAI_API_KEY        upstream key (only for UPSTREAM=openai)
+    OPENAI_BASE           upstream base URL          (default https://api.openai.com/v1)
+"""
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+GATEWAY = os.getenv("CORDUM_GATEWAY", "https://localhost:8081").rstrip("/")
+API_KEY = os.getenv("CORDUM_API_KEY", "")
+TENANT = os.getenv("CORDUM_TENANT", "default")
+PRINCIPAL = os.getenv("CORDUM_PROXY_PRINCIPAL", "llm-proxy-1")
+CA_CERT = os.getenv("CORDUM_CA_CERT", "./certs/ca/ca.crt")
+UPSTREAM = os.getenv("UPSTREAM", "mock").lower()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+OPENAI_BASE = os.getenv("OPENAI_BASE", "https://api.openai.com/v1").rstrip("/")
+
+# verify: path to CA bundle when present, else skip (demo-only).
+_VERIFY: Any = CA_CERT if os.path.exists(CA_CERT) else False
+
+app = FastAPI(title="Cordum OpenAI governance proxy")
+
+_state: dict[str, str] = {}  # session_id / execution_id, created at startup
+
+
+def _gw_headers() -> dict[str, str]:
+    return {
+        "X-API-Key": API_KEY,
+        "X-Tenant-ID": TENANT,
+        "Content-Type": "application/json",
+    }
+
+
+def _bootstrap_session() -> None:
+    """Create the Edge session + llm-proxy execution this proxy records into.
+
+    The proxy is shared infrastructure: it owns an `llm-proxy` execution within
+    the tenant (not bound to any one developer's principal).
+    """
+    with httpx.Client(verify=_VERIFY, timeout=10.0) as c:
+        sess = c.post(
+            f"{GATEWAY}/api/v1/edge/sessions",
+            headers=_gw_headers(),
+            json={
+                "agent_product": "meeting-assistant",
+                "agent_version": "demo",
+                "mode": "enterprise-managed",
+                "policy_snapshot": "demo",
+                "policy_mode": "enforce",
+            },
+        )
+        sess.raise_for_status()
+        session_id = sess.json()["session_id"]
+        exe = c.post(
+            f"{GATEWAY}/api/v1/edge/executions",
+            headers=_gw_headers(),
+            json={
+                "session_id": session_id,
+                "adapter": "llm-proxy",
+                "mode": "enterprise-managed",
+            },
+        )
+        exe.raise_for_status()
+        _state["session_id"] = session_id
+        _state["execution_id"] = exe.json()["execution_id"]
+    print(f"[cordum-proxy] session={_state['session_id']} execution={_state['execution_id']}")
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    if not API_KEY:
+        print("[cordum-proxy] WARNING: CORDUM_API_KEY not set")
+    try:
+        _bootstrap_session()
+    except Exception as exc:  # noqa: BLE001 - surface bootstrap failure clearly
+        print(f"[cordum-proxy] FAILED to create edge session/execution: {exc}")
+        print("[cordum-proxy] is the gateway up with CORDUM_EDGE_LLM_INGEST_ENABLED=true?")
+
+
+def _ingest(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """POST a batch of LLM events to the gateway; return per-event decisions."""
+    body = {"source": {"source_id": PRINCIPAL}, "events": events}
+    with httpx.Client(verify=_VERIFY, timeout=15.0) as c:
+        resp = c.post(f"{GATEWAY}/api/v1/edge/llm/events", headers=_gw_headers(), json=body)
+        resp.raise_for_status()
+        return resp.json().get("decisions", [])
+
+
+def _event(kind: str, direction: str, content: str, seid: str) -> dict[str, Any]:
+    return {
+        "tenant_id": TENANT,
+        "session_id": _state.get("session_id", ""),
+        "execution_id": _state.get("execution_id", ""),
+        "source_event_id": seid,
+        "observed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "kind": kind,
+        "provider": "openai",
+        "direction": direction,
+    } | ({"content": content} if content else {})
+
+
+def _redact_messages(messages: list[dict[str, Any]], turn: str) -> tuple[list[dict[str, Any]], list[str]]:
+    """Send each message through Cordum; return messages with redacted content."""
+    events = [
+        _event("llm.request.pre", "prompt", str(m.get("content", "")), f"{turn}-msg-{i}")
+        for i, m in enumerate(messages)
+        if str(m.get("content", "")).strip()
+    ]
+    if not events:
+        return messages, []
+    decisions = _ingest(events)
+    by_seid = {d["source_event_id"]: d for d in decisions}
+    out, findings = [], []
+    di = 0
+    for i, m in enumerate(messages):
+        content = str(m.get("content", ""))
+        d = by_seid.get(f"{turn}-msg-{i}")
+        if d and content.strip():
+            if d.get("decision") == "redact" and d.get("redacted_content"):
+                content = d["redacted_content"]
+            findings += d.get("findings", [])
+        out.append({**m, "content": content})
+        di += 1
+    return out, sorted(set(findings))
+
+
+def _mock_completion(model: str, redacted_messages: list[dict[str, Any]]) -> dict[str, Any]:
+    last = next((m["content"] for m in reversed(redacted_messages) if m.get("role") == "user"), "")
+    seen = " | ".join(f"{m.get('role')}: {m.get('content','')[:120]}" for m in redacted_messages)
+    text = (
+        "[mock-openai] I only ever received the REDACTED payload below — no raw "
+        "names, emails, comp figures, or secrets reached the model:\n  "
+        + seen[:600]
+        + "\n\n(Action items would be generated here from the redacted transcript.)"
+    )
+    return {
+        "id": f"chatcmpl-mock-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": len(last) // 4, "completion_tokens": 64, "total_tokens": len(last) // 4 + 64},
+    }
+
+
+def _real_completion(body: dict[str, Any], redacted_messages: list[dict[str, Any]]) -> dict[str, Any]:
+    payload = {**body, "messages": redacted_messages}
+    with httpx.Client(timeout=60.0) as c:
+        r = c.post(
+            f"{OPENAI_BASE}/chat/completions",
+            headers={"Authorization": f"Bearer {OPENAI_API_KEY}", "Content-Type": "application/json"},
+            json=payload,
+        )
+        r.raise_for_status()
+        return r.json()
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request) -> JSONResponse:
+    body = await request.json()
+    model = body.get("model", "gpt-4o-mini")
+    messages = body.get("messages", [])
+    turn = uuid.uuid4().hex[:8]
+
+    redacted_messages, in_findings = _redact_messages(messages, turn)
+
+    print(f"\n[cordum-proxy] turn={turn} model={model}")
+    print(f"  prompt findings: {in_findings or 'none'}")
+    if in_findings:
+        print("  → OpenAI will receive the REDACTED prompt (sensitive spans masked)")
+
+    if UPSTREAM == "openai" and OPENAI_API_KEY:
+        completion = _real_completion(body, redacted_messages)
+    else:
+        completion = _mock_completion(model, redacted_messages)
+
+    # Egress governance: audit (and redact) the model's response too.
+    answer = completion.get("choices", [{}])[0].get("message", {}).get("content", "")
+    if answer:
+        out_decisions = _ingest([_event("llm.request.post", "response", answer, f"{turn}-resp")])
+        if out_decisions:
+            od = out_decisions[0]
+            if od.get("decision") == "redact" and od.get("redacted_content"):
+                completion["choices"][0]["message"]["content"] = od["redacted_content"]
+            if od.get("findings"):
+                print(f"  response findings (redacted before return): {od['findings']}")
+
+    return JSONResponse(completion)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {"ok": True, "gateway": GATEWAY, "upstream": UPSTREAM, **_state}

--- a/demo/llm-governance/proxy/requirements.txt
+++ b/demo/llm-governance/proxy/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+uvicorn>=0.29
+httpx>=0.27

--- a/demo/llm-governance/run_demo.sh
+++ b/demo/llm-governance/run_demo.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run the LLM-governance demo end to end:
+#   1) start the Cordum OpenAI governance proxy
+#   2) run the meeting-assistant agent through it
+#   3) show the recorded, redacted turn in the Edge audit trail
+#
+# Prereqs: Cordum stack up + ./setup.sh applied; python3 with the proxy and
+# agent requirements installed. Defaults target the local dev stack.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+
+export CORDUM_GATEWAY="${CORDUM_GATEWAY:-https://localhost:8081}"
+export CORDUM_TENANT="${CORDUM_TENANT:-default}"
+export CORDUM_API_KEY="${CORDUM_API_KEY:-demo-llm-proxy-key}"
+export CORDUM_PROXY_PRINCIPAL="${CORDUM_PROXY_PRINCIPAL:-llm-proxy-1}"
+export CORDUM_CA_CERT="${CORDUM_CA_CERT:-$REPO_ROOT/certs/ca/ca.crt}"
+export UPSTREAM="${UPSTREAM:-mock}"
+PROXY_PORT="${PROXY_PORT:-8088}"
+export CORDUM_PROXY_URL="http://localhost:${PROXY_PORT}/v1"
+
+CURL_CA=( --cacert "$CORDUM_CA_CERT" )
+[[ -f "$CORDUM_CA_CERT" ]] || CURL_CA=( -k )
+
+echo ">> Starting governance proxy on :${PROXY_PORT} (upstream=${UPSTREAM})"
+( cd "$HERE/proxy" && uvicorn cordum_openai_proxy:app --port "$PROXY_PORT" --log-level warning ) &
+PROXY_PID=$!
+trap 'kill "$PROXY_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 30); do
+  if curl -fsS "http://localhost:${PROXY_PORT}/healthz" >/dev/null 2>&1; then break; fi
+  sleep 0.5
+done
+SESSION_ID="$(curl -fsS "http://localhost:${PROXY_PORT}/healthz" | sed -n 's/.*"session_id":"\([^"]*\)".*/\1/p')"
+echo ">> Proxy ready. edge session: ${SESSION_ID:-<unknown>}"
+echo
+
+echo ">> Running meeting-assistant agent through the proxy"
+( cd "$HERE/agent" && python3 meeting_agent.py "$HERE/fixtures/meeting_transcript.txt" )
+echo
+
+if [[ -n "${SESSION_ID:-}" ]]; then
+  echo ">> Recorded, redacted turns in the Edge audit trail:"
+  curl -fsS "${CURL_CA[@]}" \
+    -H "X-API-Key: $CORDUM_API_KEY" -H "X-Tenant-ID: $CORDUM_TENANT" \
+    "${CORDUM_GATEWAY}/api/v1/edge/sessions/${SESSION_ID}/events" || true
+  echo
+  echo "(Note llm.finding.* labels + redacted input — no raw PII/secrets stored.)"
+fi

--- a/demo/llm-governance/run_demo.sh
+++ b/demo/llm-governance/run_demo.sh
@@ -17,6 +17,9 @@ export CORDUM_API_KEY="${CORDUM_API_KEY:-demo-llm-proxy-key}"
 export CORDUM_PROXY_PRINCIPAL="${CORDUM_PROXY_PRINCIPAL:-llm-proxy-1}"
 export CORDUM_CA_CERT="${CORDUM_CA_CERT:-$REPO_ROOT/certs/ca/ca.crt}"
 export UPSTREAM="${UPSTREAM:-mock}"
+# The local dev stack's gateway cert has no "localhost" SAN, so skip TLS verify
+# toward it for the demo. Unset for a stack with a proper cert.
+export CORDUM_TLS_INSECURE="${CORDUM_TLS_INSECURE:-true}"
 PROXY_PORT="${PROXY_PORT:-8088}"
 export CORDUM_PROXY_URL="http://localhost:${PROXY_PORT}/v1"
 

--- a/demo/llm-governance/setup.sh
+++ b/demo/llm-governance/setup.sh
@@ -41,6 +41,20 @@ echo ">> Appending demo gateway settings to $ENV_FILE"
 { echo ""; echo "# --- llm-governance demo (added by setup.sh) ---"; cat "$DEMO_ENV"; } >> "$ENV_FILE"
 
 echo ">> Restarting api-gateway"
+echo "   NOTE: the gateway must receive the CORDUM_EDGE_LLM_* + CORDUM_API_KEYS"
+echo "   vars in its CONTAINER env. If your compose file does not map them from"
+echo "   .env, add them to the api-gateway 'environment:' block (or a compose"
+echo "   override) before restarting — see config/gateway.demo.env."
 ( cd "$REPO_ROOT" && docker compose up -d api-gateway )
+
+# When RBAC is entitled, the llm_proxy role must exist with edge.llm.ingest
+# (built-in roles do not include it). Idempotent; harmless in non-RBAC mode.
+ADMIN_KEY="$(grep -E '^CORDUM_API_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2 | tr -d '"')"
+if [[ -n "$ADMIN_KEY" ]]; then
+  echo ">> Ensuring llm_proxy RBAC role (edge.llm.ingest)"
+  curl -ksS -X PUT "https://localhost:8081/api/v1/auth/roles/llm_proxy" \
+    -H "X-API-Key: $ADMIN_KEY" -H "X-Tenant-ID: default" -H "Content-Type: application/json" \
+    -d '{"description":"LLM proxy ingest","permissions":["edge.llm.ingest"]}' >/dev/null 2>&1 || true
+fi
 
 echo ">> Done. Now run: ./run_demo.sh"

--- a/demo/llm-governance/setup.sh
+++ b/demo/llm-governance/setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Configure the Cordum stack for the LLM-governance demo.
+#
+# This merges the gateway-side settings (config/gateway.demo.env) into the
+# stack's top-level .env and restarts the gateway so POST /api/v1/edge/llm/events
+# is exposed with PII+secret+keyword redaction enabled.
+#
+# Usage:
+#   ./setup.sh            # print the steps (safe, no changes)
+#   ./setup.sh --apply    # append to ../../.env and restart api-gateway
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+DEMO_ENV="$HERE/config/gateway.demo.env"
+
+echo "Repo root: $REPO_ROOT"
+echo "Gateway demo env: $DEMO_ENV"
+echo
+
+if [[ "${1:-}" != "--apply" ]]; then
+  cat <<EOF
+DRY RUN. To enable the demo on a running stack:
+
+  1) Append the gateway settings to your stack .env:
+       cat "$DEMO_ENV" >> "$ENV_FILE"
+
+  2) Restart the gateway so it picks them up:
+       (cd "$REPO_ROOT" && docker compose up -d api-gateway)
+
+  3) Run the demo:
+       ./run_demo.sh
+
+Re-run with --apply to do steps 1-2 automatically.
+EOF
+  exit 0
+fi
+
+echo ">> Appending demo gateway settings to $ENV_FILE"
+{ echo ""; echo "# --- llm-governance demo (added by setup.sh) ---"; cat "$DEMO_ENV"; } >> "$ENV_FILE"
+
+echo ">> Restarting api-gateway"
+( cd "$REPO_ROOT" && docker compose up -d api-gateway )
+
+echo ">> Done. Now run: ./run_demo.sh"


### PR DESCRIPTION
## Govern LLM data egress — reusing the Safety Kernel scanners (not a new edge system)

Stacked on `feat/copilot-llm-proxy` (#372). Target use case: an AI agent built on **LangChain/LangGraph + the OpenAI API** (e.g. a meeting assistant) whose operators fear **sensitive content leaking to the model provider**. This makes the LLM-proxy path **redact + audit every prompt/response** before it reaches OpenAI — and does it the right way architecturally.

### Architecture correction (important)
Detection is **not** duplicated in `core/edge`. It lives once, in the **Safety Kernel scanner framework** (`core/controlplane/safetykernel/scanners.go` — `piiScanner` email/SSN/phone/card+Luhn, `secretScanner`, `keywordScanner`), and the edge/LLM path **reuses** it:

- **`safetykernel/content_redact.go`** (new) exports `ScanContent` / `RedactContent` / `ContentScanOptionsFromEnv` — reusing the shipped scanners + operator custom patterns. Structured findings (`Type, Severity, Confidence, Offset, Length`); in-place span masking that preserves surrounding prose. Mirrors the existing `ScanForPromptInjection` reuse pattern.
- **`core/edge/llmingest`** adapter now takes an **injected `ContentRedactor`**; the **gateway** wires the kernel redactor in (`handlers_edge_llm_ingest.go`), so edge never imports the control plane. Nil → falls back to the generic edge secret redactor (keeps the package standalone-testable).
- PII + secrets on by default for the LLM path; finding taxonomy follows the kernel (`pii`, `secret_leak`, `keyword_match`, `custom`).

> An earlier draft added a parallel PII regex set to the edge redactor — removed. **Edge and control plane share one detection system.**

### Demo — `demo/llm-governance/` (self-contained)
- **OpenAI-compatible governance proxy** (FastAPI): the agent points `ChatOpenAI(base_url=…)` at it; it routes each turn through `POST /api/v1/edge/llm/events` (redact + audit) and forwards only the **redacted** payload upstream.
- **LangChain meeting agent** + **sensitive transcript fixture** (emails, phone, payment card, comp figure, project codename, a pasted API key) + **operator config** (keyword roster + salary pattern) + `setup.sh`/`run_demo.sh` + README (the 3-beat narrative; honest about regex-vs-ML).
- **Default offline mock upstream** — no data is sent to OpenAI during a leakage demo. `UPSTREAM=openai` forwards to the real API.

### Honest scope
Detectors are regex + Luhn + keyword — they will not catch an arbitrary un-rostered name in free prose. Contextual ML/NER PII (**Presidio / AWS Comprehend / GCP DLP**) plugs into the existing `OutputScanner` interface with **no proxy/edge change**, because detection is centralized in the kernel. Documented as roadmap.

### Verification
- `go build ./...`, `vet`, `staticcheck` — clean
- `safetykernel` + `edge` (all) + **full gateway** suites — green
- `py_compile` of proxy + agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)