### PR TITLE
fix(ci): fall back to count-only star tracking when no PAT is present

### DIFF
--- a/.github/workflows/star-tracker.yml
+++ b/.github/workflows/star-tracker.yml
@@ -74,13 +74,26 @@ jobs:
       - name: Fetch current stargazers
         id: fetch_stargazers
         env:
-          GH_TOKEN: ${{ github.token }}
+          # A STARGAZER_PAT secret (classic PAT, public_repo scope) restores
+          # full per-user unstar detection. Without one, github.token gets a
+          # 403 on the stargazers endpoint regardless of media type (verified
+          # by manual dispatch — see #406), so this falls back to tracking
+          # just the stargazer count: still catches "someone unstarred" but
+          # can't say who.
+          GH_TOKEN: ${{ secrets.STARGAZER_PAT || github.token }}
         run: |
-          bash tools/scripts/fetch_stargazers.sh \
-            --repo "${REPO_FULL_NAME}" \
-            --output /tmp/current_usernames.txt
-          TOTAL=$(wc -l < /tmp/current_usernames.txt | tr -d ' ')
-          echo "📊 Current stargazers: ${TOTAL}"
+          if bash tools/scripts/fetch_stargazers.sh \
+              --repo "${REPO_FULL_NAME}" \
+              --output /tmp/current_usernames.txt; then
+            TOTAL=$(wc -l < /tmp/current_usernames.txt | tr -d ' ')
+            echo "📊 Current stargazers: ${TOTAL} (per-user mode)"
+            echo "mode=usernames" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Per-user stargazer listing unavailable (add a STARGAZER_PAT secret to restore it) — falling back to count-only tracking."
+            gh api "repos/${REPO_FULL_NAME}" --jq '.stargazers_count' > /tmp/current_count.txt
+            echo "📊 Current stargazers: $(cat /tmp/current_count.txt) (count-only mode)"
+            echo "mode=count" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download previous snapshot
         env:
@@ -99,46 +112,69 @@ jobs:
           cd /tmp/previous
           unzip -o snapshot.zip
           rm snapshot.zip
-          if [ ! -f current_usernames.txt ]; then
-            echo "Snapshot artifact is missing current_usernames.txt" >&2
+          if [ ! -f current_usernames.txt ] && [ ! -f current_count.txt ]; then
+            echo "Snapshot artifact has neither current_usernames.txt nor current_count.txt" >&2
             exit 1
           fi
-          mv current_usernames.txt stargazers.txt
+          [ -f current_usernames.txt ] && mv current_usernames.txt stargazers.txt
+          [ -f current_count.txt ] && mv current_count.txt count.txt
+          true
 
       - name: Compare and detect unstars
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         run: |
-          if [ ! -f /tmp/previous/stargazers.txt ]; then
-            echo "📝 No previous snapshot — this is the first run. Saving baseline."
+          MODE="${{ steps.fetch_stargazers.outputs.mode }}"
+
+          if [ "$MODE" = "usernames" ] && [ -f /tmp/previous/stargazers.txt ]; then
+            # Find users in previous but NOT in current = unstars
+            comm -23 /tmp/previous/stargazers.txt /tmp/current_usernames.txt > /tmp/unstars.txt
+            # Find users in current but NOT in previous = new stars (caught by watch event too)
+            comm -13 /tmp/previous/stargazers.txt /tmp/current_usernames.txt > /tmp/new_stars.txt
+
+            UNSTAR_COUNT=$(wc -l < /tmp/unstars.txt | tr -d ' ')
+            NEW_COUNT=$(wc -l < /tmp/new_stars.txt | tr -d ' ')
+            PREV_TOTAL=$(wc -l < /tmp/previous/stargazers.txt | tr -d ' ')
+            CURR_TOTAL=$(wc -l < /tmp/current_usernames.txt | tr -d ' ')
+
+            echo "📊 Previous: ${PREV_TOTAL} → Current: ${CURR_TOTAL} (${NEW_COUNT} new, ${UNSTAR_COUNT} removed)"
+
+            if [ "$UNSTAR_COUNT" = "0" ]; then
+              echo "✅ No unstars detected"
+              exit 0
+            fi
+
+            echo "⚠️ Unstars detected:"
+            cat /tmp/unstars.txt
+
+            UNSTAR_LIST=""
+            while IFS= read -r user; do
+              UNSTAR_LIST="${UNSTAR_LIST}<li><a href='https://github.com/${user}'>${user}</a></li>"
+            done < /tmp/unstars.txt
+            SUBJECT="⚠️ ${UNSTAR_COUNT} user(s) unstarred ${REPO_FULL_NAME}"
+            BODY_EXTRA="<h3>Who left:</h3><ul>${UNSTAR_LIST}</ul>"
+
+          elif [ "$MODE" = "count" ] && [ -f /tmp/previous/count.txt ]; then
+            PREV_TOTAL=$(cat /tmp/previous/count.txt)
+            CURR_TOTAL=$(cat /tmp/current_count.txt)
+            DELTA=$((PREV_TOTAL - CURR_TOTAL))
+
+            echo "📊 Previous: ${PREV_TOTAL} → Current: ${CURR_TOTAL}"
+
+            if [ "$DELTA" -le 0 ]; then
+              echo "✅ No net star loss detected"
+              exit 0
+            fi
+
+            echo "⚠️ Net star count dropped by ${DELTA} (count-only mode — individual usernames unavailable; add a STARGAZER_PAT secret to restore those)"
+            UNSTAR_COUNT="${DELTA}"
+            SUBJECT="⚠️ Star count dropped by ${DELTA} on ${REPO_FULL_NAME}"
+            BODY_EXTRA="<p><em>Running in count-only mode — add a STARGAZER_PAT repo secret to see who unstarred.</em></p>"
+
+          else
+            echo "📝 No comparable previous snapshot (first run, or mode changed since last run) — saving baseline."
             exit 0
           fi
