### PR TITLE
build(deps): bump cap dependency to the published v2.16.1 tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     env:
-      CAP_REV: 7c3cec3236c1970bbeb71951826eb3bcfc1d17d5
-      CAP_HANDSHAKE_CAP_SHA: 7c3cec3236c1970bbeb71951826eb3bcfc1d17d5
+      CAP_REV: 32b9db9670c597685344808272f9b246026091ba
+      CAP_HANDSHAKE_CAP_SHA: 32b9db9670c597685344808272f9b246026091ba
       CAP_HANDSHAKE_REDIS_URL: redis://127.0.0.1:6379/0
     services:
       redis:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ toolchain go1.26.5
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/alicebob/miniredis/v2 v2.38.0
-	github.com/cordum-io/cap/v2 v2.15.2-0.20260721195051-7c3cec3236c1
+	github.com/cordum-io/cap/v2 v2.16.1
 	github.com/cordum/cordum/sdk v0.0.0
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/crewjam/saml v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cordum-io/cap/v2 v2.15.2-0.20260721195051-7c3cec3236c1 h1:bH1oVrLXsZSsQGVGZm1nuUYiTMCZox+/cqPFZfHH8SE=
-github.com/cordum-io/cap/v2 v2.15.2-0.20260721195051-7c3cec3236c1/go.mod h1:NEQzP0Xu0fqpk4ZufJzxcmYUYY+ZW1Ka+XIhohAWOIk=
+github.com/cordum-io/cap/v2 v2.16.1 h1:mM/eh+ZkfBzDk3CHOAzIRn+hPJRr6rw9x/kOuynspoo=
+github.com/cordum-io/cap/v2 v2.16.1/go.mod h1:NEQzP0Xu0fqpk4ZufJzxcmYUYY+ZW1Ka+XIhohAWOIk=
 github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
 github.com/coreos/go-oidc/v3 v3.20.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/tests/handshakeinterop/run.ps1
+++ b/tests/handshakeinterop/run.ps1
@@ -23,11 +23,20 @@ function Assert-CapRevision {
     Assert-NativeSuccess 'read full CAP revision'
     $CapVersion = (& go -C $CordumRoot list -m -f '{{.Version}}' github.com/cordum-io/cap/v2).Trim()
     Assert-NativeSuccess 'read Cordum CAP pin'
-    if ($CapVersion -notmatch '-([0-9a-f]{12})$') {
-        throw "Cordum CAP version lacks a 12-hex revision suffix: $CapVersion"
+    if ($CapVersion -match '-([0-9a-f]{12})$') {
+        # Pseudo-version: the commit hash is embedded in the version string.
+        $PinnedSha = (& git -C $CapRoot rev-parse "$($Matches[1])^{commit}").Trim()
+        Assert-NativeSuccess 'resolve Cordum CAP revision in source repository'
     }
-    $PinnedSha = (& git -C $CapRoot rev-parse "$($Matches[1])^{commit}").Trim()
-    Assert-NativeSuccess 'resolve Cordum CAP revision in source repository'
+    else {
+        # Clean release tag (e.g. v2.16.1): resolve the tag itself in the
+        # checked-out CAP source (requires the checkout step to have fetched
+        # tags) instead of parsing a hash out of the version string.
+        $PinnedSha = (& git -C $CapRoot rev-parse "refs/tags/$CapVersion^{commit}" 2>$null).Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($PinnedSha)) {
+            throw "Cordum CAP version $CapVersion has no matching tag in the checked-out CAP source"
+        }
+    }
     if ($CapSha -ne $PinnedSha) {
         throw "CAP source $CapSha does not match Cordum pin $PinnedSha"
     }


### PR DESCRIPTION
## Summary
- Replaces the pseudo-version pin (`v2.15.2-0.20260721195051-7c3cec3`, an untagged commit tracked during #394's development) with cap's actual published `v2.16.1` release tag.
- cap v2.16.1 is now live and independently verified on all four registries: `pypi.org/cap-sdk-python`, `pypi.org/cordum-guard`, `registry.npmjs.org/cap-sdk-node`, `proxy.golang.org/github.com/cordum-io/cap/v2`.
- Updates `CAP_REV`/`CAP_HANDSHAKE_CAP_SHA` in `.github/workflows/ci.yml` to the tag's commit SHA for the handshake trust interop job.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` — full suite passes
- [x] `tools/scripts/handshake_interop_workflow.test.sh` — self-test confirms `CAP_REV` matches the tag's commit SHA and correctly detects go.mod pins a release tag (skips the offline pseudo-version cross-check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handshake trust interoperability verification by making CAP revision/tag resolution more reliable, including clearer failure messages when a matching tag can’t be found.
- **Chores**
  - Updated the handshake interoperability CI verification to use the latest pinned CAP revision.
  - Upgraded the CAP library dependency to **v2.16.1** to keep compatibility testing current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->