### PR TITLE
fix(sdk-python): regenerate client for ingest_edge_llm_events and resolve_memory_resource

### DIFF
--- a/sdk/python/src/cordum_sdk/_generated/api/edge/ingest_edge_llm_events.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/edge/ingest_edge_llm_events.py
@@ -1,0 +1,283 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.edge_error import EdgeError
+from ...models.edge_llm_ingest_request import EdgeLLMIngestRequest
+from ...models.edge_llm_ingest_response import EdgeLLMIngestResponse
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    *,
+    body: EdgeLLMIngestRequest,
+    x_tenant_id: str,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+    headers["X-Tenant-ID"] = x_tenant_id
+
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/edge/llm/events",
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, EdgeError, EdgeLLMIngestResponse]]:
+    if response.status_code == 200:
+        response_200 = EdgeLLMIngestResponse.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 201:
+        response_201 = EdgeLLMIngestResponse.from_dict(response.json())
+
+
+
+        return response_201
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 413:
+        response_413 = cast(Any, None)
+        return response_413
+    if response.status_code == 429:
+        response_429 = EdgeError.from_dict(response.json())
+
+
+
+        return response_429
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if response.status_code == 500:
+        response_500 = cast(Any, None)
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, EdgeError, EdgeLLMIngestResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EdgeLLMIngestRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EdgeError, EdgeLLMIngestResponse]]:
+    """ Ingest intercepted LLM chat turns from a trusted proxy
+
+     Disabled by default. When `CORDUM_EDGE_LLM_INGEST_ENABLED` is unset (or non-truthy) the route
+    returns 503 `service_unavailable` and persists nothing. When enabled, an authenticated LLM proxy
+    holding `edge.llm.ingest` submits a bounded batch of intercepted model interactions
+    (prompt/response/cost). The gateway redacts prompt and response content via the Edge redactor,
+    classifies and records each turn as an `AgentActionEvent` with `layer=llm` and `decision=RECORDED`,
+    and returns a per-event advisory decision (`record` | `redact`) plus the redacted content and
+    detected secret finding types. The ALLOW/DENY policy decision is NOT made here — a proxy that must
+    block a prompt pairs this call with `POST /api/v1/edge/evaluate` (layer-agnostic, already classifies
+    `layer=llm`). The `source.source_id` must match the authenticated proxy principal and the referenced
+    session/execution must exist in the tenant under the `llm-proxy` execution adapter. An optional
+    bounded `nonce` is deduplicated against a Redis replay window scoped to `(tenant, llm-proxy)`. Raw
+    provider keys, headers, cookies, and authorization values are rejected at the strict-schema decode
+    boundary. All-or-nothing batch acceptance. See `docs/edge/llm-proxy-governance.md`.
+
+    Args:
+        x_tenant_id (str):
+        body (EdgeLLMIngestRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EdgeError, EdgeLLMIngestResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EdgeLLMIngestRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EdgeError, EdgeLLMIngestResponse]]:
+    """ Ingest intercepted LLM chat turns from a trusted proxy
+
+     Disabled by default. When `CORDUM_EDGE_LLM_INGEST_ENABLED` is unset (or non-truthy) the route
+    returns 503 `service_unavailable` and persists nothing. When enabled, an authenticated LLM proxy
+    holding `edge.llm.ingest` submits a bounded batch of intercepted model interactions
+    (prompt/response/cost). The gateway redacts prompt and response content via the Edge redactor,
+    classifies and records each turn as an `AgentActionEvent` with `layer=llm` and `decision=RECORDED`,
+    and returns a per-event advisory decision (`record` | `redact`) plus the redacted content and
+    detected secret finding types. The ALLOW/DENY policy decision is NOT made here — a proxy that must
+    block a prompt pairs this call with `POST /api/v1/edge/evaluate` (layer-agnostic, already classifies
+    `layer=llm`). The `source.source_id` must match the authenticated proxy principal and the referenced
+    session/execution must exist in the tenant under the `llm-proxy` execution adapter. An optional
+    bounded `nonce` is deduplicated against a Redis replay window scoped to `(tenant, llm-proxy)`. Raw
+    provider keys, headers, cookies, and authorization values are rejected at the strict-schema decode
+    boundary. All-or-nothing batch acceptance. See `docs/edge/llm-proxy-governance.md`.
+
+    Args:
+        x_tenant_id (str):
+        body (EdgeLLMIngestRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EdgeError, EdgeLLMIngestResponse]
+     """
+
+
+    return sync_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EdgeLLMIngestRequest,
+    x_tenant_id: str,
+
+) -> Response[Union[Any, EdgeError, EdgeLLMIngestResponse]]:
+    """ Ingest intercepted LLM chat turns from a trusted proxy
+
+     Disabled by default. When `CORDUM_EDGE_LLM_INGEST_ENABLED` is unset (or non-truthy) the route
+    returns 503 `service_unavailable` and persists nothing. When enabled, an authenticated LLM proxy
+    holding `edge.llm.ingest` submits a bounded batch of intercepted model interactions
+    (prompt/response/cost). The gateway redacts prompt and response content via the Edge redactor,
+    classifies and records each turn as an `AgentActionEvent` with `layer=llm` and `decision=RECORDED`,
+    and returns a per-event advisory decision (`record` | `redact`) plus the redacted content and
+    detected secret finding types. The ALLOW/DENY policy decision is NOT made here — a proxy that must
+    block a prompt pairs this call with `POST /api/v1/edge/evaluate` (layer-agnostic, already classifies
+    `layer=llm`). The `source.source_id` must match the authenticated proxy principal and the referenced
+    session/execution must exist in the tenant under the `llm-proxy` execution adapter. An optional
+    bounded `nonce` is deduplicated against a Redis replay window scoped to `(tenant, llm-proxy)`. Raw
+    provider keys, headers, cookies, and authorization values are rejected at the strict-schema decode
+    boundary. All-or-nothing batch acceptance. See `docs/edge/llm-proxy-governance.md`.
+
+    Args:
+        x_tenant_id (str):
+        body (EdgeLLMIngestRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, EdgeError, EdgeLLMIngestResponse]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+x_tenant_id=x_tenant_id,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: EdgeLLMIngestRequest,
+    x_tenant_id: str,
+
+) -> Optional[Union[Any, EdgeError, EdgeLLMIngestResponse]]:
+    """ Ingest intercepted LLM chat turns from a trusted proxy
+
+     Disabled by default. When `CORDUM_EDGE_LLM_INGEST_ENABLED` is unset (or non-truthy) the route
+    returns 503 `service_unavailable` and persists nothing. When enabled, an authenticated LLM proxy
+    holding `edge.llm.ingest` submits a bounded batch of intercepted model interactions
+    (prompt/response/cost). The gateway redacts prompt and response content via the Edge redactor,
+    classifies and records each turn as an `AgentActionEvent` with `layer=llm` and `decision=RECORDED`,
+    and returns a per-event advisory decision (`record` | `redact`) plus the redacted content and
+    detected secret finding types. The ALLOW/DENY policy decision is NOT made here — a proxy that must
+    block a prompt pairs this call with `POST /api/v1/edge/evaluate` (layer-agnostic, already classifies
+    `layer=llm`). The `source.source_id` must match the authenticated proxy principal and the referenced
+    session/execution must exist in the tenant under the `llm-proxy` execution adapter. An optional
+    bounded `nonce` is deduplicated against a Redis replay window scoped to `(tenant, llm-proxy)`. Raw
+    provider keys, headers, cookies, and authorization values are rejected at the strict-schema decode
+    boundary. All-or-nothing batch acceptance. See `docs/edge/llm-proxy-governance.md`.
+
+    Args:
+        x_tenant_id (str):
+        body (EdgeLLMIngestRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, EdgeError, EdgeLLMIngestResponse]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+x_tenant_id=x_tenant_id,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/api/memory/resolve_memory_resource.py
+++ b/sdk/python/src/cordum_sdk/_generated/api/memory/resolve_memory_resource.py
@@ -1,0 +1,193 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.resolve_memory_resource_body import ResolveMemoryResourceBody
+from ...models.resolve_memory_resource_response_200 import ResolveMemoryResourceResponse200
+from typing import cast
+from typing import Dict
+
+
+
+def _get_kwargs(
+    *,
+    body: ResolveMemoryResourceBody,
+
+) -> Dict[str, Any]:
+    headers: Dict[str, Any] = {}
+
+
+    
+
+    
+
+    _kwargs: Dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v1/memory/resolve",
+    }
+
+    _body = body.to_dict()
+
+
+    _kwargs["json"] = _body
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, ResolveMemoryResourceResponse200]]:
+    if response.status_code == 200:
+        response_200 = ResolveMemoryResourceResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == 413:
+        response_413 = cast(Any, None)
+        return response_413
+    if response.status_code == 503:
+        response_503 = cast(Any, None)
+        return response_503
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, ResolveMemoryResourceResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ResolveMemoryResourceBody,
+
+) -> Response[Union[Any, ResolveMemoryResourceResponse200]]:
+    """ Resolve a structured resource in an authenticated job scope
+
+    Args:
+        body (ResolveMemoryResourceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ResolveMemoryResourceResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ResolveMemoryResourceBody,
+
+) -> Optional[Union[Any, ResolveMemoryResourceResponse200]]:
+    """ Resolve a structured resource in an authenticated job scope
+
+    Args:
+        body (ResolveMemoryResourceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ResolveMemoryResourceResponse200]
+     """
+
+
+    return sync_detailed(
+        client=client,
+body=body,
+
+    ).parsed
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ResolveMemoryResourceBody,
+
+) -> Response[Union[Any, ResolveMemoryResourceResponse200]]:
+    """ Resolve a structured resource in an authenticated job scope
+
+    Args:
+        body (ResolveMemoryResourceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ResolveMemoryResourceResponse200]]
+     """
+
+
+    kwargs = _get_kwargs(
+        body=body,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: ResolveMemoryResourceBody,
+
+) -> Optional[Union[Any, ResolveMemoryResourceResponse200]]:
+    """ Resolve a structured resource in an authenticated job scope
+
+    Args:
+        body (ResolveMemoryResourceBody):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ResolveMemoryResourceResponse200]
+     """
+
+
+    return (await asyncio_detailed(
+        client=client,
+body=body,
+
+    )).parsed