-
-          # Find users in previous but NOT in current = unstars
-          comm -23 /tmp/previous/stargazers.txt /tmp/current_usernames.txt > /tmp/unstars.txt
-          # Find users in current but NOT in previous = new stars (caught by watch event too)
-          comm -13 /tmp/previous/stargazers.txt /tmp/current_usernames.txt > /tmp/new_stars.txt
-
-          UNSTAR_COUNT=$(wc -l < /tmp/unstars.txt | tr -d ' ')
-          NEW_COUNT=$(wc -l < /tmp/new_stars.txt | tr -d ' ')
-          PREV_TOTAL=$(wc -l < /tmp/previous/stargazers.txt | tr -d ' ')
-          CURR_TOTAL=$(wc -l < /tmp/current_usernames.txt | tr -d ' ')
-
-          echo "📊 Previous: ${PREV_TOTAL} → Current: ${CURR_TOTAL} (${NEW_COUNT} new, ${UNSTAR_COUNT} removed)"
-
-          if [ "$UNSTAR_COUNT" = "0" ]; then
-            echo "✅ No unstars detected"
-            exit 0
-          fi
-
-          echo "⚠️ Unstars detected:"
-          cat /tmp/unstars.txt
-
-          # Build email body
-          UNSTAR_LIST=""
-          while IFS= read -r user; do
-            UNSTAR_LIST="${UNSTAR_LIST}<li><a href='https://github.com/${user}'>${user}</a></li>"
-          done < /tmp/unstars.txt
 
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -154,8 +190,8 @@ jobs:
           {
             "from": "Cordum Stars <stars@cordum.io>",
             "to": ["$NOTIFY_EMAIL"],
-            "subject": "⚠️ ${UNSTAR_COUNT} user(s) unstarred ${REPO_FULL_NAME}",
-            "html": "<h2>Star Removal Alert</h2><p><strong>${UNSTAR_COUNT}</strong> user(s) removed their star from <a href='https://github.com/${REPO_FULL_NAME}'>${REPO_FULL_NAME}</a></p><h3>Who left:</h3><ul>${UNSTAR_LIST}</ul><p>Star count: ${PREV_TOTAL} → ${CURR_TOTAL}</p><p>Detected at: ${TIMESTAMP}</p><p><a href='https://github.com/${REPO_FULL_NAME}/stargazers'>View current stargazers</a></p>"
+            "subject": "${SUBJECT}",
+            "html": "<h2>Star Removal Alert</h2><p><strong>${UNSTAR_COUNT}</strong> star(s) lost on <a href='https://github.com/${REPO_FULL_NAME}'>${REPO_FULL_NAME}</a></p>${BODY_EXTRA}<p>Star count: ${PREV_TOTAL} → ${CURR_TOTAL}</p><p>Detected at: ${TIMESTAMP}</p><p><a href='https://github.com/${REPO_FULL_NAME}/stargazers'>View current stargazers</a></p>"
           }
           PAYLOAD
           )"
@@ -167,6 +203,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: stargazer-snapshot
-          path: /tmp/current_usernames.txt
+          path: |
+            /tmp/current_usernames.txt
+            /tmp/current_count.txt
           overwrite: true
           retention-days: 90

--- a/.github/workflows/star-tracker.yml
+++ b/.github/workflows/star-tracker.yml
@@ -126,15 +126,30 @@ jobs:
         run: |
           MODE="${{ steps.fetch_stargazers.outputs.mode }}"
 
