### PR TITLE
CAP v2.17.0 promotion capstone: version-consistency guard, claim truth, dashboard wire-contract fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+#### CAP dependency promoted to the published v2.17.0 release (2026-07-22, task-a24b53c5)
+
+- Root and nested `sdk` modules pin the released `github.com/cordum-io/cap/v2 v2.17.0`
+  (tag commit `e580c670d54a7563c749835c7dd09d81f116c823`), completed as a full
+  release: GitHub Release published, `cap-sdk-node`/`cap-sdk-python`/`cordum-guard`
+  2.17.0 live on npm/PyPI, Go module verified against the public proxy with a
+  clean module cache, and the CAP release manifest promoted to declare 2.17.0.
+- Added `tools/scripts/cap_version_consistency_test.go`: root, nested SDK, and CI
+  `CAP_REV`/`CAP_HANDSHAKE_CAP_SHA` must agree on one exact published CAP
+  tag/commit pair, with pseudo-versions and CAP `replace` directives rejected.
+- Documentation current-support claims were corrected to introduction-provenance
+  phrasing (for example "introduced in CAP v2.13.1") so they stay truthful across
+  future dependency bumps; explicitly historical sections are unchanged.
+- Not included in this promotion: the interop surfaces tracked by task-674
+  (TraceContext, WorkflowEvent, A2A bridge, governed MCP demo) — none of these
+  are part of CAP v2.17.0.
+
 ### Security
 
 #### CAP-PRODUCTION — fail-closed exact-wire trust, attempt fencing, durable effects, and structured resources (2026-07-21, task-a13f83fa)

--- a/dashboard/src/api/errorCodeContract.test.ts
+++ b/dashboard/src/api/errorCodeContract.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { AlertSeverity, ErrorCode, errorCodeCategory, errorCodeLabel } from "./types";
+
+// Wire contract: proto/cordum/agent/v1/job.proto enum ErrorCode and
+// proto/cordum/agent/v1/alert.proto enum AlertSeverity in the pinned CAP
+// dependency. The backend populates error_code_enum with these exact numeric
+// values; if this table drifts from the proto, the dashboard mislabels errors.
+const WIRE_ERROR_CODES: Record<string, number> = {
+  UNSPECIFIED: 0,
+  PROTOCOL_VERSION_MISMATCH: 100,
+  PROTOCOL_MALFORMED_PACKET: 101,
+  PROTOCOL_UNKNOWN_PAYLOAD: 102,
+  PROTOCOL_SIGNATURE_INVALID: 103,
+  PROTOCOL_SIGNATURE_MISSING: 104,
+  JOB_TIMEOUT: 200,
+  JOB_RESOURCE_EXHAUSTED: 201,
+  JOB_PERMISSION_DENIED: 202,
+  JOB_INVALID_INPUT: 203,
+  JOB_NOT_FOUND: 204,
+  JOB_DUPLICATE: 205,
+  JOB_WORKER_UNAVAILABLE: 206,
+  SAFETY_DENIED: 300,
+  SAFETY_POLICY_VIOLATION: 301,
+  SAFETY_RISK_TAG_BLOCKED: 302,
+  TRANSPORT_PUBLISH_FAILED: 400,
+  TRANSPORT_SUBSCRIBE_FAILED: 401,
+  TRANSPORT_CONNECTION_LOST: 402,
+};
+
+describe("ErrorCode wire contract", () => {
+  it("matches the CAP protocol ErrorCode enum name-for-name and value-for-value", () => {
+    const declared = Object.fromEntries(
+      Object.entries(ErrorCode).filter(([, v]) => typeof v === "number"),
+    );
+    expect(declared).toEqual(WIRE_ERROR_CODES);
+  });
+
+  it("labels wire values with the matching category and name", () => {
+    expect(errorCodeLabel(200)).toBe("Job: Timeout");
+    expect(errorCodeLabel(204)).toBe("Job: Not Found");
+    expect(errorCodeLabel(102)).toBe("Protocol: Unknown Payload");
+    expect(errorCodeLabel(104)).toBe("Protocol: Signature Missing");
+    expect(errorCodeLabel(302)).toBe("Safety: Risk Tag Blocked");
+    expect(errorCodeLabel(400)).toBe("Transport: Publish Failed");
+    expect(errorCodeLabel(999)).toBe("Error 999");
+  });
+
+  it("categorizes each wire range for badge coloring", () => {
+    expect(errorCodeCategory(103)).toBe("protocol");
+    expect(errorCodeCategory(206)).toBe("job");
+    expect(errorCodeCategory(302)).toBe("safety");
+    expect(errorCodeCategory(402)).toBe("transport");
+    expect(errorCodeCategory(1000)).toBe("unknown");
+  });
+});
+
+describe("AlertSeverity wire contract", () => {
+  it("matches the CAP protocol AlertSeverity enum", () => {
+    expect(AlertSeverity.UNSPECIFIED).toBe(0);
+    expect(AlertSeverity.INFO).toBe(1);
+    expect(AlertSeverity.WARNING).toBe(2);
+    expect(AlertSeverity.ERROR).toBe(3);
+    expect(AlertSeverity.CRITICAL).toBe(4);
+  });
+});

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -577,56 +577,57 @@ export interface Job {
 }
 
 // ---------------------------------------------------------------------------