--- a/sdk/python/src/cordum_sdk/_generated/models/__init__.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/__init__.py
@@ -168,6 +168,18 @@ from .edge_execution_metrics import EdgeExecutionMetrics
 from .edge_execution_page_response import EdgeExecutionPageResponse
 from .edge_heartbeat_response import EdgeHeartbeatResponse
 from .edge_labels import EdgeLabels
+from .edge_llm_event_decision import EdgeLLMEventDecision
+from .edge_llm_event_decision_decision import EdgeLLMEventDecisionDecision
+from .edge_llm_event_envelope import EdgeLLMEventEnvelope
+from .edge_llm_event_envelope_direction import EdgeLLMEventEnvelopeDirection
+from .edge_llm_event_envelope_kind import EdgeLLMEventEnvelopeKind
+from .edge_llm_event_envelope_labels import EdgeLLMEventEnvelopeLabels
+from .edge_llm_event_envelope_outcome_status import EdgeLLMEventEnvelopeOutcomeStatus
+from .edge_llm_ingest_request import EdgeLLMIngestRequest
+from .edge_llm_ingest_response import EdgeLLMIngestResponse
+from .edge_llm_ingest_source import EdgeLLMIngestSource
+from .edge_llm_message import EdgeLLMMessage
+from .edge_llm_tokens import EdgeLLMTokens
 from .edge_risk_summary import EdgeRiskSummary
 from .edge_risk_summary_max_risk import EdgeRiskSummaryMaxRisk
 from .edge_runtime_dns_summary import EdgeRuntimeDNSSummary