+          # A previous total is derivable from either snapshot shape (line
+          # count of the username list, or the stored count itself), so a
+          # mode change between runs (e.g. a STARGAZER_PAT was just added
+          # or removed) still gets a real count comparison instead of being
+          # silently treated as a first run.
+          PREV_TOTAL=""
+          if [ -f /tmp/previous/stargazers.txt ]; then
+            PREV_TOTAL=$(wc -l < /tmp/previous/stargazers.txt | tr -d ' ')
+          elif [ -f /tmp/previous/count.txt ]; then
+            PREV_TOTAL=$(cat /tmp/previous/count.txt)
+          fi
+
+          if [ -z "$PREV_TOTAL" ]; then
+            echo "📝 No previous snapshot — this is the first run. Saving baseline."
+            exit 0
+          fi
+
           if [ "$MODE" = "usernames" ] && [ -f /tmp/previous/stargazers.txt ]; then
-            # Find users in previous but NOT in current = unstars
+            # Both sides have a username list: full per-user diff.
             comm -23 /tmp/previous/stargazers.txt /tmp/current_usernames.txt > /tmp/unstars.txt
-            # Find users in current but NOT in previous = new stars (caught by watch event too)
             comm -13 /tmp/previous/stargazers.txt /tmp/current_usernames.txt > /tmp/new_stars.txt
 
             UNSTAR_COUNT=$(wc -l < /tmp/unstars.txt | tr -d ' ')
             NEW_COUNT=$(wc -l < /tmp/new_stars.txt | tr -d ' ')
-            PREV_TOTAL=$(wc -l < /tmp/previous/stargazers.txt | tr -d ' ')
             CURR_TOTAL=$(wc -l < /tmp/current_usernames.txt | tr -d ' ')
 
             echo "📊 Previous: ${PREV_TOTAL} → Current: ${CURR_TOTAL} (${NEW_COUNT} new, ${UNSTAR_COUNT} removed)"
@@ -154,9 +169,14 @@ jobs:
             SUBJECT="⚠️ ${UNSTAR_COUNT} user(s) unstarred ${REPO_FULL_NAME}"
             BODY_EXTRA="<h3>Who left:</h3><ul>${UNSTAR_LIST}</ul>"
 
-          elif [ "$MODE" = "count" ] && [ -f /tmp/previous/count.txt ]; then
-            PREV_TOTAL=$(cat /tmp/previous/count.txt)
-            CURR_TOTAL=$(cat /tmp/current_count.txt)
+          else
+            # Either side is count-only (same-mode count comparison, or a
+            # mode transition): total-only comparison, no usernames.
+            if [ "$MODE" = "usernames" ]; then
+              CURR_TOTAL=$(wc -l < /tmp/current_usernames.txt | tr -d ' ')
+            else
+              CURR_TOTAL=$(cat /tmp/current_count.txt)
+            fi
             DELTA=$((PREV_TOTAL - CURR_TOTAL))
 
             echo "📊 Previous: ${PREV_TOTAL} → Current: ${CURR_TOTAL}"
@@ -166,14 +186,10 @@ jobs:
               exit 0
             fi
 
-            echo "⚠️ Net star count dropped by ${DELTA} (count-only mode — individual usernames unavailable; add a STARGAZER_PAT secret to restore those)"
+            echo "⚠️ Net star count dropped by ${DELTA} (count-only comparison — individual usernames unavailable; add a STARGAZER_PAT secret to restore those)"
             UNSTAR_COUNT="${DELTA}"
             SUBJECT="⚠️ Star count dropped by ${DELTA} on ${REPO_FULL_NAME}"
-            BODY_EXTRA="<p><em>Running in count-only mode — add a STARGAZER_PAT repo secret to see who unstarred.</em></p>"
-
-          else
-            echo "📝 No comparable previous snapshot (first run, or mode changed since last run) — saving baseline."
-            exit 0
+            BODY_EXTRA="<p><em>Count-only comparison — add a STARGAZER_PAT repo secret to see who unstarred.</em></p>"
           fi
 
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary
Follow-up to #406, which removed an unused header but (as documented there) did not actually fix Star Tracker's `detect-unstars` job — `github.token` gets a 403 on the stargazers endpoint regardless of media type, confirmed by manual dispatch.

This makes the workflow degrade gracefully instead of failing every 15 minutes:
- If a `STARGAZER_PAT` secret (classic PAT, `public_repo` scope) is ever added, full per-user unstar detection resumes automatically — no further code changes needed.
- Otherwise, falls back to comparing `repos/{repo}.stargazers_count` (ordinary repo metadata, always readable by `github.token`) and alerts on net count drops, without naming who unstarred.

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [x] Each embedded shell step syntax-checked (`bash -n`)
- [ ] Will manually dispatch against this branch to confirm the job now completes successfully before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional enhanced tracking to report per-user star additions/removals when available.
  * Added improved count-only tracking that continues working when individual stargazer data isn’t accessible.
  * Updated email alerts to use mode-specific wording and templates.
* **Bug Fixes**
  * Improved snapshot file validation and standardized saved snapshot naming for better reliability.
  * Updated first-run/baseline and tracking-mode change handling to avoid false alerts. 
  * Expanded stored tracking snapshots to include both usernames and total star counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->