-// ErrorCode enum (matches CAP v2.5.2 protobuf ErrorCode)
+// ErrorCode enum (matches the CAP protocol ErrorCode in
+// proto/cordum/agent/v1/job.proto; pinned by src/api/errorCodeContract.test.ts)
 // ---------------------------------------------------------------------------
 
 export enum ErrorCode {
   UNSPECIFIED = 0,
   // Protocol (100-104)
   PROTOCOL_VERSION_MISMATCH = 100,
-  PROTOCOL_INVALID_PACKET = 101,
-  PROTOCOL_SIGNATURE_INVALID = 102,
-  PROTOCOL_TIMEOUT = 103,
-  PROTOCOL_RATE_LIMITED = 104,
+  PROTOCOL_MALFORMED_PACKET = 101,
+  PROTOCOL_UNKNOWN_PAYLOAD = 102,
+  PROTOCOL_SIGNATURE_INVALID = 103,
+  PROTOCOL_SIGNATURE_MISSING = 104,
   // Job (200-206)
-  JOB_NOT_FOUND = 200,
-  JOB_ALREADY_COMPLETED = 201,
-  JOB_TIMEOUT = 202,
-  JOB_CANCELLED = 203,
-  JOB_PERMISSION_DENIED = 204,
-  JOB_RESOURCE_EXHAUSTED = 205,
-  JOB_INVALID_INPUT = 206,
+  JOB_TIMEOUT = 200,
+  JOB_RESOURCE_EXHAUSTED = 201,
+  JOB_PERMISSION_DENIED = 202,
+  JOB_INVALID_INPUT = 203,
+  JOB_NOT_FOUND = 204,
+  JOB_DUPLICATE = 205,
+  JOB_WORKER_UNAVAILABLE = 206,
   // Safety (300-302)
   SAFETY_DENIED = 300,
   SAFETY_POLICY_VIOLATION = 301,
-  SAFETY_OUTPUT_QUARANTINED = 302,
+  SAFETY_RISK_TAG_BLOCKED = 302,
   // Transport (400-402)
-  TRANSPORT_UNAVAILABLE = 400,
-  TRANSPORT_POOL_EXHAUSTED = 401,
-  TRANSPORT_DELIVERY_FAILED = 402,
+  TRANSPORT_PUBLISH_FAILED = 400,
+  TRANSPORT_SUBSCRIBE_FAILED = 401,
+  TRANSPORT_CONNECTION_LOST = 402,
 }
 
 /** Human-readable label for an ErrorCode value. */
 export function errorCodeLabel(code: number): string {
   switch (code) {
     case ErrorCode.PROTOCOL_VERSION_MISMATCH: return "Protocol: Version Mismatch";
-    case ErrorCode.PROTOCOL_INVALID_PACKET: return "Protocol: Invalid Packet";
+    case ErrorCode.PROTOCOL_MALFORMED_PACKET: return "Protocol: Malformed Packet";
+    case ErrorCode.PROTOCOL_UNKNOWN_PAYLOAD: return "Protocol: Unknown Payload";
     case ErrorCode.PROTOCOL_SIGNATURE_INVALID: return "Protocol: Signature Invalid";
-    case ErrorCode.PROTOCOL_TIMEOUT: return "Protocol: Timeout";
-    case ErrorCode.PROTOCOL_RATE_LIMITED: return "Protocol: Rate Limited";
-    case ErrorCode.JOB_NOT_FOUND: return "Job: Not Found";
-    case ErrorCode.JOB_ALREADY_COMPLETED: return "Job: Already Completed";
+    case ErrorCode.PROTOCOL_SIGNATURE_MISSING: return "Protocol: Signature Missing";
     case ErrorCode.JOB_TIMEOUT: return "Job: Timeout";
-    case ErrorCode.JOB_CANCELLED: return "Job: Cancelled";
-    case ErrorCode.JOB_PERMISSION_DENIED: return "Job: Permission Denied";
     case ErrorCode.JOB_RESOURCE_EXHAUSTED: return "Job: Resource Exhausted";
+    case ErrorCode.JOB_PERMISSION_DENIED: return "Job: Permission Denied";
     case ErrorCode.JOB_INVALID_INPUT: return "Job: Invalid Input";
+    case ErrorCode.JOB_NOT_FOUND: return "Job: Not Found";
+    case ErrorCode.JOB_DUPLICATE: return "Job: Duplicate";
+    case ErrorCode.JOB_WORKER_UNAVAILABLE: return "Job: Worker Unavailable";
     case ErrorCode.SAFETY_DENIED: return "Safety: Denied";
     case ErrorCode.SAFETY_POLICY_VIOLATION: return "Safety: Policy Violation";
-    case ErrorCode.SAFETY_OUTPUT_QUARANTINED: return "Safety: Output Quarantined";
-    case ErrorCode.TRANSPORT_UNAVAILABLE: return "Transport: Unavailable";
-    case ErrorCode.TRANSPORT_POOL_EXHAUSTED: return "Transport: Pool Exhausted";
-    case ErrorCode.TRANSPORT_DELIVERY_FAILED: return "Transport: Delivery Failed";
+    case ErrorCode.SAFETY_RISK_TAG_BLOCKED: return "Safety: Risk Tag Blocked";
+    case ErrorCode.TRANSPORT_PUBLISH_FAILED: return "Transport: Publish Failed";
+    case ErrorCode.TRANSPORT_SUBSCRIBE_FAILED: return "Transport: Subscribe Failed";
+    case ErrorCode.TRANSPORT_CONNECTION_LOST: return "Transport: Connection Lost";
     default: return `Error ${code}`;
   }
 }