@@ -420,6 +432,9 @@ from .repair_approval_body import RepairApprovalBody
 from .rerun_workflow_body import RerunWorkflowBody
 from .rerun_workflow_response_200 import RerunWorkflowResponse200
 from .reset_user_password_body import ResetUserPasswordBody
+from .resolve_memory_resource_body import ResolveMemoryResourceBody
+from .resolve_memory_resource_body_reference import ResolveMemoryResourceBodyReference
+from .resolve_memory_resource_response_200 import ResolveMemoryResourceResponse200
 from .resolve_shadow_agent_finding_request import ResolveShadowAgentFindingRequest
 from .retry_dlq_entry_response_200 import RetryDLQEntryResponse200
 from .revoke_delegation_token_body import RevokeDelegationTokenBody
@@ -675,6 +690,18 @@ __all__ = (
     "EdgeExecutionPageResponse",
     "EdgeHeartbeatResponse",
     "EdgeLabels",
+    "EdgeLLMEventDecision",
+    "EdgeLLMEventDecisionDecision",
+    "EdgeLLMEventEnvelope",
+    "EdgeLLMEventEnvelopeDirection",
+    "EdgeLLMEventEnvelopeKind",
+    "EdgeLLMEventEnvelopeLabels",
+    "EdgeLLMEventEnvelopeOutcomeStatus",
+    "EdgeLLMIngestRequest",
+    "EdgeLLMIngestResponse",
+    "EdgeLLMIngestSource",
+    "EdgeLLMMessage",
+    "EdgeLLMTokens",
     "EdgeRiskSummary",
     "EdgeRiskSummaryMaxRisk",
     "EdgeRuntimeDNSSummary",
@@ -905,6 +932,9 @@ __all__ = (
     "RerunWorkflowBody",
     "RerunWorkflowResponse200",
     "ResetUserPasswordBody",
+    "ResolveMemoryResourceBody",
+    "ResolveMemoryResourceBodyReference",
+    "ResolveMemoryResourceResponse200",
     "ResolveShadowAgentFindingRequest",
     "RetryDLQEntryResponse200",
     "RevokeDelegationTokenBody",

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_decision.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_decision.py
@@ -1,0 +1,162 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..models.edge_llm_event_decision_decision import EdgeLLMEventDecisionDecision
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.edge_llm_message import EdgeLLMMessage
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMEventDecision")
+
+
+@_attrs_define
+class EdgeLLMEventDecision:
+    """ Per-event advisory outcome. `decision=redact` means a secret was detected and the proxy should forward
+    `redacted_content` (subject to `truncated`) instead of the original. This is NOT a policy allow/deny decision.
+
+        Attributes:
+            source_event_id (str):
+            kind (str):
+            decision (EdgeLLMEventDecisionDecision):
+            redacted (bool):
+            redaction_complete (bool): Whether this decision reflects a scan of the FULL turn content.
+                Always true except for kind=llm.stream.chunk, where it is true
+                ONLY when the chunk was submitted with final=true (which requires
+                the full aggregated content). A non-final chunk is scanned in
+                isolation and can miss a secret split across a chunk boundary —
+                proxies MUST NOT treat redaction_complete=false as a governance
+                verdict for forwarding purposes.
+            truncated (Union[Unset, bool]):
+            redacted_content (Union[Unset, str]):
+            redacted_messages (Union[Unset, List['EdgeLLMMessage']]): Role-preserving redacted chat messages when the
+                submitted event used `messages`. Absent for content-only (single-string) envelopes.
+            findings (Union[Unset, List[str]]): Detected secret finding TYPES (never values), e.g. aws_credential,
+                bearer_token, private_key.
+     """
+
+    source_event_id: str
+    kind: str
+    decision: EdgeLLMEventDecisionDecision
+    redacted: bool
+    redaction_complete: bool
+    truncated: Union[Unset, bool] = UNSET
+    redacted_content: Union[Unset, str] = UNSET
+    redacted_messages: Union[Unset, List['EdgeLLMMessage']] = UNSET
+    findings: Union[Unset, List[str]] = UNSET
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.edge_llm_message import EdgeLLMMessage
+        source_event_id = self.source_event_id
+
+        kind = self.kind
+
+        decision = self.decision.value
+
+        redacted = self.redacted
+
+        redaction_complete = self.redaction_complete
+
+        truncated = self.truncated
+
+        redacted_content = self.redacted_content
+
+        redacted_messages: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.redacted_messages, Unset):
+            redacted_messages = []
+            for redacted_messages_item_data in self.redacted_messages:
+                redacted_messages_item = redacted_messages_item_data.to_dict()
+                redacted_messages.append(redacted_messages_item)
+
+
+
+        findings: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.findings, Unset):
+            findings = self.findings
+
+
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "source_event_id": source_event_id,
+            "kind": kind,
+            "decision": decision,
+            "redacted": redacted,
+            "redaction_complete": redaction_complete,
+        })
+        if truncated is not UNSET:
+            field_dict["truncated"] = truncated
+        if redacted_content is not UNSET:
+            field_dict["redacted_content"] = redacted_content
+        if redacted_messages is not UNSET:
+            field_dict["redacted_messages"] = redacted_messages
+        if findings is not UNSET:
+            field_dict["findings"] = findings
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.edge_llm_message import EdgeLLMMessage
+        d = src_dict.copy()
+        source_event_id = d.pop("source_event_id")
+
+        kind = d.pop("kind")
+
+        decision = EdgeLLMEventDecisionDecision(d.pop("decision"))
+
+
+
+
+        redacted = d.pop("redacted")
+
+        redaction_complete = d.pop("redaction_complete")
+
+        truncated = d.pop("truncated", UNSET)
+
+        redacted_content = d.pop("redacted_content", UNSET)
+
+        redacted_messages = []
+        _redacted_messages = d.pop("redacted_messages", UNSET)
+        for redacted_messages_item_data in (_redacted_messages or []):
+            redacted_messages_item = EdgeLLMMessage.from_dict(redacted_messages_item_data)
+
+
+
+            redacted_messages.append(redacted_messages_item)
+
+
+        findings = cast(List[str], d.pop("findings", UNSET))
+
+
+        edge_llm_event_decision = cls(
+            source_event_id=source_event_id,
+            kind=kind,
+            decision=decision,
+            redacted=redacted,
+            redaction_complete=redaction_complete,
+            truncated=truncated,
+            redacted_content=redacted_content,
+            redacted_messages=redacted_messages,
+            findings=findings,
+        )
+
+        return edge_llm_event_decision
+

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_decision_decision.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_decision_decision.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class EdgeLLMEventDecisionDecision(str, Enum):
+    RECORD = "record"
+    REDACT = "redact"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope.py
@@ -1,0 +1,331 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..models.edge_llm_event_envelope_direction import EdgeLLMEventEnvelopeDirection
+from ..models.edge_llm_event_envelope_kind import EdgeLLMEventEnvelopeKind
+from ..models.edge_llm_event_envelope_outcome_status import EdgeLLMEventEnvelopeOutcomeStatus
+from ..types import UNSET, Unset
+from dateutil.parser import isoparse
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.edge_llm_message import EdgeLLMMessage
+  from ..models.edge_llm_tokens import EdgeLLMTokens
+  from ..models.edge_llm_event_envelope_labels import EdgeLLMEventEnvelopeLabels
+  from ..models.edge_artifact_pointer import EdgeArtifactPointer
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMEventEnvelope")
+
+
+@_attrs_define
+class EdgeLLMEventEnvelope:
+    """ One intercepted LLM interaction. Smuggled keys (authorization, headers, cookies, api_key, provider keys) are
+    rejected at the strict-schema decode boundary; content and messages are redacted by the gateway before persistence.
+
+        Attributes:
+            tenant_id (str):
+            session_id (str):
+            execution_id (str):
+            source_event_id (str):
+            observed_at (datetime.datetime):
+            kind (EdgeLLMEventEnvelopeKind): llm.stream.chunk carries one delta of a streamed response and is
+                scanned in isolation — a secret split across a chunk boundary can
+                evade per-chunk redaction. A chunk is redaction-complete (see
+                EdgeLLMEventDecision.redaction_complete) ONLY when submitted with
+                final=true and the full aggregated content/messages for the
+                stream. See docs/edge/llm-proxy-governance.md "Streaming chunk
+                redaction limits".
+            outcome_status (Union[Unset, EdgeLLMEventEnvelopeOutcomeStatus]):
+            agent_product (Union[Unset, str]):
+            provider (Union[Unset, str]):
+            model (Union[Unset, str]):
+            direction (Union[Unset, EdgeLLMEventEnvelopeDirection]):
+            content (Union[Unset, str]): Prompt or completion text; bounded by the 1 MiB raw-envelope cap and redacted by
+                the gateway before persistence.
+            messages (Union[Unset, List['EdgeLLMMessage']]):
+            tokens (Union[Unset, EdgeLLMTokens]): Optional token accounting for usage/cost evidence.
+            cost_usd (Union[Unset, float]):
+            labels (Union[Unset, EdgeLLMEventEnvelopeLabels]):
+            artifact_ptrs (Union[Unset, List['EdgeArtifactPointer']]):
+            stream_id (Union[Unset, str]): Groups the chunks of one streamed response. Only meaningful for
+                kind=llm.stream.chunk; reserved as the key for a future server-side reassembly pass.
+            sequence (Union[Unset, int]): 0-based chunk position within stream_id. Only meaningful for
+                kind=llm.stream.chunk.
+            final (Union[Unset, bool]): Marks the last chunk of a stream. When true, content (or messages) MUST carry the
+                full aggregated response text, not just the last delta — required for the mandatory redaction scan to be
+                complete. A final=true chunk with no content or messages is rejected.
+     """
+
+    tenant_id: str
+    session_id: str
+    execution_id: str
+    source_event_id: str
+    observed_at: datetime.datetime
+    kind: EdgeLLMEventEnvelopeKind
+    outcome_status: Union[Unset, EdgeLLMEventEnvelopeOutcomeStatus] = UNSET
+    agent_product: Union[Unset, str] = UNSET
+    provider: Union[Unset, str] = UNSET
+    model: Union[Unset, str] = UNSET
+    direction: Union[Unset, EdgeLLMEventEnvelopeDirection] = UNSET
+    content: Union[Unset, str] = UNSET
+    messages: Union[Unset, List['EdgeLLMMessage']] = UNSET
+    tokens: Union[Unset, 'EdgeLLMTokens'] = UNSET
+    cost_usd: Union[Unset, float] = UNSET
+    labels: Union[Unset, 'EdgeLLMEventEnvelopeLabels'] = UNSET
+    artifact_ptrs: Union[Unset, List['EdgeArtifactPointer']] = UNSET
+    stream_id: Union[Unset, str] = UNSET
+    sequence: Union[Unset, int] = UNSET
+    final: Union[Unset, bool] = UNSET
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.edge_llm_message import EdgeLLMMessage
+        from ..models.edge_llm_tokens import EdgeLLMTokens
+        from ..models.edge_llm_event_envelope_labels import EdgeLLMEventEnvelopeLabels
+        from ..models.edge_artifact_pointer import EdgeArtifactPointer
+        tenant_id = self.tenant_id
+
+        session_id = self.session_id
+
+        execution_id = self.execution_id
+
+        source_event_id = self.source_event_id
+
+        observed_at = self.observed_at.isoformat()
+
+        kind = self.kind.value
+
+        outcome_status: Union[Unset, str] = UNSET
+        if not isinstance(self.outcome_status, Unset):
+            outcome_status = self.outcome_status.value
+
+
+        agent_product = self.agent_product
+
+        provider = self.provider
+
+        model = self.model
+
+        direction: Union[Unset, str] = UNSET
+        if not isinstance(self.direction, Unset):
+            direction = self.direction.value
+
+
+        content = self.content
+
+        messages: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.messages, Unset):
+            messages = []
+            for messages_item_data in self.messages:
+                messages_item = messages_item_data.to_dict()
+                messages.append(messages_item)
+
+
+
+        tokens: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.tokens, Unset):
+            tokens = self.tokens.to_dict()
+
+        cost_usd = self.cost_usd
+
+        labels: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.labels, Unset):
+            labels = self.labels.to_dict()
+
+        artifact_ptrs: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.artifact_ptrs, Unset):
+            artifact_ptrs = []
+            for artifact_ptrs_item_data in self.artifact_ptrs:
+                artifact_ptrs_item = artifact_ptrs_item_data.to_dict()
+                artifact_ptrs.append(artifact_ptrs_item)
+
+
+
+        stream_id = self.stream_id
+
+        sequence = self.sequence
+
+        final = self.final
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "tenant_id": tenant_id,
+            "session_id": session_id,
+            "execution_id": execution_id,
+            "source_event_id": source_event_id,
+            "observed_at": observed_at,
+            "kind": kind,
+        })
+        if outcome_status is not UNSET:
+            field_dict["outcome_status"] = outcome_status
+        if agent_product is not UNSET:
+            field_dict["agent_product"] = agent_product
+        if provider is not UNSET:
+            field_dict["provider"] = provider
+        if model is not UNSET:
+            field_dict["model"] = model
+        if direction is not UNSET:
+            field_dict["direction"] = direction
+        if content is not UNSET:
+            field_dict["content"] = content
+        if messages is not UNSET:
+            field_dict["messages"] = messages
+        if tokens is not UNSET:
+            field_dict["tokens"] = tokens
+        if cost_usd is not UNSET:
+            field_dict["cost_usd"] = cost_usd
+        if labels is not UNSET:
+            field_dict["labels"] = labels
+        if artifact_ptrs is not UNSET:
+            field_dict["artifact_ptrs"] = artifact_ptrs
+        if stream_id is not UNSET:
+            field_dict["stream_id"] = stream_id
+        if sequence is not UNSET:
+            field_dict["sequence"] = sequence
+        if final is not UNSET:
+            field_dict["final"] = final
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.edge_llm_message import EdgeLLMMessage
+        from ..models.edge_llm_tokens import EdgeLLMTokens
+        from ..models.edge_llm_event_envelope_labels import EdgeLLMEventEnvelopeLabels
+        from ..models.edge_artifact_pointer import EdgeArtifactPointer
+        d = src_dict.copy()
+        tenant_id = d.pop("tenant_id")
+
+        session_id = d.pop("session_id")
+
+        execution_id = d.pop("execution_id")
+
+        source_event_id = d.pop("source_event_id")
+
+        observed_at = isoparse(d.pop("observed_at"))
+
+
+
+
+        kind = EdgeLLMEventEnvelopeKind(d.pop("kind"))
+
+
+
+
+        _outcome_status = d.pop("outcome_status", UNSET)
+        outcome_status: Union[Unset, EdgeLLMEventEnvelopeOutcomeStatus]
+        if isinstance(_outcome_status,  Unset):
+            outcome_status = UNSET
+        else:
+            outcome_status = EdgeLLMEventEnvelopeOutcomeStatus(_outcome_status)
+
+
+
+
+        agent_product = d.pop("agent_product", UNSET)
+
+        provider = d.pop("provider", UNSET)
+
+        model = d.pop("model", UNSET)
+
+        _direction = d.pop("direction", UNSET)
+        direction: Union[Unset, EdgeLLMEventEnvelopeDirection]
+        if isinstance(_direction,  Unset):
+            direction = UNSET
+        else:
+            direction = EdgeLLMEventEnvelopeDirection(_direction)
+
+
+
+
+        content = d.pop("content", UNSET)
+
+        messages = []
+        _messages = d.pop("messages", UNSET)
+        for messages_item_data in (_messages or []):
+            messages_item = EdgeLLMMessage.from_dict(messages_item_data)
+
+
+
+            messages.append(messages_item)
+
+
+        _tokens = d.pop("tokens", UNSET)
+        tokens: Union[Unset, EdgeLLMTokens]
+        if isinstance(_tokens,  Unset):
+            tokens = UNSET
+        else:
+            tokens = EdgeLLMTokens.from_dict(_tokens)
+
+
+
+
+        cost_usd = d.pop("cost_usd", UNSET)
+
+        _labels = d.pop("labels", UNSET)
+        labels: Union[Unset, EdgeLLMEventEnvelopeLabels]
+        if isinstance(_labels,  Unset):
+            labels = UNSET
+        else:
+            labels = EdgeLLMEventEnvelopeLabels.from_dict(_labels)
+
+
+
+
+        artifact_ptrs = []
+        _artifact_ptrs = d.pop("artifact_ptrs", UNSET)
+        for artifact_ptrs_item_data in (_artifact_ptrs or []):
+            artifact_ptrs_item = EdgeArtifactPointer.from_dict(artifact_ptrs_item_data)
+
+
+
+            artifact_ptrs.append(artifact_ptrs_item)
+
+
+        stream_id = d.pop("stream_id", UNSET)
+
+        sequence = d.pop("sequence", UNSET)
+
+        final = d.pop("final", UNSET)
+
+        edge_llm_event_envelope = cls(
+            tenant_id=tenant_id,
+            session_id=session_id,
+            execution_id=execution_id,
+            source_event_id=source_event_id,
+            observed_at=observed_at,
+            kind=kind,
+            outcome_status=outcome_status,
+            agent_product=agent_product,
+            provider=provider,
+            model=model,
+            direction=direction,
+            content=content,
+            messages=messages,
+            tokens=tokens,
+            cost_usd=cost_usd,
+            labels=labels,
+            artifact_ptrs=artifact_ptrs,
+            stream_id=stream_id,
+            sequence=sequence,
+            final=final,
+        )
+
+        return edge_llm_event_envelope
+

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_direction.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_direction.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class EdgeLLMEventEnvelopeDirection(str, Enum):
+    PROMPT = "prompt"
+    RESPONSE = "response"
+    VALUE_0 = ""
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_kind.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_kind.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class EdgeLLMEventEnvelopeKind(str, Enum):
+    LLM_COST_RECORDED = "llm.cost.recorded"
+    LLM_REQUEST_POST = "llm.request.post"
+    LLM_REQUEST_PRE = "llm.request.pre"
+    LLM_STREAM_CHUNK = "llm.stream.chunk"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_labels.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_labels.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMEventEnvelopeLabels")
+
+
+@_attrs_define
+class EdgeLLMEventEnvelopeLabels:
+    """ 
+     """
+
+    additional_properties: Dict[str, str] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        edge_llm_event_envelope_labels = cls(
+        )
+
+
+        edge_llm_event_envelope_labels.additional_properties = d
+        return edge_llm_event_envelope_labels
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_outcome_status.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_event_envelope_outcome_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class EdgeLLMEventEnvelopeOutcomeStatus(str, Enum):
+    DEGRADED = "degraded"
+    FAILED = "failed"
+    OK = "ok"
+    VALUE_0 = ""
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_ingest_request.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_ingest_request.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.edge_llm_event_envelope import EdgeLLMEventEnvelope
+  from ..models.edge_llm_ingest_source import EdgeLLMIngestSource
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMIngestRequest")
+
+
+@_attrs_define
+class EdgeLLMIngestRequest:
+    """ 
+        Attributes:
+            source (EdgeLLMIngestSource):
+            events (List['EdgeLLMEventEnvelope']):
+            nonce (Union[Unset, str]): Optional replay-protection nonce. When present it is deduplicated against a Redis
+                replay window scoped to `(tenant, llm-proxy)`. Set `CORDUM_EDGE_LLM_REPLAY_REQUIRED=true` to mandate it.
+            batch_id (Union[Unset, str]): Operator correlation identifier only; not used for replay protection.
+     """
+
+    source: 'EdgeLLMIngestSource'
+    events: List['EdgeLLMEventEnvelope']
+    nonce: Union[Unset, str] = UNSET
+    batch_id: Union[Unset, str] = UNSET
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.edge_llm_event_envelope import EdgeLLMEventEnvelope
+        from ..models.edge_llm_ingest_source import EdgeLLMIngestSource
+        source = self.source.to_dict()
+
+        events = []
+        for events_item_data in self.events:
+            events_item = events_item_data.to_dict()
+            events.append(events_item)
+
+
+
+        nonce = self.nonce
+
+        batch_id = self.batch_id
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "source": source,
+            "events": events,
+        })
+        if nonce is not UNSET:
+            field_dict["nonce"] = nonce
+        if batch_id is not UNSET:
+            field_dict["batch_id"] = batch_id
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.edge_llm_event_envelope import EdgeLLMEventEnvelope
+        from ..models.edge_llm_ingest_source import EdgeLLMIngestSource
+        d = src_dict.copy()
+        source = EdgeLLMIngestSource.from_dict(d.pop("source"))
+
+
+
+
+        events = []
+        _events = d.pop("events")
+        for events_item_data in (_events):
+            events_item = EdgeLLMEventEnvelope.from_dict(events_item_data)
+
+
+
+            events.append(events_item)
+
+
+        nonce = d.pop("nonce", UNSET)
+
+        batch_id = d.pop("batch_id", UNSET)
+
+        edge_llm_ingest_request = cls(
+            source=source,
+            events=events,
+            nonce=nonce,
+            batch_id=batch_id,
+        )
+
+        return edge_llm_ingest_request
+

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_ingest_response.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_ingest_response.py
@@ -1,0 +1,115 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+from typing import List
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast
+from typing import cast, List
+from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+  from ..models.edge_llm_event_decision import EdgeLLMEventDecision
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMIngestResponse")
+
+
+@_attrs_define
+class EdgeLLMIngestResponse:
+    """ 
+        Attributes:
+            accepted_count (int):
+            decisions (Union[Unset, List['EdgeLLMEventDecision']]):
+            replayed (Union[Unset, bool]): True when a duplicate nonce was suppressed and no events were appended. Default:
+                False.
+     """
+
+    accepted_count: int
+    decisions: Union[Unset, List['EdgeLLMEventDecision']] = UNSET
+    replayed: Union[Unset, bool] = False
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.edge_llm_event_decision import EdgeLLMEventDecision
+        accepted_count = self.accepted_count
+
+        decisions: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.decisions, Unset):
+            decisions = []
+            for decisions_item_data in self.decisions:
+                decisions_item = decisions_item_data.to_dict()
+                decisions.append(decisions_item)
+
+
+
+        replayed = self.replayed
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "accepted_count": accepted_count,
+        })
+        if decisions is not UNSET:
+            field_dict["decisions"] = decisions
+        if replayed is not UNSET:
+            field_dict["replayed"] = replayed
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.edge_llm_event_decision import EdgeLLMEventDecision
+        d = src_dict.copy()
+        accepted_count = d.pop("accepted_count")
+
+        decisions = []
+        _decisions = d.pop("decisions", UNSET)
+        for decisions_item_data in (_decisions or []):
+            decisions_item = EdgeLLMEventDecision.from_dict(decisions_item_data)
+
+
+
+            decisions.append(decisions_item)
+
+
+        replayed = d.pop("replayed", UNSET)
+
+        edge_llm_ingest_response = cls(
+            accepted_count=accepted_count,
+            decisions=decisions,
+            replayed=replayed,
+        )
+
+
+        edge_llm_ingest_response.additional_properties = d
+        return edge_llm_ingest_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_ingest_source.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_ingest_source.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMIngestSource")
+
+
+@_attrs_define
+class EdgeLLMIngestSource:
+    """ 
+        Attributes:
+            source_id (str): Stable identifier of the trusted LLM proxy; must match the authenticated proxy principal.
+     """
+
+    source_id: str
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        source_id = self.source_id
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "source_id": source_id,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        source_id = d.pop("source_id")
+
+        edge_llm_ingest_source = cls(
+            source_id=source_id,
+        )
+
+        return edge_llm_ingest_source
+

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_message.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_message.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMMessage")
+
+
+@_attrs_define
+class EdgeLLMMessage:
+    """ One role-tagged chat message; content is redacted before persistence.
+
+        Attributes:
+            role (str):
+            content (str): Message text; bounded by the 1 MiB raw-envelope cap (MaxLLMRawEnvelopeBytes in
+                core/edge/llmingest) and redacted by the gateway before persistence.
+     """
+
+    role: str
+    content: str
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        role = self.role
+
+        content = self.content
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "role": role,
+            "content": content,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        role = d.pop("role")
+
+        content = d.pop("content")
+
+        edge_llm_message = cls(
+            role=role,
+            content=content,
+        )
+
+        return edge_llm_message
+

--- a/sdk/python/src/cordum_sdk/_generated/models/edge_llm_tokens.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/edge_llm_tokens.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="EdgeLLMTokens")
+
+
+@_attrs_define
+class EdgeLLMTokens:
+    """ Optional token accounting for usage/cost evidence.
+
+        Attributes:
+            input_tokens (Union[Unset, int]):
+            output_tokens (Union[Unset, int]):
+            total_tokens (Union[Unset, int]):
+     """
+
+    input_tokens: Union[Unset, int] = UNSET
+    output_tokens: Union[Unset, int] = UNSET
+    total_tokens: Union[Unset, int] = UNSET
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        input_tokens = self.input_tokens
+
+        output_tokens = self.output_tokens
+
+        total_tokens = self.total_tokens
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+        })
+        if input_tokens is not UNSET:
+            field_dict["input_tokens"] = input_tokens
+        if output_tokens is not UNSET:
+            field_dict["output_tokens"] = output_tokens
+        if total_tokens is not UNSET:
+            field_dict["total_tokens"] = total_tokens
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        input_tokens = d.pop("input_tokens", UNSET)
+
+        output_tokens = d.pop("output_tokens", UNSET)
+
+        total_tokens = d.pop("total_tokens", UNSET)
+
+        edge_llm_tokens = cls(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+        )
+
+        return edge_llm_tokens
+