@@ -641,7 +642,8 @@ export function errorCodeCategory(code: number): "safety" | "job" | "protocol" |
 }
 
 // ---------------------------------------------------------------------------
-// AlertSeverity enum (matches CAP v2.5.2 protobuf AlertSeverity)
+// AlertSeverity enum (matches the CAP protocol AlertSeverity in
+// proto/cordum/agent/v1/alert.proto; pinned by src/api/errorCodeContract.test.ts)
 // ---------------------------------------------------------------------------
 
 export enum AlertSeverity {

--- a/docs/AGENT_PROTOCOL.md
+++ b/docs/AGENT_PROTOCOL.md
@@ -102,7 +102,7 @@ Priority semantics:
   - `UpdateMemory(memory_id, logical_payload, model_response, mode)` → appends chat history or summaries.
 - Uses the same Redis instance; keys are namespaced under `mem:<memory_id>:*`.
 
-## Error Codes (CAP v2.13.1)
+## Error Codes (introduced in CAP v2.13.1)
 
 The `ErrorCode` enum provides structured error classification, replacing ad-hoc string error codes. Both string `error_code` and numeric `error_code_enum` are populated during the transition period.
 
@@ -137,7 +137,7 @@ Cordum upgraded its CAP dependency from v2.8.6 to v2.9.0. The wire contract gain
 
 See `AGENTS.md` § "Control Plane Boundary Hardening (recent)" for the operator-facing surface that consumes these fields (Topic Registry, Worker Credentials, schema enforcement modes).
 
-## Enhanced SystemAlert (CAP v2.13.1)
+## Enhanced SystemAlert (introduced in CAP v2.13.1)
 
 `SystemAlert` now carries structured fields alongside the deprecated string-based fields:
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -114,7 +114,7 @@ If no mapping exists: fail fast to DLQ with `no_pool_mapping`.
 - Workers come online in that pool.
 - Scheduler behavior remains unchanged.
 
-### CAP v2.13.1 Protocol Features (Scheduler)
+### CAP Protocol Features introduced in v2.13.1 (Scheduler)
 - **Handshake handling**: The scheduler subscribes to `sys.handshake` and processes `BusPacket{Handshake}` messages. Worker-role handshakes update the in-memory worker registry with component capabilities, enabling capability-aware routing.
 - **ErrorCode enum**: Job failures now carry a structured `error_code_enum` (`ErrorCode` enum) alongside the deprecated string `error_code`. The scheduler auto-populates `error_code_enum` from the string code when only the string is provided (e.g., `"timeout"` maps to `ERROR_CODE_JOB_TIMEOUT`). DLQ entries also carry the structured code.
 - **Bus-layer validation**: Incoming `JobRequest` and `JobResult` packets are validated using CAP SDK helpers (`ValidateJobRequest`/`ValidateJobResult`). Invalid packets are rejected, logged, and counted via the `validation_rejections_total` metric.

--- a/docs/backend_feature_matrix.md
+++ b/docs/backend_feature_matrix.md
@@ -22,7 +22,7 @@ This table tracks key backend features, their implementation status, and test co
 | CLI (cordumctl) | Yes | None | `cmd/cordumctl` + smoke script; ships as `cordumctl`. |
 | Topic Registry | Yes | Unit + integration | `GET/POST/DELETE /api/v1/topics`; submit-time topic validation at gateway and scheduler boundaries; pack manifest `inputSchema`/`outputSchema` registered at install. |
 | Worker Credentials | Yes | Unit + integration | `GET/POST/DELETE /api/v1/workers/credentials`; argon2id-hashed tokens; `WORKER_ATTESTATION=enforce\|warn\|off`. |
-| Worker readiness handshake | Yes | Unit (CAP v2.9.0 SDK + scheduler filter) | `Agent.Start()` auto-publishes `Handshake{ready_topics, auth_token}`; scheduler filters on `ready=true` when `WORKER_READINESS_REQUIRED=true`. |
+| Worker readiness handshake | Yes | Unit (pinned CAP SDK + scheduler filter) | `Agent.Start()` auto-publishes `Handshake{ready_topics, auth_token}`; scheduler filters on `ready=true` when `WORKER_READINESS_REQUIRED=true`. |
 | Output Policy (two-phase) | Yes | Unit + integration (`core/controlplane/safetykernel/scanners.go`, `core/protocol/proto/v1/output_policy.proto`) | Sync metadata fast-path + async content checks; decisions `ALLOW`/`QUARANTINE`/`REDACT`; `OUTPUT_QUARANTINED` job state. |
 | Approvals + Delegations | Yes | Unit + integration (`handlers_approvals.go`, `handlers_delegation*.go`) | A2A delegation tokens, cascade revocation, scheduler dispatch-time re-verify, nonce/replay protection, `auth.PermDelegationImpersonate`. |
 | Audit verification pipeline | Yes | Unit + integration (`core/audit/`, `core/audit/exporter*`) | Chain verification + consumer + legal-hold + multi-backend exporter (webhook HMAC-SHA256, syslog RFC 5424, Datadog v2, CloudWatch Logs SigV4). |

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -684,9 +684,9 @@ func TestFullPipeline(t *testing.T) {
 
 ---
 
-## 8. CAP v2.13.1 Re-exported Types
+## 8. CAP Re-exported Types
 
-The `sdk/runtime` package re-exports several types from the CAP v2.13.1 SDK for convenience. These are available under the `runtime` package without importing CAP directly.
+The `sdk/runtime` package re-exports several types from the pinned CAP SDK for convenience (first introduced in CAP v2.13.1). These are available under the `runtime` package without importing CAP directly.
 
 ### MetricsHook
 
@@ -756,7 +756,7 @@ func TestMyHandler(t *testing.T) {
 
 ### Updated Worker Config Fields
 
-The `Config` struct now accepts two additional fields from CAP v2.13.1:
+The `Config` struct accepts two additional fields introduced in CAP v2.13.1:
 
 ```go
 type Config struct {

--- a/sdk/runtime/runtime.go
+++ b/sdk/runtime/runtime.go
@@ -24,13 +24,13 @@ type (
 	NATSConn                   = capruntime.NATSConn
 	RedisBlobStore             = capruntime.RedisBlobStore
 
-	// CAP v2.5.2 types
+	// types introduced with CAP v2.5.2
 	Handshake     = agentv1.Handshake
 	ComponentRole = agentv1.ComponentRole
 	ErrorCode     = agentv1.ErrorCode
 	AlertSeverity = agentv1.AlertSeverity
 
-	// CAP v2.5.3 — observability, testing, middleware
+	// introduced with CAP v2.5.3 — observability, testing, middleware
 	MetricsHook = capsdk.MetricsHook
 	Middleware  = capruntime.Middleware
 	HandlerFunc = capruntime.HandlerFunc

--- a/tools/scripts/cap_version_consistency_test.go
+++ b/tools/scripts/cap_version_consistency_test.go
@@ -1,0 +1,276 @@
+package scripts_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// knownCAPTagCommits binds every deliberately promoted stable CAP tag to its
+// immutable release commit. Extend this table (one line) on each future CAP
+// promotion; the consistency test then keeps proving that the configured
+// tag/commit pair is a published one rather than an aspirational or drifted
+// combination.
+var knownCAPTagCommits = map[string]string{
+	"v2.17.0": "e580c670d54a7563c749835c7dd09d81f116c823",
+}
+
+var (
+	capRequirePattern = regexp.MustCompile(`(?m)^\s*(?:require\s+)?github\.com/cordum-io/cap/v2\s+(\S+?)\s*(?://.*)?$`)
+	capReplacePattern = regexp.MustCompile(`(?m)^\s*(?:replace\s+)?github\.com/cordum-io/cap/v2(?:\s+\S+)?\s*=>`)
+	stableTagPattern  = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+	capRevPattern     = regexp.MustCompile(`(?m)^[ \t]+CAP_REV:\s*(\S+)\s*$`)
+	capShaPattern     = regexp.MustCompile(`(?m)^[ \t]+CAP_HANDSHAKE_CAP_SHA:\s*(\S+)\s*$`)
+	fullShaPattern    = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
+
+type capConsistencyInput struct {
+	rootGoMod []byte
+	sdkGoMod  []byte
+	ciYAML    []byte
+}
+
+// checkCAPVersionConsistency validates that the root module, the nested SDK
+// module, and the CI CAP checkout all agree on one exact, stable, published
+// CAP version. It returns a list of human-readable problems; an empty list
+// means the configuration is consistent.
+func checkCAPVersionConsistency(in capConsistencyInput) []string {
+	var problems []string
+
+	rootVersion, ok := capRequireVersion(in.rootGoMod)
+	if !ok {
+		problems = append(problems, "root go.mod: missing github.com/cordum-io/cap/v2 requirement")
+	}
+	sdkVersion, ok := capRequireVersion(in.sdkGoMod)
+	if !ok {
+		problems = append(problems, "sdk/go.mod: missing github.com/cordum-io/cap/v2 requirement")
+	}
+	for name, version := range map[string]string{"root go.mod": rootVersion, "sdk/go.mod": sdkVersion} {
+		if version != "" && !stableTagPattern.MatchString(version) {
+			problems = append(problems, fmt.Sprintf("%s: CAP version %q is not an exact stable tag (pseudo-versions and pre-releases are forbidden)", name, version))
+		}
+	}
+	if rootVersion != "" && sdkVersion != "" && rootVersion != sdkVersion {
+		problems = append(problems, fmt.Sprintf("root go.mod pins CAP %s but sdk/go.mod pins %s; both modules must pin the same released tag", rootVersion, sdkVersion))
+	}
+	if capReplacePattern.Match(normalizeEOL(in.rootGoMod)) {
+		problems = append(problems, "root go.mod: forbidden replace directive for github.com/cordum-io/cap/v2")
+	}
+	if capReplacePattern.Match(normalizeEOL(in.sdkGoMod)) {
+		problems = append(problems, "sdk/go.mod: forbidden replace directive for github.com/cordum-io/cap/v2")
+	}
+
+	capRev, ok := singleMatch(capRevPattern, in.ciYAML)
+	if !ok {
+		problems = append(problems, "ci.yml: missing or ambiguous CAP_REV")
+	}
+	capSha, ok := singleMatch(capShaPattern, in.ciYAML)
+	if !ok {
+		problems = append(problems, "ci.yml: missing or ambiguous CAP_HANDSHAKE_CAP_SHA")
+	}
+	for name, sha := range map[string]string{"CAP_REV": capRev, "CAP_HANDSHAKE_CAP_SHA": capSha} {
+		if sha != "" && !fullShaPattern.MatchString(sha) {
+			problems = append(problems, fmt.Sprintf("ci.yml: %s %q is not one full lowercase 40-hex commit SHA", name, sha))
+		}
+	}
+	if capRev != "" && capSha != "" && capRev != capSha {
+		problems = append(problems, fmt.Sprintf("ci.yml: CAP_REV %s != CAP_HANDSHAKE_CAP_SHA %s", capRev, capSha))
+	}
+
+	if rootVersion != "" && stableTagPattern.MatchString(rootVersion) {
+		wantCommit, known := knownCAPTagCommits[rootVersion]
+		if !known {
+			problems = append(problems, fmt.Sprintf("CAP tag %s is not in the known promoted tag/commit table; add it only for a genuinely published release", rootVersion))
+		} else if capRev != "" && capRev != wantCommit {
+			problems = append(problems, fmt.Sprintf("ci.yml CAP_REV %s does not match the %s release commit %s", capRev, rootVersion, wantCommit))
+		}
+	}
+
+	return problems
+}
+
+func capRequireVersion(goMod []byte) (string, bool) {
+	match := capRequirePattern.FindSubmatch(normalizeEOL(goMod))
+	if len(match) != 2 {
+		return "", false
+	}
+	return string(match[1]), true
+}
+
+func singleMatch(pattern *regexp.Regexp, data []byte) (string, bool) {
+	matches := pattern.FindAllSubmatch(normalizeEOL(data), -1)
+	if len(matches) != 1 {
+		return "", false
+	}
+	return string(matches[0][1]), true
+}
+
+// normalizeEOL strips carriage returns so the line-anchored patterns behave
+// identically on LF and CRLF working trees (autocrlf checkouts on Windows).
+func normalizeEOL(data []byte) []byte {
+	return []byte(strings.ReplaceAll(string(data), "\r\n", "\n"))
+}
+
+func validCAPFixture() capConsistencyInput {
+	return capConsistencyInput{
+		rootGoMod: []byte("module github.com/cordum/cordum\n\ngo 1.26.3\n\nrequire (\n\tgithub.com/cordum-io/cap/v2 v2.17.0\n\tgithub.com/other/dep v1.0.0\n)\n\nreplace github.com/cordum/cordum/sdk => ./sdk\n"),
+		sdkGoMod:  []byte("module github.com/cordum/cordum/sdk\n\ngo 1.26.3\n\nrequire (\n\tgithub.com/cordum-io/cap/v2 v2.17.0\n)\n"),
+		ciYAML:    []byte("jobs:\n  handshake:\n    env:\n      CAP_REV: e580c670d54a7563c749835c7dd09d81f116c823\n      CAP_HANDSHAKE_CAP_SHA: e580c670d54a7563c749835c7dd09d81f116c823\n"),
+	}
+}
+
+func assertSingleProblemContains(t *testing.T, problems []string, want string) {
+	t.Helper()
+	if len(problems) != 1 {
+		t.Fatalf("problems = %v, want exactly one mentioning %q", problems, want)
+	}
+	if !strings.Contains(problems[0], want) {
+		t.Fatalf("problem %q does not mention %q", problems[0], want)
+	}
+}
+
+func TestCAPConsistencyAcceptsPromotedState(t *testing.T) {
+	if problems := checkCAPVersionConsistency(validCAPFixture()); len(problems) != 0 {
+		t.Fatalf("valid promoted fixture reported problems: %v", problems)
+	}
+}
+
+func TestCAPConsistencyHandlesCRLF(t *testing.T) {
+	in := validCAPFixture()
+	in.rootGoMod = []byte(strings.ReplaceAll(string(in.rootGoMod), "\n", "\r\n"))
+	in.sdkGoMod = []byte(strings.ReplaceAll(string(in.sdkGoMod), "\n", "\r\n"))
+	in.ciYAML = []byte(strings.ReplaceAll(string(in.ciYAML), "\n", "\r\n"))
+	if problems := checkCAPVersionConsistency(in); len(problems) != 0 {
+		t.Fatalf("CRLF fixture reported problems: %v", problems)
+	}
+}
+
+func TestCAPConsistencyDetectsPseudoVersion(t *testing.T) {
+	in := validCAPFixture()
+	in.rootGoMod = []byte(strings.ReplaceAll(string(in.rootGoMod), "v2.17.0", "v2.16.2-0.20260722152314-e580c670d54a"))
+	in.sdkGoMod = []byte(strings.ReplaceAll(string(in.sdkGoMod), "v2.17.0", "v2.16.2-0.20260722152314-e580c670d54a"))
+	problems := checkCAPVersionConsistency(in)
+	if len(problems) != 2 {
+		t.Fatalf("problems = %v, want two pseudo-version problems", problems)
+	}
+	for _, p := range problems {
+		if !strings.Contains(p, "not an exact stable tag") {
+			t.Fatalf("problem %q does not flag the pseudo-version", p)
+		}
+	}
+}
+
+func TestCAPConsistencyDetectsRootSdkSkew(t *testing.T) {
+	in := validCAPFixture()
+	in.sdkGoMod = []byte(strings.ReplaceAll(string(in.sdkGoMod), "v2.17.0", "v2.15.1"))
+	problems := checkCAPVersionConsistency(in)
+	found := false
+	for _, p := range problems {
+		if strings.Contains(p, "both modules must pin the same released tag") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("problems = %v, want a root/sdk skew problem", problems)
+	}
+}
+
+func TestCAPConsistencyDetectsCapReplace(t *testing.T) {
+	in := validCAPFixture()
+	in.rootGoMod = append(in.rootGoMod, []byte("\nreplace github.com/cordum-io/cap/v2 => ../cap\n")...)
+	assertSingleProblemContains(t, checkCAPVersionConsistency(in), "forbidden replace directive")
+}
+
+func TestCAPConsistencyDetectsCIShaMismatch(t *testing.T) {
+	in := validCAPFixture()
+	in.ciYAML = []byte(strings.Replace(string(in.ciYAML), "CAP_HANDSHAKE_CAP_SHA: e580c670d54a7563c749835c7dd09d81f116c823", "CAP_HANDSHAKE_CAP_SHA: 32b9db9670c597685344808272f9b246026091ba", 1))
+	problems := checkCAPVersionConsistency(in)
+	found := false
+	for _, p := range problems {
+		if strings.Contains(p, "CAP_REV e580c670d54a7563c749835c7dd09d81f116c823 != CAP_HANDSHAKE_CAP_SHA 32b9db9670c597685344808272f9b246026091ba") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("problems = %v, want a CAP_REV/CAP_HANDSHAKE_CAP_SHA mismatch problem", problems)
+	}
+}
+
+func TestCAPConsistencyDetectsUnknownTag(t *testing.T) {
+	in := validCAPFixture()
+	in.rootGoMod = []byte(strings.ReplaceAll(string(in.rootGoMod), "v2.17.0", "v2.99.0"))
+	in.sdkGoMod = []byte(strings.ReplaceAll(string(in.sdkGoMod), "v2.17.0", "v2.99.0"))
+	problems := checkCAPVersionConsistency(in)
+	found := false
+	for _, p := range problems {
+		if strings.Contains(p, "not in the known promoted tag/commit table") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("problems = %v, want an unknown-tag problem", problems)
+	}
+}
+
+func TestCAPConsistencyDetectsCICommitNotMatchingTag(t *testing.T) {
+	in := validCAPFixture()
+	in.ciYAML = []byte(strings.ReplaceAll(string(in.ciYAML), "e580c670d54a7563c749835c7dd09d81f116c823", "32b9db9670c597685344808272f9b246026091ba"))
+	problems := checkCAPVersionConsistency(in)
+	found := false
+	for _, p := range problems {
+		if strings.Contains(p, "does not match the v2.17.0 release commit") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("problems = %v, want a tag/commit binding problem", problems)
+	}
+}
+
+func TestCAPConsistencySupportsSingleLineRequire(t *testing.T) {
+	in := validCAPFixture()
+	in.sdkGoMod = []byte("module github.com/cordum/cordum/sdk\n\ngo 1.26.3\n\nrequire github.com/cordum-io/cap/v2 v2.17.0\n")
+	if problems := checkCAPVersionConsistency(in); len(problems) != 0 {
+		t.Fatalf("single-line require fixture reported problems: %v", problems)
+	}
+}
+
+func TestCAPConsistencyDetectsMissingRequirement(t *testing.T) {
+	in := validCAPFixture()
+	in.sdkGoMod = []byte("module github.com/cordum/cordum/sdk\n\ngo 1.26.3\n")
+	problems := checkCAPVersionConsistency(in)
+	found := false
+	for _, p := range problems {
+		if strings.Contains(p, "sdk/go.mod: missing github.com/cordum-io/cap/v2 requirement") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("problems = %v, want a missing-requirement problem", problems)
+	}
+}
+
+// TestRepositoryCAPVersionConsistency runs the checker against the real
+// repository files: the root module, the nested SDK module, and the CI
+// workflow that checks out CAP for the handshake interop gate.
+func TestRepositoryCAPVersionConsistency(t *testing.T) {
+	root := repositoryRoot(t)
+	read := func(rel string) []byte {
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		return data
+	}
+	in := capConsistencyInput{
+		rootGoMod: read("go.mod"),
+		sdkGoMod:  read("sdk/go.mod"),
+		ciYAML:    read(".github/workflows/ci.yml"),
+	}
+	if problems := checkCAPVersionConsistency(in); len(problems) != 0 {
+		t.Fatalf("repository CAP version consistency problems:\n  %s", strings.Join(problems, "\n  "))
+	}
+}


### PR DESCRIPTION
Capstone residuals for the CAP v2.17.0 promotion (task-a24b53c5; core pins landed in #408 by @yaront1111). Frozen target: **v2.17.0 @ `e580c670d54a7563c749835c7dd09d81f116c823`** — a completed release: GitHub Release published 2026-07-22T20:01:47Z, all four publish workflows green, registries verified live (Go proxy Origin.Hash exact; npm `cap-sdk-node@2.17.0` sha512-4kAPiJeVI7I3…; PyPI `cap-sdk-python`/`cordum-guard` 2.17.0 whl+sdist hashes recorded); CAP manifest promotion in cordum-io/cap#90 (42/42 checks green, awaiting admin merge).

## Commits
1. `63faa18e` **test(cap)**: cross-file CAP version-consistency regression test (`tools/scripts`) — root+sdk+CI CAP_REV/CAP_HANDSHAKE_CAP_SHA must agree on one exact published tag/commit pair (knownCAPTagCommits binds v2.17.0→e580c670); rejects pseudo-versions and CAP replaces; CRLF-immune; every rule proven by a wrong-fixture test (11 tests).
2. `e6659096` **docs**: current-support claims corrected to introduction-provenance phrasing (AGENT_PROTOCOL/CORE/sdk-reference/feature-matrix/runtime.go comments); CHANGELOG promotion entry incl. explicit exclusion of interop task-674 surfaces; historical sections retained; deploy/compose/cordum-helm confirmed CAP-version-free (grep evidence).
3. `7a8dc549` **fix(dashboard)**: ErrorCode enum had drifted from the wire protocol (102-104, whole 200-range, 302, 400-range mislabeled — e.g. wire 200 JOB_TIMEOUT rendered "Job: Not Found"). Aligned name-for-name/value-for-value with `proto/cordum/agent/v1/job.proto`; AlertSeverity verified already-correct; new `errorCodeContract.test.ts` pins the table (written first, observed RED 2/4, then GREEN 4/4).

## Evidence (full logs in task record)
- Prereq gate: 6 squash commits (#69/#82/#85/#83/#76/#80) ancestor+merged+content-verified on CAP main; INTEROP=N/A_NOT_LANDED.
- Full suite at exact pushed SHA in a fresh worktree: 98 ok / 18 platform skips / only the two pre-existing CRLF-environment toolchain tests red locally (Linux CI green). `-p 1 -count=3` flake sweep all ok (scheduler 108.9s, gateway 230.3s, …). `-race` unavailable (CGO off) — count=3 is the approved substitute.
- Real transport, twice, zero skips: `tests/handshakeinterop` 47 PASS (challenge→authenticate→result + 8 negatives × Go/Py/Node installed SDKs, real Redis by digest, embedded real NATS, CAP SHA enforced); `tests/capproduction` 198 PASS / 5 pkgs (signed work/result; unsigned/tampered/expired/wrong-audience/wrong-session/replay/stale-attempt rejected before side effects; sealed ResourceRef). Full compose stack 8/8 healthy + `-tags=integration` 97 ok.
- Dashboard rail vs branch-point baseline (tsc 0 / vitest 247-2111 / build ok): tsc 0 errors; vitest **248 files / 2115 tests passed**; build 4.97s — delta is exactly the new contract test.
- No CAP replace/pseudo-version anywhere; clean-cache Origin.Hash re-verified; no go.work; .env/certs gitignored and never staged.

Review order: this PR is independent of cordum-io/cordum-packs (packs promotion PR); both depend conceptually on cordum-io/cap#90 for manifest truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated dashboard error-code names, values, labels, and severity mappings to match the current protocol contract.
  * Promoted the CAP dependency to v2.17.0 across supported SDK and module references.
  * Added consistency checks to detect mismatched versions, commits, or unsupported dependency overrides.

* **Documentation**
  * Clarified CAP feature version references and SDK documentation.
  * Updated worker readiness documentation to reflect the pinned SDK baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->