--- a/sdk/python/src/cordum_sdk/_generated/models/resolve_memory_resource_body.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/resolve_memory_resource_body.py
@@ -1,0 +1,68 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+from typing import Dict
+
+if TYPE_CHECKING:
+  from ..models.resolve_memory_resource_body_reference import ResolveMemoryResourceBodyReference
+
+
+
+
+
+T = TypeVar("T", bound="ResolveMemoryResourceBody")
+
+
+@_attrs_define
+class ResolveMemoryResourceBody:
+    """ 
+        Attributes:
+            job_id (str):
+            reference (ResolveMemoryResourceBodyReference):
+     """
+
+    job_id: str
+    reference: 'ResolveMemoryResourceBodyReference'
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.resolve_memory_resource_body_reference import ResolveMemoryResourceBodyReference
+        job_id = self.job_id
+
+        reference = self.reference.to_dict()
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "job_id": job_id,
+            "reference": reference,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.resolve_memory_resource_body_reference import ResolveMemoryResourceBodyReference
+        d = src_dict.copy()
+        job_id = d.pop("job_id")
+
+        reference = ResolveMemoryResourceBodyReference.from_dict(d.pop("reference"))
+
+
+
+
+        resolve_memory_resource_body = cls(
+            job_id=job_id,
+            reference=reference,
+        )
+
+        return resolve_memory_resource_body
+

--- a/sdk/python/src/cordum_sdk/_generated/models/resolve_memory_resource_body_reference.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/resolve_memory_resource_body_reference.py
@@ -1,0 +1,105 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="ResolveMemoryResourceBodyReference")
+
+
+@_attrs_define
+class ResolveMemoryResourceBodyReference:
+    """ 
+        Attributes:
+            resolver_id (str):
+            uri (str):
+            sha256 (str):
+            media_type (str):
+            size_bytes (int):
+            expires_at (datetime.datetime):
+            purpose (str):
+     """
+
+    resolver_id: str
+    uri: str
+    sha256: str
+    media_type: str
+    size_bytes: int
+    expires_at: datetime.datetime
+    purpose: str
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        resolver_id = self.resolver_id
+
+        uri = self.uri
+
+        sha256 = self.sha256
+
+        media_type = self.media_type
+
+        size_bytes = self.size_bytes
+
+        expires_at = self.expires_at.isoformat()
+
+        purpose = self.purpose
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "resolverId": resolver_id,
+            "uri": uri,
+            "sha256": sha256,
+            "mediaType": media_type,
+            "sizeBytes": size_bytes,
+            "expiresAt": expires_at,
+            "purpose": purpose,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        resolver_id = d.pop("resolverId")
+
+        uri = d.pop("uri")
+
+        sha256 = d.pop("sha256")
+
+        media_type = d.pop("mediaType")
+
+        size_bytes = d.pop("sizeBytes")
+
+        expires_at = isoparse(d.pop("expiresAt"))
+
+
+
+
+        purpose = d.pop("purpose")
+
+        resolve_memory_resource_body_reference = cls(
+            resolver_id=resolver_id,
+            uri=uri,
+            sha256=sha256,
+            media_type=media_type,
+            size_bytes=size_bytes,
+            expires_at=expires_at,
+            purpose=purpose,
+        )
+
+        return resolve_memory_resource_body_reference
+

--- a/sdk/python/src/cordum_sdk/_generated/models/resolve_memory_resource_response_200.py
+++ b/sdk/python/src/cordum_sdk/_generated/models/resolve_memory_resource_response_200.py
@@ -1,0 +1,67 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ResolveMemoryResourceResponse200")
+
+
+@_attrs_define
+class ResolveMemoryResourceResponse200:
+    """ 
+        Attributes:
+            media_type (str):
+            size_bytes (int):
+            base64 (str):
+     """
+
+    media_type: str
+    size_bytes: int
+    base64: str
+
+
+    def to_dict(self) -> Dict[str, Any]:
+        media_type = self.media_type
+
+        size_bytes = self.size_bytes
+
+        base64 = self.base64
+
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update({
+            "media_type": media_type,
+            "size_bytes": size_bytes,
+            "base64": base64,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        media_type = d.pop("media_type")
+
+        size_bytes = d.pop("size_bytes")
+
+        base64 = d.pop("base64")
+
+        resolve_memory_resource_response_200 = cls(
+            media_type=media_type,
+            size_bytes=size_bytes,
+            base64=base64,
+        )
+
+        return resolve_memory_resource_response_200
+


### PR DESCRIPTION
## Summary
- `test_every_operation_id_generates_endpoint_module` has been failing on `main` (and every PR that touches `sdk-python.yml`, most recently #396) since PR #372 added the LLM-proxy ingest endpoint and PR #394 added the memory resource-resolution endpoint to the OpenAPI spec without regenerating cordum's own Python SDK client: 233 operationIds vs 231 generated modules.
- Added the two missing endpoint modules (`ingest_edge_llm_events`, `resolve_memory_resource`) and their model dependencies by hand rather than re-running `openapi-python-client` wholesale — the currently-installable generator version (0.21.7) reformats every one of the other 711 existing generated files (different import style/docstring quoting), which would turn this into a ~96k-line diff instead of the ~30-line additive one it should be.
- Also found, but left alone as an unrelated pre-existing drift: two renamed/removed worker-credential and shadow-agent-finding schemas the generator no longer emits under their old names. Out of scope for this fix.

## Test plan
- [x] `pytest tests/` in `sdk/python` — 56/56 pass (previously 55 passed, 1 failed)
- [x] Manually imported every new module/class to confirm no import errors
- [x] Confirmed the only non-EOL-noise diff is the 17 new files + a 30-line additive change to `models/__init__.py`